### PR TITLE
Add capability to use BIDS convention (i/j/k) for specifying axes

### DIFF
--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -338,13 +338,13 @@ main()
 		#   0.000580002668012
 		SEEchoSpacing="NONE"
 
-		# Spin Echo Unwarping Direction
-		# x or y (minus or not does not matter)
-		# "NONE" if not used
+		# Spin Echo Unwarping Direction (according to the *voxel* axes)
+		# {x,y} (FSL nomenclature), or alternatively, {i,j} (BIDS nomenclature for the voxel axes)
+		# Set to "NONE" if not used.
 		#
-		# Example values for when using Spin Echo Field Maps: x, -x, y, -y
-		# Note: '+x' or '+y' are not supported. i.e., for positive values, DO NOT include the + sign
-		## MPH: Why do we say that "minus or not does not matter", but then list -x and -y as example values??
+		# Example values for when using Spin Echo Field Maps: {x,y} or {i,j}
+		# Note: '+x' or '+y' are not supported. i.e., for positive values, DO NOT include the '+' sign
+		# Note: Polarity not important here [i.e., don't use {x-,y-} or {i-,j-}]
 		SEUnwarpDir="NONE"
 
 		# Topup Configuration file
@@ -402,9 +402,12 @@ main()
 
 		# Structural Scan Settings
 		#
-		# Note that "UnwarpDir" is the *readout* direction of the *structural* (T1w,T2w)
-		# images, and should not be confused with "SEUnwarpDir" which is the *phase* encoding direction
+		# "UnwarpDir" is the *readout* direction of the *structural* (T1w,T2w) images,
+		# *after* the application of 'fslreorient2std' (which is built into PreFreeSurferPipeline.sh)
+		# Do NOT confuse with "SEUnwarpDir" which is the *phase* encoding direction
 		# of the Spin Echo Field Maps (if using them).
+		# Note that polarity of UnwarpDir DOES matter.
+		# Allowed values: {x,y,z,x-,y-,z-} (FSL nomenclature) or {i,j,k,i-,j-,k-} (BIDS nomenclature)
 		#
 		# set all these values to NONE if not doing readout distortion correction
 		#
@@ -423,7 +426,6 @@ main()
 		T2wSampleSpacing="0.0000021"
 
 		# z appears to be the appropriate polarity for the 3D structurals collected on Siemens scanners
-		# or "NONE" if not used
 		UnwarpDir="z"
 
 		# Other Config Settings

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -219,14 +219,14 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                     Echo Field Maps
   --seechospacing=<seconds>         Effective Echo Spacing of Spin Echo Field Map,
                                     (in seconds) or "NONE" if not used
-  --seunwarpdir={x, y, NONE}        Phase encoding direction of the spin echo 
-                                    field map. (Only applies when using a spin echo
-                                    field map.)
+  --seunwarpdir={x,y,NONE}          Phase encoding direction (according to the *voxel* axes)
+             or={i,j,NONE}          of the spin echo field map. 
+                                    (Only applies when using a spin echo field map.)
   --t1samplespacing=<seconds>       T1 image sample spacing, "NONE" if not used
   --t2samplespacing=<seconds>       T2 image sample spacing, "NONE" if not used
-  --unwarpdir={x, y, z}             Readout direction of the T1w and T2w images
-                                    (Used with either a gradient echo field map 
-                                     or a spin echo field map)
+  --unwarpdir={x,y,z,x-,y-,z-}      Readout direction of the T1w and T2w images (according to the *voxel axes)
+           or={i,j,k,i-,j-,k-}      (Used with either a gradient echo field map 
+                                    or a spin echo field map)
   --gdcoeffs=<file path>            File containing gradient distortion 
                                     coefficients, Set to "NONE" to turn off
   --avgrdcmethod=<avgrdcmethod>     Averaging and readout distortion correction

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -32,10 +32,10 @@ Usage() {
   echo "            [--SEPhaseNeg=<input spin echo negative phase encoding image>]"
   echo "            [--SEPhasePos=<input spin echo positive phase encoding image>]"
   echo "            [--seechospacing=<effective echo spacing of SEPhaseNeg and SEPhasePos, in seconds>]"
-  echo "            [--seunwarpdir=<direction of distortion of the SEPhase images according to voxel axes>]"
+  echo "            [--seunwarpdir=<direction of distortion of the SEPhase images according to *voxel* axes: {x,y,x-,y-} or {i,j,i-,j-}>]"
   echo "            --t1sampspacing=<sample spacing (readout direction) of T1w image - in seconds>"
   echo "            --t2sampspacing=<sample spacing (readout direction) of T2w image - in seconds>"
-  echo "            --unwarpdir=<direction of distortion of T1 and T2 according to voxel axes (post reorient2std)>"
+  echo "            --unwarpdir=<direction of distortion of T1 and T2 according to *voxel* axes (post fslreorient2std): {x,y,z,x-,y-,z-}, or {i,j,k,i-,j-,k-}>"
   echo "            --ot1=<output corrected T1w image>"
   echo "            --ot1brain=<output corrected, brain-extracted T1w image>"
   echo "            --ot1warp=<output warpfield for distortion correction of T1w image>"
@@ -216,10 +216,13 @@ case $DistortionCorrection in
         # -- Spin Echo Field Maps --  
         # --------------------------
 
-        if [[ ${SEUnwarpDir} = "x" || ${SEUnwarpDir} = "y" ]] ; then
-          ScoutInputName="${SpinEchoPhaseEncodePositive}"
-        elif [[ ${SEUnwarpDir} = "-x" || ${SEUnwarpDir} = "-y" || ${SEUnwarpDir} = "x-" || ${SEUnwarpDir} = "y-" ]] ; then
-          ScoutInputName="${SpinEchoPhaseEncodeNegative}"
+        if [[ ${SEUnwarpDir} = [xyij] ]] ; then
+			ScoutInputName="${SpinEchoPhaseEncodePositive}"
+        elif [[ ${SEUnwarpDir} = -[xyij] || ${SEUnwarpDir} = [xyij]- ]] ; then
+			ScoutInputName="${SpinEchoPhaseEncodeNegative}"
+		else
+			echo "${SCRIPT_NAME} - ERROR - Invalid entry for --seunwarpdir ($SEUnwarpDir)"
+			exit 1
         fi
 
         # Use topup to distortion correct the scout scans
@@ -247,14 +250,18 @@ case $DistortionCorrection in
         exit 1
 esac
 
+# FSL's naming convention for 'convertwarp --shiftdir' is {x,y,z,x-,y-,z-}
+# So, swap out any {i,j,k} for {x,y,z} (using bash pattern replacement)
+# and then make sure any '-' sign is trailing
+UnwarpDir=${UnwarpDir//i/x}
+UnwarpDir=${UnwarpDir//j/y}
+UnwarpDir=${UnwarpDir//k/z}
 if [ "${UnwarpDir}" = "-x" ] ; then
   UnwarpDir="x-"
 fi
-
 if [ "${UnwarpDir}" = "-y" ] ; then
   UnwarpDir="y-"
 fi
-
 if [ "${UnwarpDir}" = "-z" ] ; then
   UnwarpDir="z-"
 fi

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -37,7 +37,7 @@ Usage() {
   echo "             --SEPhaseNeg=<input spin echo negative phase encoding image>"
   echo "             --SEPhasePos=<input spin echo positive phase encoding image>"
   echo "             --echospacing=<effective echo spacing of fMRI image, in seconds>"
-  echo "             --unwarpdir=<unwarping direction: x/y/z/-x/-y/-z>"
+  echo "             --unwarpdir=<PE direction for unwarping according to the *voxel* axes: {x,y,x-,y-} or {i,j,i-,j-}>"
   echo "             --owarp=<output filename for warp of EPI to T1w>"
   echo "             --biasfield=<input T1w bias field estimate image, in fMRI space>"
   echo "             --oregim=<output registered image (EPI to T1w)>"
@@ -232,6 +232,22 @@ fi
 ########################################## DO WORK ########################################## 
 
 cp ${T1wBrainImage}.nii.gz ${WD}/${T1wBrainImageFile}.nii.gz
+
+# FSL's naming convention for 'epi_reg --pedir' is {x,y,z,-x,-y,-z}
+# So, swap out any {i,j,k} for {x,y,z} (using bash pattern replacement)
+# and then make sure any '-' sign is preceding
+UnwarpDir=${UnwarpDir//i/x}
+UnwarpDir=${UnwarpDir//j/y}
+UnwarpDir=${UnwarpDir//k/z}
+if [ "${UnwarpDir}" = "x-" ] ; then
+  UnwarpDir="-x"
+fi
+if [ "${UnwarpDir}" = "y-" ] ; then
+  UnwarpDir="-y"
+fi
+if [ "${UnwarpDir}" = "z-" ] ; then
+  UnwarpDir="-z"
+fi
 
 case $DistortionCorrection in
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -37,7 +37,7 @@ Usage() {
   echo "             --SEPhaseNeg=<input spin echo negative phase encoding image>"
   echo "             --SEPhasePos=<input spin echo positive phase encoding image>"
   echo "             --echospacing=<effective echo spacing of fMRI image, in seconds>"
-  echo "             --unwarpdir=<PE direction for unwarping according to the *voxel* axes: {x,y,x-,y-} or {i,j,i-,j-}>"
+  echo "             --unwarpdir=<PE direction for unwarping according to the *voxel* axes: {x,y,z,x-,y-,z-} or {i,j,k,i-,j-,k-}>"
   echo "             --owarp=<output filename for warp of EPI to T1w>"
   echo "             --biasfield=<input T1w bias field estimate image, in fMRI space>"
   echo "             --oregim=<output registered image (EPI to T1w)>"
@@ -233,6 +233,12 @@ fi
 
 cp ${T1wBrainImage}.nii.gz ${WD}/${T1wBrainImageFile}.nii.gz
 
+# Explicit check on the allowed values of UnwarpDir
+if [[ ${UnwarpDir} != [xyzijk] && ${UnwarpDir} != -[xyzijk] && ${UnwarpDir} != [xyzijk]- ]]; then
+	log_Msg "Error: Invalid entry for --unwarpdir ($UnwarpDir)"
+	exit 1
+fi
+	
 # FSL's naming convention for 'epi_reg --pedir' is {x,y,z,-x,-y,-z}
 # So, swap out any {i,j,k} for {x,y,z} (using bash pattern replacement)
 # and then make sure any '-' sign is preceding

--- a/global/scripts/TopupPreprocessingAll.sh
+++ b/global/scripts/TopupPreprocessingAll.sh
@@ -234,6 +234,7 @@ elif [[ $UnwarpDir = [yj] || $UnwarpDir = [yj]- || $UnwarpDir = -[yj] ]] ; then
     i=`echo "$i + 1" | bc`
   done
 else
+	# Per Jesper Anderson, topup does NOT allow PE dir to be along Z (no good reason, other than that made implementation easier)
 	log_Msg "Error: Invalid entry for --unwarpdir ($UnwarpDir)"
     exit 1
 fi
@@ -254,7 +255,7 @@ fi
 ${FSLDIR}/bin/fslmaths ${WD}/BothPhases -abs -add 1 -mas ${WD}/Mask -dilM -dilM -dilM -dilM -dilM ${WD}/BothPhases
 
 # RUN TOPUP
-# Needs FSL (version 5.0.6)
+# Needs FSL (version 5.0.6 or later)
 ${FSLDIR}/bin/topup --imain=${WD}/BothPhases --datain=$txtfname --config=${TopupConfig} --out=${WD}/Coefficents --iout=${WD}/Magnitudes --fout=${WD}/TopupField --dfout=${WD}/WarpField --rbmout=${WD}/MotionMatrix --jacout=${WD}/Jacobian -v 
 
 #Remove Z slice padding if needed

--- a/global/scripts/TopupPreprocessingAll.sh
+++ b/global/scripts/TopupPreprocessingAll.sh
@@ -233,6 +233,9 @@ elif [[ $UnwarpDir = [yj] || $UnwarpDir = [yj]- || $UnwarpDir = -[yj] ]] ; then
     ShiftTwo="y"
     i=`echo "$i + 1" | bc`
   done
+else
+	log_Msg "Error: Invalid entry for --unwarpdir ($UnwarpDir)"
+    exit 1
 fi
 
 #Pad in Z by one slice if odd so that topup does not complain (slice consists of zeros that will be dilated by following step)

--- a/global/scripts/TopupPreprocessingAll.sh
+++ b/global/scripts/TopupPreprocessingAll.sh
@@ -21,7 +21,7 @@ Usage() {
   echo "            --phasetwo=<second set of SE EPI images: assumed to be the 'positive' PE direction>"
   echo "            --scoutin=<scout input image: should be corrected for gradient non-linear distortions>"
   echo "            --echospacing=<effective echo spacing of EPI, in seconds>"
-  echo "            --unwarpdir=<PE direction for unwarping according to the *voxel* axes: {x,y,x-,y-} or {i,j,i-,j-,}>"
+  echo "            --unwarpdir=<PE direction for unwarping according to the *voxel* axes: {x,y,x-,y-} or {i,j,i-,j-}>"
   echo "            [--owarp=<output warpfield image: scout to distortion corrected SE EPI>]"
   echo "            [--ofmapmag=<output 'Magnitude' image: scout to distortion corrected SE EPI>]" 
   echo "            [--ofmapmagbrain=<output 'Magnitude' brain image: scout to distortion corrected SE EPI>]"   

--- a/global/scripts/TopupPreprocessingAll.sh
+++ b/global/scripts/TopupPreprocessingAll.sh
@@ -21,7 +21,7 @@ Usage() {
   echo "            --phasetwo=<second set of SE EPI images: assumed to be the 'positive' PE direction>"
   echo "            --scoutin=<scout input image: should be corrected for gradient non-linear distortions>"
   echo "            --echospacing=<effective echo spacing of EPI, in seconds>"
-  echo "            --unwarpdir=<PE direction for unwarping: x/y/z/-x/-y/-z>"
+  echo "            --unwarpdir=<PE direction for unwarping according to the *voxel* axes: {x,y,x-,y-} or {i,j,i-,j-,}>"
   echo "            [--owarp=<output warpfield image: scout to distortion corrected SE EPI>]"
   echo "            [--ofmapmag=<output 'Magnitude' image: scout to distortion corrected SE EPI>]" 
   echo "            [--ofmapmagbrain=<output 'Magnitude' brain image: scout to distortion corrected SE EPI>]"   
@@ -197,8 +197,9 @@ dimtTwo=`${FSLDIR}/bin/fslval ${WD}/PhaseTwo dim4`
 #  Factors such as in-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
 #  must already be accounted for as part of the "EffectiveEchoSpacing"
 
+# For UnwarpDir, allow for both {x,y} and {i,j} nomenclature
 # X direction phase encode
-if [[ $UnwarpDir = "x" || $UnwarpDir = "x-" || $UnwarpDir = "-x" ]] ; then
+if [[ $UnwarpDir = [xi] || $UnwarpDir = [xi]- || $UnwarpDir = -[xi] ]] ; then
   dimP=`${FSLDIR}/bin/fslval ${WD}/PhaseOne dim1`
   dimPminus1=$(($dimP - 1))
   ro_time=`echo "scale=6; ${EchoSpacing} * ${dimPminus1}" | bc -l` #Compute Total_readout in secs with up to 6 decimal places
@@ -216,7 +217,7 @@ if [[ $UnwarpDir = "x" || $UnwarpDir = "x-" || $UnwarpDir = "-x" ]] ; then
     i=`echo "$i + 1" | bc`
   done
 # Y direction phase encode
-elif [[ $UnwarpDir = "y" || $UnwarpDir = "y-" || $UnwarpDir = "-y" ]] ; then
+elif [[ $UnwarpDir = [yj] || $UnwarpDir = [yj]- || $UnwarpDir = -[yj] ]] ; then
   dimP=`${FSLDIR}/bin/fslval ${WD}/PhaseOne dim2`
   dimPminus1=$(($dimP - 1))
   ro_time=`echo "scale=6; ${EchoSpacing} * ${dimPminus1}" | bc -l` #Compute Total_readout in secs with up to 6 decimal places
@@ -262,7 +263,7 @@ if [ ! $(($numslice % 2)) -eq "0" ] ; then
 fi
 
 # UNWARP DIR = x,y
-if [[ $UnwarpDir = "x" || $UnwarpDir = "y" ]] ; then
+if [[ $UnwarpDir = [xyij] ]] ; then
   # select the first volume from PhaseTwo
   VolumeNumber=$(($dimtOne + 1))
   vnum=`${FSLDIR}/bin/zeropad $VolumeNumber 2`
@@ -273,7 +274,7 @@ if [[ $UnwarpDir = "x" || $UnwarpDir = "y" ]] ; then
   ${FSLDIR}/bin/imcp ${WD}/Jacobian_${vnum}.nii.gz ${WD}/Jacobian.nii.gz
   SBRefPhase=Two
 # UNWARP DIR = -x,-y
-elif [[ $UnwarpDir = "x-" || $UnwarpDir = "-x" || $UnwarpDir = "y-" || $UnwarpDir = "-y" ]] ; then
+elif [[ $UnwarpDir = [xyij]- || $UnwarpDir = -[xyij] ]] ; then
   # select the first volume from PhaseOne
   VolumeNumber=$((0 + 1))
   vnum=`${FSLDIR}/bin/zeropad $VolumeNumber 2`


### PR DESCRIPTION
This will allow for pulling values directly from BIDS-style sidecar json files, without needing to remap the axes into the x/y/z nomenclature.