### PR TITLE
Feature/fsl v6

### DIFF
--- a/global/scripts/mcflirt.sh
+++ b/global/scripts/mcflirt.sh
@@ -93,11 +93,11 @@ for i in `ls ${output}.mat/*` ; do
     mmz=`echo $mm | cut -d " " -f 3`
     radians=`${FSLDIR}/bin/avscale --allparams ${output}/${ii}.mat $mcref | grep "Rotation Angles" | awk '{print $6 " " $7 " " $8}'`
     radx=`echo $radians | cut -d " " -f 1`
-    degx=`echo "$radx * (180 / $pi)" | bc -l`
+    degx=`echo "$radx * (180 / $pi)" | sed 's/e/*10^/g' | bc -l`
     rady=`echo $radians | cut -d " " -f 2`
-    degy=`echo "$rady * (180 / $pi)" | bc -l`
+    degy=`echo "$rady * (180 / $pi)" | sed 's/e/*10^/g' | bc -l`
     radz=`echo $radians | cut -d " " -f 3`
-    degz=`echo "$radz * (180 / $pi)" | bc -l`
+    degz=`echo "$radz * (180 / $pi)" | sed 's/e/*10^/g' | bc -l`
     # The "%.6f" formatting specifier allows the numeric value to be as wide as it needs to be to accomodate the number
     # Then we mandate (include) a single space as a delimiter between values.
     echo `printf "%.6f" $mmx` `printf "%.6f" $mmy` `printf "%.6f" $mmz` `printf "%.6f" $degx` `printf "%.6f" $degy` `printf "%.6f" $degz` >> ${output}/mc.par

--- a/global/scripts/mcflirt_acc.sh
+++ b/global/scripts/mcflirt_acc.sh
@@ -56,11 +56,11 @@ for i in `${FSLDIR}/bin/imglob ${output}_tmp????.*` ; do
     mmz=`echo $mm | cut -d " " -f 3`
     radians=`${FSLDIR}/bin/avscale --allparams ${output}/${ii}.mat $ref | grep "Rotation Angles" | awk '{print $6 " " $7 " " $8}'`
     radx=`echo $radians | cut -d " " -f 1`
-    degx=`echo "$radx * (180 / $pi)" | bc -l`
+    degx=`echo "$radx * (180 / $pi)" | sed 's/e/*10^/g' | bc -l`
     rady=`echo $radians | cut -d " " -f 2`
-    degy=`echo "$rady * (180 / $pi)" | bc -l`
+    degy=`echo "$rady * (180 / $pi)" | sed 's/e/*10^/g' | bc -l`
     radz=`echo $radians | cut -d " " -f 3`
-    degz=`echo "$radz * (180 / $pi)" | bc -l`
+    degz=`echo "$radz * (180 / $pi)" | sed 's/e/*10^/g' | bc -l`
     # The "%.6f" formatting specifier allows the numeric value to be as wide as it needs to be to accomodate the number
     # Then we mandate (include) a single space as a delimiter between values.
     echo `printf "%.6f" $mmx` `printf "%.6f" $mmy` `printf "%.6f" $mmz` `printf "%.6f" $degx` `printf "%.6f" $degy` `printf "%.6f" $degz` >> ${output}/mc.par


### PR DESCRIPTION
Fixed (standard_in) 1: syntax error for Functional Preprocessing pipeline with FSL-6.0.0 - converting scientific notation for bc
Tested with both FSL-6.0.0 and FSL-5.0.11