### PR TITLE
Optionally run DiffPreprocPipeline for each blip-up/down data pair

### DIFF
--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -37,7 +37,7 @@
 #  
 # ## Prerequisite Installed Software
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -37,7 +37,7 @@
 #  
 # ## Prerequisite Installed Software
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
@@ -41,7 +41,7 @@
 # 
 # ## Prerequisite Installed Software for the entire Diffusion Preprocessing Pipeline
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
@@ -41,7 +41,7 @@
 # 
 # ## Prerequisite Installed Software for the entire Diffusion Preprocessing Pipeline
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
@@ -115,7 +115,7 @@ get_options()
 				InputNames=${argument#*=}
 				index=$(( index + 1 ))
 				;;
-			--output_dwiname=*)
+			--dwiname=*)
 				OutputName=${argument#*=}
 				index=$(( index + 1 ))
 				;;
@@ -211,7 +211,7 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
   --path=<study-path>     path to subject's data folder
   --subject=<subject-id>  subject ID
   --input_dwinames=<input_names>    @-seperated list of the DWI output directories.
-  [--output_dwiname=<output_name>]
+  [--dwiname=<output_name>]
                           Name of the directory containing the merged diffusion data
                           Defaults to Diffusion
   [--printcom=<print-command>]

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
@@ -62,7 +62,7 @@
 #
 #~ND~END~
 #
-# Merges the individually processed data pairs into a single diffusion image
+# Merges the individually processed diffusion MRI data into a single diffusion image
 #
 
 # Set up this script such that if any command exits with a non-zero value, the
@@ -170,8 +170,8 @@ validate_environment_vars()
 		error_msgs+="\nERROR: HCPPIPEDIR_dMRI environment variable not set"
 	fi
 
-	if [ ! -e ${HCPPIPEDIR_dMRI}/merge_pairs.sh ] ; then
-		error_msgs+="\nERROR: HCPPIPEDIR_dMRI/merge_pairs.sh not found"
+	if [ ! -e ${HCPPIPEDIR_dMRI}/merge_split.sh ] ; then
+		error_msgs+="\nERROR: HCPPIPEDIR_dMRI/merge_split.sh not found"
 	fi
 
 	if [ -z ${FSLDIR} ] ; then
@@ -247,10 +247,9 @@ main()
     validate_environment_vars
 
     set -e
-    echo -e "\n START: merge_split"
 
-	# Establish tool name for logging
-	log_SetToolName "${SCRIPT_NAME}"
+    # Establish tool name for logging
+    log_SetToolName "${SCRIPT_NAME}"
 
     outdir=${StudyFolder}/${Subject}/T1w/${OutputName}
 
@@ -259,7 +258,7 @@ main()
 
     log_Msg "merging ${indirs} into ${outdir}"
 
-	${runcmd} ${HCPPIPEDIR_dMRI}/merge_pairs.sh ${outdir} ${indirs}
+    ${runcmd} ${HCPPIPEDIR_dMRI}/merge_split.sh ${outdir} ${indirs}
 }
 
 

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
@@ -29,14 +29,14 @@
 #
 # ## Description
 #
-# This script, <code>DiffPreprocPipeline_Eddy.sh</code>, implements the second
-# part of the Preprocessing Pipeline for diffusion MRI describe in
-# [Glasser et al. 2013][GlasserEtAl]. The entire Preprocessing Pipeline for
-# diffusion MRI is split into pre-eddy, eddy, and post-eddy scripts so that
-# the running of eddy processing can be submitted to a cluster scheduler to
-# take advantage of running on a set of GPUs without forcing the entire diffusion
-# preprocessing to occur on a GPU enabled system.  This particular script
-# implements the eddy part of the diffusion preprocessing.
+# This script, <code>DiffPreprocPipeline_Merge.sh</code>, merges the output
+# of the Preprocessing Pipeline for diffusion MRI as described in
+# [Glasser et al. 2013][GlasserEtAl]. This script will usually
+# not be called as part of the diffusion preprocessing pipeline. However,
+# if the scanner reshimmed between the acquisition of different parts of
+# the diffusion MRI data, it can be advantageous to run the pipeline on
+# each shim group separately.
+# This script merges the output for each shim group in a single dataset.
 #
 # ## Prerequisite Installed Software for the entire Diffusion Preprocessing Pipeline
 #
@@ -50,7 +50,7 @@
 #
 # ## Prerequisite Environment Variables
 #
-# See output of usage function: e.g. <code>$ ./DiffPreprocPipeline_Eddy.sh --help</code>
+# See output of usage function: e.g. <code>$ ./DiffPreprocPipeline_Merge.sh --help</code>
 #
 # <!-- References -->
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#!/bin/bash
+#~ND~FORMAT~MARKDOWN~
+#~ND~START~
+#
+# # DiffPreprocPipeline_Merge.sh
+#
+# ## Copyright Notice
+#
+# Copyright (C) 2012-2016 The Human Connectome Project
+#
+# * Washington University in St. Louis
+# * University of Minnesota
+# * Oxford University
+#
+# ## Author(s)
+#
+# * Michiel Cottaar, FMRIB Analysis Group, Oxford University
+# * Matthew F. Glasser, Department of Anatomy and Neurobiology, Washington University in St. Louis
+# * Michael Harms, Department of Anatomy and Neurobiology, Washington University in St. Louis
+#
+# ## Product
+#
+# [Human Connectome Project][HCP] (HCP) Pipelines
+#
+# ## License
+#
+# See the [LICENSE](https://github.com/Washington-University/Pipelines/blob/master/LICENSE.md) file
+#
+# ## Description
+#
+# This script, <code>DiffPreprocPipeline_Eddy.sh</code>, implements the second
+# part of the Preprocessing Pipeline for diffusion MRI describe in
+# [Glasser et al. 2013][GlasserEtAl]. The entire Preprocessing Pipeline for
+# diffusion MRI is split into pre-eddy, eddy, and post-eddy scripts so that
+# the running of eddy processing can be submitted to a cluster scheduler to
+# take advantage of running on a set of GPUs without forcing the entire diffusion
+# preprocessing to occur on a GPU enabled system.  This particular script
+# implements the eddy part of the diffusion preprocessing.
+#
+# ## Prerequisite Installed Software for the entire Diffusion Preprocessing Pipeline
+#
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+#
+#   FSL's environment setup script must also be sourced
+#
+# * [FreeSurfer][FreeSurfer] (version 5.3.0-HCP)
+#
+# * [HCP-gradunwarp][HCP-gradunwarp] - (HCP version 1.0.2)
+#
+# ## Prerequisite Environment Variables
+#
+# See output of usage function: e.g. <code>$ ./DiffPreprocPipeline_Eddy.sh --help</code>
+#
+# <!-- References -->
+#
+# [HCP]: http://www.humanconnectome.org
+# [GlasserEtAl]: http://www.ncbi.nlm.nih.gov/pubmed/23668970
+# [FSL]: http://fsl.fmrib.ox.ac.uk
+# [FreeSurfer]: http://freesurfer.net
+# [HCP-gradunwarp]: https://github.com/Washington-University/gradunwarp/releases
+#
+#~ND~END~
+#
+# Merges the individually processed data pairs into a single diffusion image
+#
+
+# Set up this script such that if any command exits with a non-zero value, the
+# script itself exits and does not attempt any further processing.
+set -e
+
+# Load Function Libraries
+source ${HCPPIPEDIR}/global/scripts/log.shlib     # log_ functions
+source ${HCPPIPEDIR}/global/scripts/version.shlib # version_ functions
+
+get_options()
+{
+	local arguments=($@)
+
+	# initialize global output variables
+	unset StudyFolder
+	unset Subject
+	unset InputNames
+	unset OutputName
+	unset runcmd
+	OutputName="Diffusion"
+	runcmd=""
+
+	# parse arguments
+	local index=0
+	local numArgs=${#arguments[@]}
+	local argument
+
+	while [ ${index} -lt ${numArgs} ] ; do
+		argument=${arguments[index]}
+
+		case ${argument} in
+			--help)
+				usage
+				exit 1
+				;;
+			--version)
+				version_show $@
+				exit 0
+				;;
+			--path=*)
+				StudyFolder=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--subject=*)
+				Subject=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--input_dwinames=*)
+				InputNames=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--output_dwiname=*)
+				OutputName=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--printcom=*)
+				runcmd=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			*)
+				PassOnArguments+=" ${argument} "
+				index=$(( index + 1 ))
+				;;
+		esac
+	done
+
+	local error_msgs=""
+
+	# check required parameters
+	if [ -z ${StudyFolder} ] ; then
+		error_msgs+="\nERROR: <study-path> not specified"
+	fi
+
+	if [ -z ${Subject} ] ; then
+		error_msgs+="\nERROR: <subject-id> not specified"
+	fi
+
+	if [ -z ${InputNames} ] ; then
+		error_msgs+="\nERROR: <input_dwinames> not specified"
+	fi
+
+	if [ ! -z "${error_msgs}" ] ; then
+		usage
+		echo -e ${error_msgs}
+		echo ""
+		exit 1
+	fi
+
+	# report parameters
+	echo "-- ${SCRIPT_NAME}: Specified Command-Line Parameters - Start --"
+	echo "   Path: ${StudyFolder}"
+	echo "   Subject: ${Subject}"
+	echo "   InputDWINames: ${InputNames}"
+	echo "   OutputDWIName: ${OutputName}"
+	echo "-- ${SCRIPT_NAME}: Specified Command-Line Parameters - End --"
+}
+
+validate_environment_vars()
+{
+	local error_msgs=""
+
+	# validate
+	if [ -z ${HCPPIPEDIR_dMRI} ] ; then
+		error_msgs+="\nERROR: HCPPIPEDIR_dMRI environment variable not set"
+	fi
+
+	if [ ! -e ${HCPPIPEDIR_dMRI}/merge_pairs.sh ] ; then
+		error_msgs+="\nERROR: HCPPIPEDIR_dMRI/merge_pairs.sh not found"
+	fi
+
+	if [ -z ${FSLDIR} ] ; then
+		error_msgs+="\nERROR: FSLDIR environment variable not set"
+	fi
+
+	if [ ! -z "${error_msgs}" ] ; then
+		usage
+		echo -e ${error_msgs}
+		echo ""
+		exit 1
+	fi
+
+	# report
+	echo "-- ${SCRIPT_NAME}: Environment Variables Used - Start --"
+	echo "   HCPPIPEDIR_dMRI: ${HCPPIPEDIR_dMRI}"
+	echo "   FSLDIR: ${FSLDIR}"
+	echo "-- ${SCRIPT_NAME}: Environment Variables Used - End --"
+}
+
+usage()
+{
+	cat << EOF
+
+Merges the results from multiple runs of the HCP pipeline on the same subject
+
+This is designed to handle the case where the scanner was reshimmed between the
+acquisition of different diffusion MRI data pairs and hence are preprocessed
+independently in their own call to DiffPreprocPipeline.sh. This merges the results.
+
+Usage: ${SCRIPT_NAME} PARAMETER...
+
+PARAMETERs are: [ ] = optional; < > = user supplied value
+  [--help]                show usage information and exit with a non-zero return
+                          code
+  [--version]             show version information and exit with 0 as return code
+  --path=<study-path>     path to subject's data folder
+  --subject=<subject-id>  subject ID
+  --input_dwinames=<input_names>    @-seperated list of the DWI output directories.
+  [--output_dwiname=<output_name>]
+                          Name of the directory containing the merged diffusion data
+                          Defaults to Diffusion
+  [--printcom=<print-command>]
+                          Use the specified <print-command> to echo or otherwise
+                          output the commands that would be executed instead of
+                          actually running them. --printcom=echo is intended to
+                          be used for testing purposes
+
+Return Status Value:
+
+  0                       if help was not requested, all parameters were properly
+                          formed, and processing succeeded
+  Non-zero                Otherwise - malformed parameters, help requested, or a
+                          processing failure was detected
+
+Required Environment Variables:
+
+  HCPPIPEDIR_dMRI         Location of the Diffusion MRI Preprocessing sub-scripts
+                          that are used to carry out some of the steps of the
+                          Diffusion Preprocessing Pipeline.
+                          (e.g. \${HCPPIPEDIR}/DiffusionPreprocessing/scripts)
+  FSLDIR                  The home directory for FSL
+
+EOF
+}
+
+
+main()
+{
+	# Get Command Line Options
+	get_options $@
+
+    validate_environment_vars
+
+    set -e
+    echo -e "\n START: merge_split"
+
+	# Establish tool name for logging
+	log_SetToolName "${SCRIPT_NAME}"
+
+    outdir=${StudyFolder}/${Subject}/T1w/${OutputName}
+
+    indirs=`echo ${InputNames} | sed 's/@/ /g'`
+    indirs=`printf "${StudyFolder}/${Subject}/T1w/%s " ${indirs}`
+
+    log_Msg "merging ${indirs} into ${outdir}"
+
+	${runcmd} ${HCPPIPEDIR_dMRI}/merge_pairs.sh ${outdir} ${indirs}
+}
+
+
+main $@

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
@@ -40,7 +40,7 @@
 #
 # ## Prerequisite Installed Software for the entire Diffusion Preprocessing Pipeline
 #
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -41,7 +41,7 @@
 # 
 # ## Prerequisite Installed Software for the Diffusion Preprocessing Pipeline
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
 #
 #   FSL's environment setup script must also be sourced
 # 

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -41,7 +41,7 @@
 # 
 # ## Prerequisite Installed Software for the Diffusion Preprocessing Pipeline
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 #
 #   FSL's environment setup script must also be sourced
 # 

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -40,7 +40,7 @@
 #
 # ## Prerequisite Installed Software for the Diffusion Preprocessing Pipeline
 #
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
 #   
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -40,7 +40,7 @@
 #
 # ## Prerequisite Installed Software for the Diffusion Preprocessing Pipeline
 #
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 #   
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -147,7 +147,7 @@ EOF
 #  ${PEdir}	              Phase Encoding Direction, 1=RL/LR, 2=PA/AP
 #  ${PosInputImages}      @ symbol separated list of data with 'positive' phase 
 #                         encoding direction
-#  ${NegInputImages}      @ symbol separated lsit of data with 'negative' phase
+#  ${NegInputImages}      @ symbol separated list of data with 'negative' phase
 #                         encoding direction 
 #  ${echospacing}         Echo spacing in msecs
 #  ${DWIName}             Name to give DWI output directories

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
@@ -365,7 +365,7 @@ main()
 		preproc_pipeline_cmd+=" --subject=${Subject} "
 		preproc_pipeline_cmd+="${PassOnArguments}"
 		log_Msg "Invoking Preprocessing pipeline for positive/negative data pair ${pair}"
-		${preproc_pipeline_cmd}
+		echo ${preproc_pipeline_cmd}
 	done
 
     merge_cmd="${HCPPIPEDIR}/DiffusionPreprocessing/scripts/merge_pairs.sh "

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+#~ND~FORMAT~MARKDOWN~
+#~ND~START~
+#
+# # DiffPreprocPipeline.sh
+# 
+# ## Copyright Notice
+#
+# Copyright (C) 2012-2016 The Human Connectome Project
+# 
+# * Washington University in St. Louis
+# * University of Minnesota
+# * Oxford University
+# 
+# ## Author(s)
+# 
+# * Stamatios Sotiropoulos, FMRIB Analysis Group, Oxford University
+# * Saad Jbabdi, FMRIB Analysis Group, Oxford University
+# * Jesper Andersson, FMRIB Analysis Group, Oxford University
+# * Matthew F. Glasser, Department of Anatomy and Neurobiology, Washington University in St. Louis
+# * Timothy B. Brown, Neuroinfomatics Research Group, Washington University in St. Louis
+#
+# ## Product
+# 
+# [Human Connectome Project][HCP] (HCP) Pipelines
+# 
+# ## License
+#
+# See the [LICENSE](https://github.com/Washington-University/Pipelines/blob/master/LICENSE.md) file
+# 
+# ## Description 
+#
+# This script, <code>DiffPreprocPipeline.sh</code>, implements the Diffusion 
+# MRI Preprocessing Pipeline described in [Glasser et al. 2013][GlasserEtAl]. 
+# It generates the "data" directory that can be used as input to the fibre 
+# orientation estimation scripts.
+#  
+# ## Prerequisite Installed Software
+# 
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+#
+#   FSL's environment setup script must also be sourced
+#
+# * [FreeSurfer][FreeSurfer] (version 5.3.0-HCP)
+# 
+# * [HCP-gradunwarp][HCP-gradunwarp] - (HCP version 1.0.2)
+#
+# ## Prerequisite Environment Variables
+# 
+# See output of usage function: 
+# e.g. <code>$ ./DiffPreprocPipeline.sh --help</code>
+# 
+# ## Output Directories
+# 
+# *NB: NO assumption is made about the input paths with respect to the output 
+#      directories - they can be totally different. All inputs are taken directly
+#      from the input variables without additions or modifications.*
+# 
+# Output path specifiers
+# 
+# * <code>${StudyFolder}</code> is an input parameter
+# * <code>${Subject}</code> is an input parameter
+# 
+# Main output directories
+# 
+# * <code>DiffFolder=${StudyFolder}/${Subject}/Diffusion</code>
+# * <code>T1wDiffFolder=${StudyFolder}/${Subject}/T1w/Diffusion</code>
+# 
+# All outputs are within the directory: <code>${StudyFolder}/${Subject}</code>
+# 
+# The full list of output directories are the following
+# 
+# * <code>$DiffFolder/rawdata</code>
+# * <code>$DiffFolder/topup</code>
+# * <code>$DiffFolder/eddy</code>
+# * <code>$DiffFolder/data</code>
+# * <code>$DiffFolder/reg</code>
+# * <code>$T1wDiffFolder</code>
+# 
+# Also assumes that T1 preprocessing has been carried out with results in 
+# <code>${StudyFolder}/${Subject}/T1w</code>
+# 
+# <!-- References -->
+# 
+# [HCP]: http://www.humanconnectome.org
+# [GlasserEtAl]: http://www.ncbi.nlm.nih.gov/pubmed/23668970
+# [FSL]: http://fsl.fmrib.ox.ac.uk
+# [FreeSurfer]: http://freesurfer.net
+# [HCP-gradunwarp]: https://github.com/Washington-University/gradunwarp/releases
+# [license]: https://github.com/Washington-University/Pipelines/blob/master/LICENSE.md
+# 
+#~ND~END~
+
+# Set up this script such that if any command exits with a non-zero value, the 
+# script itself exits and does not attempt any further processing.
+set -e
+
+# Load Function Libraries
+source ${HCPPIPEDIR}/global/scripts/log.shlib		# log_ functions
+source ${HCPPIPEDIR}/global/scripts/version.shlib	# version_ functions
+
+# Global values
+DEFAULT_B0_MAX_BVAL=50
+DEFAULT_DEGREES_OF_FREEDOM=6
+SCRIPT_NAME=$(basename ${0})
+
+#
+# Function Descripton
+#  Show usage information for this script
+#
+usage()
+{
+	cat << EOF
+
+Perform the steps of the HCP Diffusion Preprocessing Pipeline for each positive/negative data pair separately
+
+Usage: ${SCRIPT_NAME} PARAMETER...
+
+PARAMETERs are: [ ] = optional; < > = user supplied value
+  [--help]                show usage information and exit with a non-zero return
+                          code
+  [--version]             show version information and exit with 0 as return code
+  --posData=<positive-phase-encoding-data>
+                          @ symbol separated list of data with 'positive' phase
+                          encoding direction; e.g.,
+                            data_RL1@data_RL2@...data_RLn, or
+                            data_PA1@data_PA2@...data_PAn
+  --negData=<negative-phase-encoding-data>
+                          @ symbol separated list of data with 'negative' phase 
+                          encoding direction; e.g.,
+                            data_LR1@data_LR2@...data_LRn, or
+                            data_AP1@data_AP2@...data_APn
+  [--dwiname=<DWIName>]   basename to give DWI output directories.
+                          will be appended with "_scanA", "_scanB", etc.
+                          Defaults to Diffusion
+
+  All other parameters are passed on to DiffPreprocPipeline.sh without alteration
+  Run DiffPreprocPipeline.sh for more details
+
+Return Status Value:
+
+  0                       if help was not requested, all parameters were properly
+                          formed, and processing succeeded
+  Non-zero                Otherwise - malformed parameters, help requested, or a 
+                          processing failure was detected
+
+Required Environment Variables:
+
+  HCPPIPEDIR              The home directory for the version of the HCP Pipeline 
+                          Scripts being used.
+  HCPPIPEDIR_dMRI         Location of the Diffusion MRI Preprocessing sub-scripts
+                          that are used to carry out some of the steps of the
+                          Diffusion Preprocessing Pipeline. 
+                          (e.g. \${HCPPIPEDIR}/DiffusionPreprocessing/scripts)
+  FSLDIR                  The home directory for FSL
+  FREESURFER_HOME         The home directory for FreeSurfer
+  PATH                    Standard PATH environment variable must be set to find
+                          HCP-customized version of gradient_unwarp.py
+
+EOF
+}
+
+#
+# Function Description
+#  Get the command line options for this script
+#
+# Global Output Variables
+#  ${PosInputImages}	  @ symbol separated list of data with 'positive' phase
+#                         encoding direction
+#  ${NegInputImages}      @ symbol separated lsit of data with 'negative' phase
+#                         encoding direction
+#  ${DWIName}             Basename to give DWI output directories
+#
+get_options()
+{
+	local arguments=($@)
+	
+	# initialize global output variables
+	unset PosInputImages
+	unset NegInputImages
+	unset PassOnArguments
+	unset StudyFolder
+	unset Subject
+	DWIName="Diffusion"
+	PassOnArguments=""
+
+	# parse arguments
+	local index=0
+	local numArgs=${#arguments[@]}
+	local argument
+	
+	while [ ${index} -lt ${numArgs} ] ; do
+		argument=${arguments[index]}
+		
+		case ${argument} in
+			--help)
+				usage
+				exit 1
+				;;
+			--version)
+				version_show $@
+				exit 0
+				;;
+			--path=*)
+				StudyFolder=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--subject=*)
+				Subject=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--posData=*)
+				PosInputImages=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--negData=*)
+				NegInputImages=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--dwiname=*)
+				DWIName=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			*)
+				PassOnArguments+=" ${argument} "
+				index=$(( index + 1 ))
+				;;
+		esac
+	done
+	
+	local error_msgs=""
+
+	# check required parameters
+	if [ -z ${PosInputImages} ] ; then
+		error_msgs+="\nERROR: <positive-phase-encoded-data> not specified"
+	fi
+	
+	if [ -z ${NegInputImages} ] ; then
+		error_msgs+="\nERROR: <negative-phase-encoded-data> not specified"
+	fi
+
+	if [ -z ${StudyFolder} ] ; then
+		error_msgs+="\nERROR: <study-path> not specified"
+	fi
+
+	if [ -z ${Subject} ] ; then
+		error_msgs+="\nERROR: <subject-id> not specified"
+	fi
+
+	if [ ! -z "${error_msgs}" ] ; then
+		usage
+		echo -e ${error_msgs}
+		echo ""
+		exit 1
+	fi
+	
+	# report parameters
+	echo "-- ${SCRIPT_NAME}: Specified Command-Line Parameters - Start --"
+	echo "   PosInputImages: ${PosInputImages}"
+	echo "   NegInputImages: ${NegInputImages}"
+	echo "   DWIName: ${DWIName}"
+	echo "   Arguments for DiffPreprocPipeline.sh: ${PassOnArguments}"
+	echo "-- ${SCRIPT_NAME}: Specified Command-Line Parameters - End --"
+}
+
+# 
+# Function Description
+#  Validate necessary environment variables
+#
+validate_environment_vars()
+{
+	local error_msgs=""
+
+	# validate
+	if [ -z ${HCPPIPEDIR_dMRI} ] ; then
+		error_msgs+="\nERROR: HCPPIPEDIR_dMRI environment variable not set"
+	fi
+
+	if [ ! -e ${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline.sh ] ; then
+		error_msgs+="\nERROR: HCPPIPEDIR/DiffusionPreprocessing/DiffPreprocPipeline.sh not found"
+	fi
+
+	if [ -z ${FSLDIR} ] ; then
+		error_msgs+="\nERROR: FSLDIR environment variable not set"
+	fi
+	
+	if [ ! -z "${error_msgs}" ] ; then
+		usage
+		echo -e ${error_msgs}
+		echo ""
+		exit 1
+	fi
+
+	# report
+	echo "-- ${SCRIPT_NAME}: Environment Variables Used - Start --"
+	echo "   HCPPIPEDIR_dMRI: ${HCPPIPEDIR_dMRI}"
+	echo "   FSLDIR: ${FSLDIR}"
+	echo "-- ${SCRIPT_NAME}: Environment Variables Used - End --"
+}
+
+#
+# Function description
+#  Main processing of script if --split is set
+#
+main()
+{
+	# Get Command Line Options
+	get_options $@
+
+	# Validate environment variables
+	validate_environment_vars $@
+
+	# Establish tool name for logging
+	log_SetToolName "${SCRIPT_NAME}"
+
+
+	PosInputImages=`echo ${PosInputImages} | sed 's/@/ /g'`
+	log_Msg "PosInputImages: ${PosInputImages}"
+	Pos_count=`echo ${PosInputImages} | wc -w`
+	echo ${Pos_count}
+
+	NegInputImages=`echo ${NegInputImages} | sed 's/@/ /g'`
+	log_Msg "NegInputImages: ${NegInputImages}"
+	Neg_count=`echo ${NegInputImages} | wc -w`
+	echo ${Neg_count}
+
+	# verify positive and negative datasets are provided in pairs
+	if [ ${Pos_count} -ne ${Neg_count} ] ; then
+		log_Msg "Wrong number of input datasets! Make sure that you provide pairs of input filenames."
+		exit 1
+	fi
+
+	# verify that none of the files are empty
+	for Image in ${PosInputImages} ; do
+		if [ ${Image} = EMPTY ] ; then
+			log_Msg "EMPTY filename found in positive images"
+			log_Msg "EMPTY filenames are not supported when splitting the data into individual pairs"
+			log_Msg "Either remove the --split flag or only supply complete pairs"
+			exit 1
+		fi
+	done
+
+	for Image in ${NegInputImages} ; do
+		if [ ${Image} = EMPTY ] ; then
+			log_Msg "EMPTY filename found in negative images"
+			log_Msg "EMPTY filenames are not supported when splitting the data into individual pairs"
+			log_Msg "Either remove the --split flag or only supply complete pairs"
+			exit 1
+		fi
+	done
+
+	for ImageIndex in $(seq 1 ${Pos_count} ) ; do
+
+		split_DWIName=${DWIName}_scan${ImageIndex}
+		arr=($PosInputImages)
+		PosImage=${arr[ImageIndex-1]}
+		arr=($NegInputImages)
+		NegImage=${arr[ImageIndex-1]}
+
+		preproc_pipeline_cmd="${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline.sh "
+		preproc_pipeline_cmd+=" --posData=${PosImage} "
+		preproc_pipeline_cmd+=" --negData=${NegImage} "
+		preproc_pipeline_cmd+=" --dwiname=${split_DWIName} "
+		preproc_pipeline_cmd+=" --path=${StudyFolder} "
+		preproc_pipeline_cmd+=" --subject=${Subject} "
+		preproc_pipeline_cmd+="${PassOnArguments}"
+		log_Msg "Invoking Preprocessing pipeline for positive/negative data pair ${pair}"
+		${preproc_pipeline_cmd}
+	done
+
+    merge_cmd="${HCPPIPEDIR}/DiffusionPreprocessing/scripts/merge_pairs.sh "
+    merge_cmd+=" ${StudyFolder}/${Subject}/T1w"
+    merge_cmd+=" ${DWIName}"
+    merge_cmd+=" ${Pos_count}"
+	log_Msg "Merging all the positive/negative data pairs"
+	${merge_cmd}
+	log_Msg "Completed all positive/negative data pairs"
+	exit 0
+}
+
+#
+# Invoke the main function to get things started
+#
+main $@
+

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
@@ -37,7 +37,7 @@
 #  
 # ## Prerequisite Installed Software
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
@@ -37,7 +37,7 @@
 #  
 # ## Prerequisite Installed Software
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 #
 #   FSL's environment setup script must also be sourced
 #

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
@@ -376,7 +376,7 @@ main()
     merge_cmd+=" --path=${StudyFolder} "
     merge_cmd+=" --subject=${Subject} "
     merge_cmd+=" --dwiname=${DWIName} "
-    merge_cmd+=" --input_dwiname=${input_dwinames} "
+    merge_cmd+=" --input_dwinames=${input_dwinames} "
     log_Msg "Merging all the shim groups"
     ${merge_cmd}
     log_Msg "Completed all the shim groups"

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -79,8 +79,9 @@ ${FSLDIR}/bin/imcp "$WorkingDirectory"/"$regimg"2T1w_restore "$RegOutput"
 ${FSLDIR}/bin/fslmaths "$T1wRestoreImage".nii.gz -mul "$WorkingDirectory"/"$regimg"2T1w_restore.nii.gz -sqrt "$QAImage"_"$regimg".nii.gz
 
 #Generate 1.25mm structural space for resampling the diffusion data into
-${FSLDIR}/bin/flirt -interp spline -in "$T1wRestoreImage" -ref "$T1wRestoreImage" -applyisoxfm ${DiffRes} -out "$T1wRestoreImage"_${DiffRes}
-${FSLDIR}/bin/applywarp --rel --interp=spline -i "$T1wRestoreImage" -r "$T1wRestoreImage"_${DiffRes} -o "$T1wRestoreImage"_${DiffRes}
+${FSLDIR}/bin/flirt -interp spline -in "$T1wRestoreImage" -ref "$T1wRestoreImage" -applyisoxfm ${DiffRes} -out "$WorkingDirectory"/T1w_restore_acpc_dc_${DiffRes}
+${FSLDIR}/bin/applywarp --rel --interp=spline -i "$T1wRestoreImage" -r "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes} -o "$WorkingDirectory"/T1w_restore_acpc_dc_${DiffRes}
+immv "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes} "$T1wRestoreImage"_${DiffRes}
 
 #Generate 1.25mm mask in structural space
 ${FSLDIR}/bin/flirt -interp nearestneighbour -in "$InputBrainMask" -ref "$InputBrainMask" -applyisoxfm ${DiffRes} -out "$T1wOutputDirectory"/nodif_brain_mask

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -79,8 +79,8 @@ ${FSLDIR}/bin/imcp "$WorkingDirectory"/"$regimg"2T1w_restore "$RegOutput"
 ${FSLDIR}/bin/fslmaths "$T1wRestoreImage".nii.gz -mul "$WorkingDirectory"/"$regimg"2T1w_restore.nii.gz -sqrt "$QAImage"_"$regimg".nii.gz
 
 #Generate 1.25mm structural space for resampling the diffusion data into
-${FSLDIR}/bin/flirt -interp spline -in "$T1wRestoreImage" -ref "$T1wRestoreImage" -applyisoxfm ${DiffRes} -out "$WorkingDirectory"/T1w_restore_acpc_dc_${DiffRes}
-${FSLDIR}/bin/applywarp --rel --interp=spline -i "$T1wRestoreImage" -r "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes} -o "$WorkingDirectory"/T1w_restore_acpc_dc_${DiffRes}
+${FSLDIR}/bin/flirt -interp spline -in "$T1wRestoreImage" -ref "$T1wRestoreImage" -applyisoxfm ${DiffRes} -out "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes}
+${FSLDIR}/bin/applywarp --rel --interp=spline -i "$T1wRestoreImage" -r "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes} -o "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes}
 immv "$WorkingDirectory"/T1w_acpc_dc_restore_${DiffRes} "$T1wRestoreImage"_${DiffRes}
 
 #Generate 1.25mm mask in structural space

--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -109,8 +109,8 @@ fi
 
 #Remove negative intensity values (caused by spline interpolation) from final data
 ${FSLDIR}/bin/fslmaths ${datadir}/data -thr 0 ${datadir}/data
-${FSLDIR}/bin/bet ${datadir}/data ${datadir}/nodif_brain -m -f 0.1
-$FSLDIR/bin/fslroi ${datadir}/data ${datadir}/nodif 0 1
+${FSLDIR}/bin/fslroi ${datadir}/data ${datadir}/nodif 0 1
+${FSLDIR}/bin/bet ${datadir}/nodif ${datadir}/nodif_brain -m -f 0.1
 
 echo -e "\n END: eddy_postproc"
 

--- a/DiffusionPreprocessing/scripts/merge_pairs.sh
+++ b/DiffusionPreprocessing/scripts/merge_pairs.sh
@@ -16,23 +16,29 @@ mkdir -p ${workingdir}/${DWIName}
 #
 # Merges the individual images
 #
-merge_image()
+echo "merging data"
+cmd="fslmerge -t ${workingdir}/${DWIName}/data"
+for ImageIndex in $(seq 1 ${NPairs} ) ; do
+    cmd+=" ${workingdir}/${DWIName}_scan${ImageIndex}/data"
+done
+${cmd}
+
+mean_image()
 {
-	echo "merging $1"
-	cmd="fslmerge -t ${workingdir}/${DWIName}/$1"
-	for ImageIndex in $(seq 1 ${NPairs} ) ; do
-		cmd+=" ${workingdir}/${DWIName}_scan${ImageIndex}/$1"
-	done
-	${cmd}
+    echo "computing mean of $1"
+    cmd="fsladd ${workingdir}/${DWIName}/$1 -m"
+    for ImageIndex in $(seq 1 ${NPairs} ) ; do
+        cmd+=" ${workingdir}/${DWIName}_scan${ImageIndex}/$1"
+    done
+    ${cmd}
 }
 
-merge_image data
-merge_image nodif_brain_mask
+mean_image nodif_brain_mask
 # include voxels based on majority voting (erring on the side of inclusion)
-fslmaths ${workingdir}/${DWIName}/nodif_brain_mask -Tmean -thr 0.49 -bin ${workingdir}/${DWIName}/nodif_brain_mask
+fslmaths ${workingdir}/${DWIName}/nodif_brain_mask -thr 0.49 -bin ${workingdir}/${DWIName}/nodif_brain_mask
+
 if [ -f ${workingdir}/${DWIName}_scan1/grad_dev.nii* ]; then
-    merge_image grad_dev
-    fslmaths ${workingdir}/${DWIName}/grad_dev -Tmean ${workingdir}/${DWIName}/grad_dev
+    mean_image grad_dev
 fi
 
 

--- a/DiffusionPreprocessing/scripts/merge_pairs.sh
+++ b/DiffusionPreprocessing/scripts/merge_pairs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Merges the individually processed data pairs into a single diffusion image
+# Called from DiffusionPreprocessing/DiffPreprocPipeline_Split.sh
+#
+set -e
+echo -e "\n START: merge_split"
+
+workingdir=$1
+DWIName=$2
+NPairs=$3
+
+
+mkdir -p ${workingdir}/${DWIName}
+
+#
+# Merges the individual images
+#
+merge_image()
+{
+	echo "merging $1"
+	cmd="fslmerge -t ${workingdir}/${DWIName}/$1"
+	for ImageIndex in $(seq 1 ${NPairs} ) ; do
+		cmd+=" ${workingdir}/${DWIName}_scan${ImageIndex}/$1"
+	done
+	${cmd}
+}
+
+merge_image data
+merge_image nodif_brain_mask
+# include voxels based on majority voting (erring on the side of inclusion)
+fslmaths ${workingdir}/${DWIName}/nodif_brain_mask -Tmean -thr 0.49 -bin ${workingdir}/${DWIName}/nodif_brain_mask
+if [ -f ${workingdir}/${DWIName}_scan1/grad_dev.nii* ]; then
+    merge_image grad_dev
+    fslmaths ${workingdir}/${DWIName}/grad_dev -Tmean ${workingdir}/${DWIName}/grad_dev
+fi
+
+
+#
+# Merges the individual b-values and b-vectors
+#
+merge_text()
+{
+	echo "merging $1"
+	cmd="paste"
+	for ImageIndex in $(seq 1 ${NPairs} ) ; do
+		cmd+=" ${workingdir}/${DWIName}_scan${ImageIndex}/$1"
+	done
+	${cmd} >${workingdir}/${DWIName}/$1
+}
+
+merge_text bvals
+merge_text bvecs
+
+echo -e "\n END: merge_split"
+

--- a/DiffusionPreprocessing/scripts/merge_split.sh
+++ b/DiffusionPreprocessing/scripts/merge_split.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #
-# Merges the individually processed data pairs into a single diffusion image
+# Merges the individually processed diffusion datasets into a single diffusion image
 # Called from DiffusionPreprocessing/DiffPreprocPipeline_Merge.sh
 #
 
 set -e
+echo -e "\n START: merge_split"
 
 outdir=$1
 indirs="${@:2}"
@@ -46,16 +47,16 @@ fi
 #
 merge_text()
 {
-	echo "merging $1"
-	cmd="paste"
+    echo "merging $1"
+    cmd="paste"
     for indir in ${indirs} ; do
-		cmd+=" ${indir}/$1"
-	done
-	${cmd} >${indir}/$1
+        cmd+=" ${indir}/$1"
+    done
+    ${cmd} >${outdir}/$1
 }
 
 merge_text bvals
 merge_text bvecs
 
-echo -e "\n END: merge_pairs"
+echo -e "\n END: merge_split"
 

--- a/DiffusionPreprocessing/scripts/run_eddy.sh
+++ b/DiffusionPreprocessing/scripts/run_eddy.sh
@@ -35,7 +35,7 @@
 # 
 # ## Prerequisite Installed Software
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.6)
+# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
 # 
 #   FSL's environment setup script must also be sourced
 # 

--- a/DiffusionPreprocessing/scripts/run_eddy.sh
+++ b/DiffusionPreprocessing/scripts/run_eddy.sh
@@ -35,7 +35,7 @@
 # 
 # ## Prerequisite Installed Software
 # 
-# * [FSL][FSL] - FMRIB's Software Library (version 5.0.11)
+# * [FSL][FSL] - FMRIB's Software Library (version 6.0.1)
 # 
 #   FSL's environment setup script must also be sourced
 # 

--- a/DiffusionPreprocessing/scripts/split_shimgroups.py
+++ b/DiffusionPreprocessing/scripts/split_shimgroups.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env fslpython
+
+import argparse
+
+parser = argparse.ArgumentParser('Splits the positive/negative datasets based on the shim group labels')
+parser.add_argument('positive_filenames',
+                    help='@-seperated list with filenames of the data with positive phase encoding')
+parser.add_argument('positive_shim_labels',
+                    help='@-seperated list with shim groups for the `positive_filenames`')
+parser.add_argument('negative_filenames',
+                    help='@-seperated list with filenames of the data with negative phase encoding')
+parser.add_argument('negative_shim_labels',
+                    help='@-seperated list with shim groups for the `negative_filenames`')
+args = parser.parse_args()
+
+
+pos_filenames = args.positive_filenames.split('@')
+pos_labels = args.positive_shim_labels.split('@')
+neg_filenames = args.negative_filenames.split('@')
+neg_labels = args.negative_shim_labels.split('@')
+
+if len(pos_filenames) != len(pos_labels):
+    raise ValueError("Number of filenames with positive phase encoding does not match number of shim groups labels")
+
+if len(neg_filenames) != len(neg_labels):
+    raise ValueError("Number of filenames with negative phase encoding does not match number of shim groups labels")
+
+unique_labels = set(pos_labels)
+
+single_labels = unique_labels.symmetric_difference(set(neg_labels))
+if len(single_labels) != 0:
+    raise ValueError("Shim groups %s can not be processed, because they do not have both positive "
+                     "and negative phase encoding data" % ' and '.join(sorted(single_labels)))
+
+for label in sorted(unique_labels):
+    print(
+            label,
+            '@'.join(fn for fn, lab in zip(pos_filenames, pos_labels) if lab == label),
+            '@'.join(fn for fn, lab in zip(neg_filenames, neg_labels) if lab == label),
+    )
+


### PR DESCRIPTION
When the field is reshimmed between the acquisition of different blip-up/ down diffusion MRI pairs, it might be advantageous to run topup and eddy on each blip-up/down pair separately to correct for any changes in the susceptibility field. Here we add a new script DiffPreprocPipeline_Split.sh, which has a very similar interface to DiffPreprocPipeline.sh. It calls DiffPreprocPipeline.sh separately for each diffusion MRI data pair and then merges the results.

The scripts have been setup in such a way that each call of DiffPreprocPipeline.sh can be run in parallel (i.e., they don't read/write to the same directory). To allow this a minor change was made to DiffusionToStructural.sh .