### PR TITLE
Make invocations of remove_ext consistent is using full path

### DIFF
--- a/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
+++ b/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
@@ -120,8 +120,8 @@ log_Msg "mri_watershed --version: ${mri_watershed_version}"
 
 # Start work
 
-T1wImageFile=`remove_ext $T1wImage`;
-T1wImageBrainFile=`remove_ext $T1wImageBrain`;
+T1wImageFile=$(${FSLDIR}/bin/remove_ext ${T1wImage})
+T1wImageBrainFile=$(${FSLDIR}/bin/remove_ext ${T1wImageBrain})
 
 PipelineScripts=${HCPPIPEDIR_FS}
 

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -605,7 +605,7 @@ main()
 		# ----------------------------------------------------------------------
 		log_Msg "Thresholding T1w image to eliminate negative voxel values"
 		# ----------------------------------------------------------------------
-		zero_threshold_T1wImage=$(remove_ext ${T1wImage})_zero_threshold.nii.gz
+		zero_threshold_T1wImage=$(${FSLDIR}/bin/remove_ext ${T1wImage})_zero_threshold.nii.gz
 		log_Msg "...This produces a new file named: ${zero_threshold_T1wImage}"
 
 		fslmaths ${T1wImage} -thr 0 ${zero_threshold_T1wImage}


### PR DESCRIPTION
A local (WashU) user has reported that calls to `remove_ext` in the scripts do not work as `remove_ext` is not found on the `PATH`.

There is an outstanding call to change the way FSL (and FreeSurfer too I suppose) tools are invoked in the scripts to rely on the `PATH` mechanism consistently. As of now, this is not the way it is done. Instead we rely on specifying full paths to commands like `${FSLDIR}/bin/fslmaths`. Until we decide to make a complete switch over to using the `PATH` for finding FSL, FreeSurfer, etc. commands, we should probably be consistent and use full paths. 

So I've converted the few places I see `remove_ext` being used relying on the `PATH` to using `${FSLDIR}/bin/remove_ext` instead.  