### PR TITLE
Modified to work with scans that don't start with b0 volume

### DIFF
--- a/DiffusionPreprocessing/scripts/basic_preproc.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc.sh
@@ -142,7 +142,11 @@ do
 				indcount=$((${indcount} + 1))
 				count3=0
 			fi
-			echo ${indcount} >>${rawdir}/index.txt
+			tmp_ind=${indcount}
+			if [ $[tmp_ind] -eq 0 ]; then
+				tmp_ind=$((${indcount}+1))
+			fi
+			echo ${tmp_ind} >>${rawdir}/index.txt
 			count3=$((${count3} + 1))
 		fi
 		count=$((${count} + 1))
@@ -196,7 +200,11 @@ do
 				indcount=$((${indcount} + 1))
 				count3=0
 			fi
-			echo $((${indcount} + ${Poscount})) >>${rawdir}/index.txt
+			tmp_ind=${indcount}
+			if [ $[tmp_ind] -eq 0 ]; then
+				tmp_ind=$((${indcount}+1))
+			fi
+			echo $((${tmp_ind} + ${Poscount})) >>${rawdir}/index.txt
 			count3=$((${count3} + 1))
 		fi
 		count=$((${count} + 1))

--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -67,8 +67,18 @@ fi
 
 #Remove negative intensity values (caused by spline interpolation) from final data
 ${FSLDIR}/bin/fslmaths ${datadir}/data -thr 0 ${datadir}/data
-${FSLDIR}/bin/bet ${datadir}/data ${datadir}/nodif_brain -m -f 0.1
-$FSLDIR/bin/fslroi ${datadir}/data ${datadir}/nodif 0 1
+b0maxbval=100
+mcnt=0
+for i in `cat ${datadir}/bvals`
+do
+	if [ $i -lt ${b0maxbval} ]; then
+		b0idx1=${mcnt}
+		break
+	fi
+	mcnt=$((${mcnt} + 1))
+done
+${FSLDIR}/bin/fslroi ${datadir}/data ${datadir}/nodif ${b0idx1} 1
+${FSLDIR}/bin/bet ${datadir}/nodif ${datadir}/nodif_brain -m -f 0.1
 
 echo -e "\n END: eddy_postproc"
 


### PR DESCRIPTION
DiffusionPreprocessing/scripts/basic_preproc.sh does not properly match diffusion volumes to b0 scans when the diffusion volumes precede the first b0 volume: index.txt ends up with 0 and similar problem for the first Neg scans.  This patch makes matches pre-b0 diffusion volumes to the first b0 in the scan.
