### PR TITLE
BUG: run bet on a single B0 image rather than the full diffusion data

### DIFF
--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -109,8 +109,8 @@ fi
 
 #Remove negative intensity values (caused by spline interpolation) from final data
 ${FSLDIR}/bin/fslmaths ${datadir}/data -thr 0 ${datadir}/data
-${FSLDIR}/bin/bet ${datadir}/data ${datadir}/nodif_brain -m -f 0.1
-$FSLDIR/bin/fslroi ${datadir}/data ${datadir}/nodif 0 1
+${FSLDIR}/bin/fslroi ${datadir}/data ${datadir}/nodif 0 1
+${FSLDIR}/bin/bet ${datadir}/nodif ${datadir}/nodif_brain -m -f 0.1
 
 echo -e "\n END: eddy_postproc"
 


### PR DESCRIPTION
In FSL 6 running bet on a 4D diffusion MRI dataset no longer only loads the first volume,
but actually produces a 4D file with the first volume containing a mangled mask