### PR TITLE
Make dedrift and concat regname optional in DeDriftAndResample

### DIFF
--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -60,10 +60,9 @@ PARAMETERs are [ ] = optional; < > = user supplied value
        (e.g. 32@59)
    --registration-name=<regname> String corresponding to the MSMAll or other registration sphere name 
        (e.g. \${Subject}.\${Hemisphere}.sphere.\${RegName}.native.surf.gii)
-   --dedrift-reg-files=</Path/to/File/Left.sphere.surf.gii@/Path/to/File/Right.sphere.surf.gii> 
-       Path to the spheres output by the MSMRemoveGroupDrift pipeline or NONE
-   --concat-reg-name=<regname> String corresponding to the output name of the concatenated registration 
-       (i.e. the dedrifted registration)
+   [--dedrift-reg-files=</Path/to/File/Left.sphere.surf.gii@/Path/to/File/Right.sphere.surf.gii>]
+       Path to the spheres output by the MSMRemoveGroupDrift pipeline
+   [--concat-reg-name=<regname>] String corresponding to the output name of the dedrifted registration
    --maps=<non@myelin@maps> @-delimited map name strings corresponding to maps that are not myelin maps 
        (e.g. sulc@curvature@corrThickness@thickness)
    [--myelin-maps=<myelin@maps>] @-delimited map name strings corresponding to myelin maps 
@@ -107,7 +106,7 @@ get_options()
 	unset p_HighResMesh
 	unset p_LowResMeshes			# LowReshMeshes - @ delimited list, e.g. 32@59, multiple resolutions not currently supported for fMRI data
 	unset p_RegName
-	unset p_DeDriftRegFiles			# DeDriftRegFiles - @ delimited, L and R outputs from MSMRemoveGroupDrift.sh
+	p_DeDriftRegFiles=NONE			# DeDriftRegFiles - @ delimited, L and R outputs from MSMRemoveGroupDrift.sh
 	unset p_ConcatRegName
 	unset p_Maps					# @ delimited
 	p_MyelinMaps=NONE				# @ delimited
@@ -262,19 +261,12 @@ get_options()
 		log_Msg "Registration Name: ${p_RegName}"
 	fi
 	
-	if [ -z "${p_DeDriftRegFiles}" ]; then
-		log_Err "De-Drifting registration files (--dedrift-reg-files=) required"
-		error_count=$(( error_count + 1 ))
-	else
-		log_Msg "De-Drifting registration files: ${p_DeDriftRegFiles}"
-	fi
+	log_Msg "De-Drifting registration files: ${p_DeDriftRegFiles}"
 
 	if [ -z "${p_ConcatRegName}" ]; then
-		log_Err "concatenated registration name (--concat-reg-name=) required"
-		error_count=$(( error_count + 1 ))
-	else
-		log_Msg "concatenated registration name: ${p_ConcatRegName}"
+		p_ConcatRegName="${p_RegName}"
 	fi
+	log_Msg "concatenated registration name: ${p_ConcatRegName}"
 	
 	if [ -z "${p_Maps}" ]; then
 		log_Err "list of structural maps to be resampled (--maps=) required"

--- a/MSMAll/README.md
+++ b/MSMAll/README.md
@@ -1,6 +1,6 @@
 # HCP Pipelines MSMAll subdirectory
 
-MSMAll is a tool for surface-based functional alignment.  It uses T1w/T2w myelin maps, resting state network maps, and resting-state-based visuotopic maps to align a subject's cortical data to a group template.  One runs MSMAll after running either sICA+FIX (single run or multi-run).  One first runs the MSMAll Pipeline, then the DeDriftAndResample Pipeline.  Most users should not do any dedrifting as they should use an existing registration template; dedrifting is only intended to be used when generating a new registration template.
+MSMAll is a tool for surface-based functional alignment. It uses T1w/T2w myelin maps, resting state network maps, and resting-state-based visuotopic maps to align a subject's cortical data to a group template. MSMAll should be run on sICA+FIX cleaned data (single run or multi-run). First run the MSMAll Pipeline to generate the MSMAll registration, then the DeDriftAndResample Pipeline. DeDriftAndResample is generally used merely to resample the data according to the MSMAll registration, the "dedrift" part of the name only refers to an option (--dedrift-reg-files), which most users should not use, as the option's purpose is for generating a new registration template (atlas). For the uncommon case of generating a new registration template, the MSMRemoveGroupDrift script can calculate the group drift spheres.
 
 # Notes on MATLAB usage
 


### PR DESCRIPTION
This has not been tested.

DeDriftAndResample doesn't appear to actually detect NONE for the dedrift files option, instead it detects whether the regname and concatregname are the same.  I have therefore made both concateregname and dedrift files optional (if unset, concat regname gets set to regname).

This also makes additional edits to the msmall readme which @mharms and I discussed here:

https://github.com/Washington-University/HCPpipelines/commit/9f003a56b321608cd53a2474dd898b7a172ffe37#commitcomment-33644720