### PR TITLE
Replaced \-\-verbose option with \-v option in cp, rm, mkdir, and mv …

### DIFF
--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -768,7 +768,7 @@ main()
 
 					if [[ ! -e ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii ]] ; then
 						if [[ ! -z ${MyelinTargetFile} ]] ; then
-							cp --verbose ${MyelinTargetFile} ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii
+							cp -v ${MyelinTargetFile} ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii
 						else
 							log_Err_Abort "A --myelin-target-file is required to run this pipeline when using a different mesh resolution than the original MSMAll registration"
 						fi

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -768,7 +768,7 @@ main()
 
 					if [[ ! -e ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii ]] ; then
 						if [[ ! -z ${MyelinTargetFile} ]] ; then
-							cp -v ${MyelinTargetFile} ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii
+							cp ${MyelinTargetFile} ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii
 						else
 							log_Err_Abort "A --myelin-target-file is required to run this pipeline when using a different mesh resolution than the original MSMAll registration"
 						fi

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -390,9 +390,9 @@ main()
 	from_files+=" ${from_directory}/eddy_unwarped_images.eddy_parameters "
 	from_files+=" ${from_directory}/eddy_unwarped_images.eddy_post_eddy_shell_alignment_parameters "
 
-	mkdir --parents ${to_location}
+	mkdir -p ${to_location}
 	for filename in ${from_files} ; do
-		cp -v ${filename} ${to_location}
+		cp ${filename} ${to_location}
 	done
 	
 	log_Msg "Completed"

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -392,7 +392,7 @@ main()
 
 	mkdir --parents ${to_location}
 	for filename in ${from_files} ; do
-		cp --verbose ${filename} ${to_location}
+		cp -v ${filename} ${to_location}
 	done
 	
 	log_Msg "Completed"

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -751,8 +751,8 @@ main()
 	fi
 
 	log_Msg "...Clean up"
-	rm --verbose deleteme.dat
-	rm --verbose Q.lta
+	rm -v deleteme.dat
+	rm -v Q.lta
 
 	popd
 

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -751,8 +751,8 @@ main()
 	fi
 
 	log_Msg "...Clean up"
-	rm -v deleteme.dat
-	rm -v Q.lta
+	rm deleteme.dat
+	rm Q.lta
 
 	popd
 

--- a/ICAFIX/scripts/Compile_MATLAB_code.sh
+++ b/ICAFIX/scripts/Compile_MATLAB_code.sh
@@ -45,7 +45,7 @@ compile_prepareICAs()
 	log_Msg "Working in ${PWD}"
 
 	log_Msg "Creating output directory: ${output_directory}"
-	mkdir --parents ${output_directory}
+	mkdir -p ${output_directory}
 
 	log_Msg "Compiling ${app_name} application"
 	${MATLAB_HOME}/bin/mcc -mv ${app_name}.m \
@@ -71,7 +71,7 @@ compile_functionhighpassandvariancenormalize()
 	log_Msg "Working in ${PWD}"
 
 	log_Msg "Creating output directory: ${output_directory}"
-	mkdir --parents ${output_directory}
+	mkdir -p ${output_directory}
 
 	log_Msg "Compiling ${app_name} application"
 	${MATLAB_HOME}/bin/mcc -mv ${app_name}.m \

--- a/MSMAll/scripts/Compile_MATLAB_code.sh
+++ b/MSMAll/scripts/Compile_MATLAB_code.sh
@@ -45,7 +45,7 @@ compile_ComputeVN()
 	log_Msg "Working in ${PWD}"
 
 	log_Msg "Creating output directory: ${output_directory}"
-	mkdir --parents ${output_directory}
+	mkdir -p ${output_directory}
 
 	log_Msg "Compiling ${app_name} application"
 	${MATLAB_HOME}/bin/mcc -mv ${app_name}.m \
@@ -69,7 +69,7 @@ compile_MSMregression()
 	log_Msg "Working in ${PWD}"
 
 	log_Msg "Creating output directory: ${output_directory}"
-	mkdir --parents ${output_directory}
+	mkdir -p ${output_directory}
 
 	log_Msg "Compiling ${app_name} application"
 	${MATLAB_HOME}/bin/mcc -mv ${app_name}.m \

--- a/MSMAll/scripts/MSMAll.sh
+++ b/MSMAll/scripts/MSMAll.sh
@@ -581,10 +581,10 @@ main()
 		log_Msg "RSNCostWeights: ${RSNCostWeights}"
 		log_File_Must_Exist "${RSNCostWeights}"
 
-		cp -v "${RSNTargetFile}" "${DownSampleFolder}/${Subject}.atlas_RSNs_d${ICAdim}.${LowResMesh}k_fs_LR.dscalar.nii"
-		cp -v "${MyelinTargetFile}" "${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii"
-		cp -v "${TopographyROIFile}" "${DownSampleFolder}/${Subject}.atlas_Topographic_ROIs.${LowResMesh}k_fs_LR.dscalar.nii"
-		cp -v "${TopographyTargetFile}" "${DownSampleFolder}/${Subject}.atlas_Topography.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp "${RSNTargetFile}" "${DownSampleFolder}/${Subject}.atlas_RSNs_d${ICAdim}.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp "${MyelinTargetFile}" "${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp "${TopographyROIFile}" "${DownSampleFolder}/${Subject}.atlas_Topographic_ROIs.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp "${TopographyTargetFile}" "${DownSampleFolder}/${Subject}.atlas_Topography.${LowResMesh}k_fs_LR.dscalar.nii"
 
 		if [ "${InPCARegName}" = "MSMSulc" ] ; then
 			log_Msg "InPCARegName is MSMSulc"
@@ -664,10 +664,10 @@ main()
 			log_Msg "Modalities: ${Modalities}"
 
 			if [ ! -e ${NativeFolder}/${RegName} ] ; then
-				mkdir -v ${NativeFolder}/${RegName}
+				mkdir ${NativeFolder}/${RegName}
 			else
 				rm -r "${NativeFolder:?}/${RegName}"
-				mkdir -v ${NativeFolder}/${RegName}
+				mkdir ${NativeFolder}/${RegName}
 			fi
 
 			if [[ $(echo -n ${Modalities} | grep "C") || $(echo -n ${Modalities} | grep "T") ]] ; then

--- a/MSMAll/scripts/MSMAll.sh
+++ b/MSMAll/scripts/MSMAll.sh
@@ -581,10 +581,10 @@ main()
 		log_Msg "RSNCostWeights: ${RSNCostWeights}"
 		log_File_Must_Exist "${RSNCostWeights}"
 
-		cp --verbose "${RSNTargetFile}" "${DownSampleFolder}/${Subject}.atlas_RSNs_d${ICAdim}.${LowResMesh}k_fs_LR.dscalar.nii"
-		cp --verbose "${MyelinTargetFile}" "${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii"
-		cp --verbose "${TopographyROIFile}" "${DownSampleFolder}/${Subject}.atlas_Topographic_ROIs.${LowResMesh}k_fs_LR.dscalar.nii"
-		cp --verbose "${TopographyTargetFile}" "${DownSampleFolder}/${Subject}.atlas_Topography.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp -v "${RSNTargetFile}" "${DownSampleFolder}/${Subject}.atlas_RSNs_d${ICAdim}.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp -v "${MyelinTargetFile}" "${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp -v "${TopographyROIFile}" "${DownSampleFolder}/${Subject}.atlas_Topographic_ROIs.${LowResMesh}k_fs_LR.dscalar.nii"
+		cp -v "${TopographyTargetFile}" "${DownSampleFolder}/${Subject}.atlas_Topography.${LowResMesh}k_fs_LR.dscalar.nii"
 
 		if [ "${InPCARegName}" = "MSMSulc" ] ; then
 			log_Msg "InPCARegName is MSMSulc"
@@ -664,10 +664,10 @@ main()
 			log_Msg "Modalities: ${Modalities}"
 
 			if [ ! -e ${NativeFolder}/${RegName} ] ; then
-				mkdir --verbose ${NativeFolder}/${RegName}
+				mkdir -v ${NativeFolder}/${RegName}
 			else
 				rm -r "${NativeFolder:?}/${RegName}"
-				mkdir --verbose ${NativeFolder}/${RegName}
+				mkdir -v ${NativeFolder}/${RegName}
 			fi
 
 			if [[ $(echo -n ${Modalities} | grep "C") || $(echo -n ${Modalities} | grep "T") ]] ; then

--- a/MSMAll/scripts/SingleSubjectConcat.sh
+++ b/MSMAll/scripts/SingleSubjectConcat.sh
@@ -470,7 +470,7 @@ M_PROG
 		MergeSTRING=`echo "${MergeSTRING} -cifti ${ResultsFolder}/${fMRIName}${fMRIProcSTRING}${OutputProcSTRING}.dtseries.nii"`
 		
 	done
-	mkdir --parents "${OutputFolder}"
+	mkdir -p "${OutputFolder}"
 	${Caret7_Command} -cifti-merge ${OutputFolder}/${OutputfMRIName}${fMRIProcSTRING}${OutputProcSTRING}.dtseries.nii ${MergeSTRING}
 }
 

--- a/MSMRemoveGroupDrift/MSMRemoveGroupDrift.sh
+++ b/MSMRemoveGroupDrift/MSMRemoveGroupDrift.sh
@@ -369,7 +369,7 @@ main()
 
 	# Copy Atlas ROI files
 	for Hemisphere in L R ; do
-		cp --verbose \
+		cp -v \
 			${HCPPIPEDIR}/global/templates/standard_mesh_atlases/${Hemisphere}.atlasroi.${HighResMesh}k_fs_LR.shape.gii \
 			${CommonAtlasFolder}/${GroupAverageName}.${Hemisphere}.atlasroi.${HighResMesh}k_fs_LR.shape.gii
 	done

--- a/MSMRemoveGroupDrift/MSMRemoveGroupDrift.sh
+++ b/MSMRemoveGroupDrift/MSMRemoveGroupDrift.sh
@@ -369,7 +369,7 @@ main()
 
 	# Copy Atlas ROI files
 	for Hemisphere in L R ; do
-		cp -v \
+		cp \
 			${HCPPIPEDIR}/global/templates/standard_mesh_atlases/${Hemisphere}.atlasroi.${HighResMesh}k_fs_LR.shape.gii \
 			${CommonAtlasFolder}/${GroupAverageName}.${Hemisphere}.atlasroi.${HighResMesh}k_fs_LR.shape.gii
 	done

--- a/RestingStateStats/RestingStateStats.sh
+++ b/RestingStateStats/RestingStateStats.sh
@@ -455,7 +455,7 @@ mv_if_exists()
 	local to="${2}"
 
 	if [ -e "${from}" ] ; then
-		mv -v "${from}" "${to}"
+		mv "${from}" "${to}"
 	fi
 }
 
@@ -1044,9 +1044,9 @@ main()
 	esac
 
 	log_Msg "Moving results of Matlab function"
-	mv -v ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.txt ${ResultsFolder}
-	mv -v ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.dtseries.nii ${ResultsFolder}
-	mv -v ${RssFolder}/${g_fmri_name}_Atlas${RegString}_vn.dscalar.nii ${ResultsFolder}
+	mv ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.txt ${ResultsFolder}
+	mv ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.dtseries.nii ${ResultsFolder}
+	mv ${RssFolder}/${g_fmri_name}_Atlas${RegString}_vn.dscalar.nii ${ResultsFolder}
 
 	if [ -e ${ResultsFolder}/Names.txt ] ; then 
 		rm ${ResultsFolder}/Names.txt

--- a/RestingStateStats/RestingStateStats.sh
+++ b/RestingStateStats/RestingStateStats.sh
@@ -455,7 +455,7 @@ mv_if_exists()
 	local to="${2}"
 
 	if [ -e "${from}" ] ; then
-		mv --verbose "${from}" "${to}"
+		mv -v "${from}" "${to}"
 	fi
 }
 
@@ -1044,9 +1044,9 @@ main()
 	esac
 
 	log_Msg "Moving results of Matlab function"
-	mv --verbose ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.txt ${ResultsFolder}
-	mv --verbose ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.dtseries.nii ${ResultsFolder}
-	mv --verbose ${RssFolder}/${g_fmri_name}_Atlas${RegString}_vn.dscalar.nii ${ResultsFolder}
+	mv -v ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.txt ${ResultsFolder}
+	mv -v ${RssFolder}/${g_fmri_name}_Atlas${RegString}_${g_out_string}.dtseries.nii ${ResultsFolder}
+	mv -v ${RssFolder}/${g_fmri_name}_Atlas${RegString}_vn.dscalar.nii ${ResultsFolder}
 
 	if [ -e ${ResultsFolder}/Names.txt ] ; then 
 		rm ${ResultsFolder}/Names.txt

--- a/fMRIVolume/scripts/OneStepResampling.sh
+++ b/fMRIVolume/scripts/OneStepResampling.sh
@@ -143,16 +143,16 @@ ${FSLDIR}/bin/convertwarp --relout --rel --warp1=${fMRIToStructuralInput} --warp
 invwarp -w ${OutputTransform} -o ${OutputInvTransform} -r ${ScoutInputgdc}
 applywarp --rel --interp=nn -i ${FreeSurferBrainMask}.nii.gz -r ${ScoutInputgdc} -w ${OutputInvTransform} -o ${ScoutInputgdc}_mask.nii.gz
 if [ -e ${fMRIFolder}/Movement_RelativeRMS.txt ] ; then
-  /bin/rm -v ${fMRIFolder}/Movement_RelativeRMS.txt
+  /bin/rm ${fMRIFolder}/Movement_RelativeRMS.txt
 fi
 if [ -e ${fMRIFolder}/Movement_AbsoluteRMS.txt ] ; then
-  /bin/rm -v ${fMRIFolder}/Movement_AbsoluteRMS.txt
+  /bin/rm ${fMRIFolder}/Movement_AbsoluteRMS.txt
 fi
 if [ -e ${fMRIFolder}/Movement_RelativeRMS_mean.txt ] ; then
-  /bin/rm -v ${fMRIFolder}/Movement_RelativeRMS_mean.txt
+  /bin/rm ${fMRIFolder}/Movement_RelativeRMS_mean.txt
 fi
 if [ -e ${fMRIFolder}/Movement_AbsoluteRMS_mean.txt ] ; then
-  /bin/rm -v ${fMRIFolder}/Movement_AbsoluteRMS_mean.txt
+  /bin/rm ${fMRIFolder}/Movement_AbsoluteRMS_mean.txt
 fi
 ###Add stuff for RMS###
 


### PR DESCRIPTION
Related to an issue reported by a user on the HCP-Users mailing list

The MacOSX versions of the `cp`, `rm`, `mkdir`, and `mv` commands do not support the `--verbose` option. The outputs generated by the use of the `--verbose` option are still useful in debugging. So rather than completely remove the use of that option, I've replaced it with uses of the `-v` option which is supported by both the Linux versions of those commands (according to the man pages) and the MacOSX versions of those commands according to:

* https://ss64.com/osx/cp.html
* https://ss64.com/osx/rm.html
* https://ss64.com/osx/mkdir.html
* https://ss64.com/osx/mv.html

I do not have access to a Mac on which to run tests to verify that this works. So I'm relying on the documentation at the above links.