### PR TITLE
Corrected use of path for interpreted MATLAB usages

### DIFF
--- a/MSMAll/scripts/MSMAll.sh
+++ b/MSMAll/scripts/MSMAll.sh
@@ -847,11 +847,12 @@ M_PROG
 					1)
 						# Use interpreted MATLAB
 						mPath="${HCPPIPEDIR}/MSMAll/scripts"
-
+						mGlobalPath="${HCPPIPEDIR}/global/matlab"
+						
 						matlab -nojvm -nodisplay -nosplash <<M_PROG
-addpath '$mPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
+addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
 M_PROG
-						log_Msg "addpath '$mPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
+						log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 						;;
 
 					*)
@@ -1265,11 +1266,12 @@ M_PROG
 			1)
 				# Use interpreted MATLAB
 				mPath="${HCPPIPEDIR}/MSMAll/scripts"
-
+				mGlobalPath="${HCPPIPEDIR}/global/matlab"
+				
 				matlab -nojvm -nodisplay -nosplash <<M_PROG
-addpath '$mPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
+addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
 M_PROG
-				log_Msg "addpath '$mPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
+				log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 				;;
 
 			*)
@@ -1346,11 +1348,12 @@ M_PROG
 			1)
 				# Use interpreted MATLAB
 				mPath="${HCPPIPEDIR}/MSMAll/scripts"
+				mGlobalPath="${HCPPIPEDIR}/global/matlab"
 
 				matlab -nojvm -nodisplay -nosplash <<M_PROG
-addpath '$mPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
+addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
 M_PROG
-				log_Msg "addpath '$mPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
+				log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 				;;
 
 			*)

--- a/MSMAll/scripts/MSMAll.sh
+++ b/MSMAll/scripts/MSMAll.sh
@@ -750,10 +750,10 @@ main()
 						mPath="${HCPPIPEDIR}/MSMAll/scripts"
 						mGlobalPath="${HCPPIPEDIR}/global/matlab"
 
+						log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"						
 						matlab -nojvm -nodisplay -nosplash <<M_PROG
 addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
 M_PROG
-						log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 						;;
 
 					*)
@@ -849,10 +849,10 @@ M_PROG
 						mPath="${HCPPIPEDIR}/MSMAll/scripts"
 						mGlobalPath="${HCPPIPEDIR}/global/matlab"
 						
+						log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 						matlab -nojvm -nodisplay -nosplash <<M_PROG
 addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
 M_PROG
-						log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 						;;
 
 					*)
@@ -1350,10 +1350,10 @@ M_PROG
 				mPath="${HCPPIPEDIR}/MSMAll/scripts"
 				mGlobalPath="${HCPPIPEDIR}/global/matlab"
 
+				log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 				matlab -nojvm -nodisplay -nosplash <<M_PROG
 addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');
 M_PROG
-				log_Msg "addpath '$mPath'; addpath '$mGlobalPath'; MSMregression('${inputspatialmaps}','${inputdtseries}','${inputweights}','${outputspatialmaps}','${outputweights}','${Caret7_Command}','${Method}','${Params}','${VN}',${nTPsForSpectra},'${BC}','${VolParams}');"
 				;;
 
 			*)

--- a/MSMAll/scripts/SingleSubjectConcat.sh
+++ b/MSMAll/scripts/SingleSubjectConcat.sh
@@ -423,9 +423,10 @@ main()
 					1)
 						# Use interpreted MATLAB
 						mPath="${HCPPIPEDIR}/MSMAll/scripts"
+						mGlobalPath="${HCPPIPEDIR}/global/matlab"
 						
 						matlab -nojvm -nodisplay -nosplash <<M_PROG
-addpath '$mPath'; ComputeVN('${cleandtseries}','${bias}','${ICAtcs}','${ICANoise}','${OutputVN}','${Caret7_Command}');
+addpath '$mPath'; addpath '$mGlobalPath'; ComputeVN('${cleandtseries}','${bias}','${ICAtcs}','${ICANoise}','${OutputVN}','${Caret7_Command}');
 M_PROG
 						log_Msg "ComputeVN('${cleandtseries}','${bias}','${ICAtcs}','${ICANoise}','${OutputVN}','${Caret7_Command}');"
 						;;

--- a/MSMAll/scripts/SingleSubjectConcat.sh
+++ b/MSMAll/scripts/SingleSubjectConcat.sh
@@ -425,10 +425,10 @@ main()
 						mPath="${HCPPIPEDIR}/MSMAll/scripts"
 						mGlobalPath="${HCPPIPEDIR}/global/matlab"
 						
+						log_Msg "ComputeVN('${cleandtseries}','${bias}','${ICAtcs}','${ICANoise}','${OutputVN}','${Caret7_Command}');"
 						matlab -nojvm -nodisplay -nosplash <<M_PROG
 addpath '$mPath'; addpath '$mGlobalPath'; ComputeVN('${cleandtseries}','${bias}','${ICAtcs}','${ICANoise}','${OutputVN}','${Caret7_Command}');
 M_PROG
-						log_Msg "ComputeVN('${cleandtseries}','${bias}','${ICAtcs}','${ICANoise}','${OutputVN}','${Caret7_Command}');"
 						;;
 					
 					*)


### PR DESCRIPTION
Fixed problem with not properly setting up MATLAB path to include the `${HCPPIPEDIR}/global/matlab` directory when invoking interactive MATLAB.