### PR TITLE
Removed --printcom= option from FreeSurferPipelineBatch.sh

### DIFF
--- a/Examples/Scripts/FreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/FreeSurferPipelineBatch.sh
@@ -69,8 +69,6 @@ echo "$@"
     QUEUE="-q hcp_priority.q"
 #fi
 
-PRINTCOM=""
-#PRINTCOM="echo"
 #QUEUE="-q veryshort.q"
 
 
@@ -103,8 +101,7 @@ for Subject in $Subjlist ; do
       --subjectDIR="$SubjectDIR" \
       --t1="$T1wImage" \
       --t1brain="$T1wImageBrain" \
-      --t2="$T2wImage" \
-      --printcom=$PRINTCOM
+      --t2="$T2wImage"
       
   # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
 
@@ -112,8 +109,7 @@ for Subject in $Subjlist ; do
       --subjectDIR="$SubjectDIR" \
       --t1="$T1wImage" \
       --t1brain="$T1wImageBrain" \
-      --t2="$T2wImage" \
-      --printcom=$PRINTCOM"
+      --t2="$T2wImage"
 
   echo ". ${EnvironmentScript}"
 


### PR DESCRIPTION
* Fix Issue #100
* Remove use of --printcom= flag in example script
* This should go in the next release whether it is a bugfix release (e.g. v4.0.1) or a new feature release 