### PR TITLE
initial new script for RSN regression, new option parsing shlib, edits to template setup script to allow some reliance on PATH

### DIFF
--- a/Examples/Scripts/SetUpHCPPipeline.sh
+++ b/Examples/Scripts/SetUpHCPPipeline.sh
@@ -1,9 +1,9 @@
 #!/bin/echo This script should be sourced before calling a pipeline script, and should not be run directly:
 
 # Set up specific environment variables for the HCP Pipeline
-export HCPPIPEDIR=/home/somebody/Pipelines
-export MSMBINDIR=${HOME}/pipeline_tools/MSM
-export MSMCONFIGDIR=${HCPPIPEDIR}/MSMConfig
+export HCPPIPEDIR="${HOME}/HCPpipelines"
+export MSMBINDIR="${HOME}/pipeline_tools/MSM"
+export MSMCONFIGDIR="${HCPPIPEDIR}/MSMConfig"
 # export MATLAB_COMPILER_RUNTIME=/usr/local/MATLAB_Runtime/v901
 export MATLAB_COMPILER_RUNTIME=/export/matlab/MCR/R2016b/v91
 export FSL_FIXDIR=/usr/local/fix
@@ -32,7 +32,7 @@ then
             source "$FSLDIR/etc/fslconf/fsl.sh"
         fi
     else
-        echo "fslmaths not found in \$PATH, please install connectome workbench and ensure it is on \$PATH, or edit the setup script to specify its location" 1>&2
+        echo "fslmaths not found in \$PATH, please install FSL and ensure it is on \$PATH, or edit the setup script to specify its location" 1>&2
         exit 1
     fi
 fi

--- a/Examples/Scripts/SetUpHCPPipeline.sh
+++ b/Examples/Scripts/SetUpHCPPipeline.sh
@@ -1,11 +1,41 @@
-#!/bin/bash 
+#!/bin/echo This script should be sourced before calling a pipeline script, and should not be run directly:
 
-echo "This script must be SOURCED to correctly setup the environment prior to running any of the other HCP scripts contained here"
+# Set up specific environment variables for the HCP Pipeline
+export HCPPIPEDIR=/home/somebody/Pipelines
+export MSMBINDIR=${HOME}/pipeline_tools/MSM
+export MSMCONFIGDIR=${HCPPIPEDIR}/MSMConfig
+# export MATLAB_COMPILER_RUNTIME=/usr/local/MATLAB_Runtime/v901
+export MATLAB_COMPILER_RUNTIME=/export/matlab/MCR/R2016b/v91
+export FSL_FIXDIR=/usr/local/fix
+# if a suitable version of wb_command is on your $PATH, CARET7DIR can be blank
+export CARET7DIR=
 
 # Set up FSL (if not already done so in the running environment)
 # Uncomment the following 2 lines (remove the leading #) and correct the FSLDIR setting for your setup
-#export FSLDIR=/usr/share/fsl/5.0
-#source ${FSLDIR}/etc/fslconf/fsl.sh
+#export FSLDIR=/usr/local/fsl
+#source "$FSLDIR/etc/fslconf/fsl.sh"
+
+if [[ -z "${FSLDIR:-}" ]]
+then
+    found_fsl=$(which fslmaths || true)
+    if [[ ! -z "$found_fsl" ]]
+    then
+        #like our scripts, assume $FSLDIR/bin/fslmaths (neurodebian doesn't follow this, so sanity check)
+        #yes, quotes nest properly inside of $()
+        export FSLDIR=$(dirname "$(dirname "$found_fsl")")
+        #if we didn't have FSLDIR, assume we haven't sourced fslconf
+        if [[ ! -f "$FSLDIR/etc/fslconf/fsl.sh" ]]
+        then
+            echo "FSLDIR was unset, and guessed FSLDIR ($FSLDIR) does not contain etc/fslconf/fsl.sh, please specify FSLDIR in the setup script" 1>&2
+            exit 1
+        else
+            source "$FSLDIR/etc/fslconf/fsl.sh"
+        fi
+    else
+        echo "fslmaths not found in \$PATH, please install connectome workbench and ensure it is on \$PATH, or edit the setup script to specify its location" 1>&2
+        exit 1
+    fi
+fi
 
 # Let FreeSurfer know what version of FSL to use
 # FreeSurfer uses FSL_DIR instead of FSLDIR to determine the FSL version
@@ -16,32 +46,40 @@ export FSL_DIR="${FSLDIR}"
 #export FREESURFER_HOME=/usr/local/bin/freesurfer
 #source ${FREESURFER_HOME}/SetUpFreeSurfer.sh > /dev/null 2>&1
 
-# Set up specific environment variables for the HCP Pipeline
-export HCPPIPEDIR=/home/somebody/Pipelines
-export CARET7DIR=/usr/local/workbench
-export MSMBINDIR=${HOME}/pipeline_tools/MSM
-export MSMCONFIGDIR=${HCPPIPEDIR}/MSMConfig
-# export MATLAB_COMPILER_RUNTIME=/usr/local/MATLAB_Runtime/v901
-export MATLAB_COMPILER_RUNTIME=/export/matlab/MCR/R2016b/v91
-export FSL_FIXDIR=/usr/local/fix1.067
+#users probably won't need to edit anything below this line
 
-export HCPPIPEDIR_Templates=${HCPPIPEDIR}/global/templates
-export HCPPIPEDIR_Bin=${HCPPIPEDIR}/global/binaries
-export HCPPIPEDIR_Config=${HCPPIPEDIR}/global/config
+#sanity check things and/or populate from $PATH
+if [[ -z "$CARET7DIR" ]]
+then
+    found_wb=$(which wb_command || true)
+    if [[ ! -z "$found_wb" ]]
+    then
+        CARET7DIR=$(dirname "$found_wb")
+    else
+        echo "wb_command not found in \$PATH, please install connectome workbench and ensure it is on \$PATH, or edit the setup script to specify its location" 1>&2
+        exit 1
+    fi
+fi
+if [[ ! -x "$CARET7DIR/wb_command" ]]
+then
+    echo "CARET7DIR ($CARET7DIR) does not contain wb_command, please fix the settings in the setup script" 1>&2
+    exit 1
+fi
+#make sure FSLDIR is sane
+if [[ ! -x "$FSLDIR/bin/fslmaths" ]]
+then
+    echo "FSLDIR ($FSLDIR) does not contain bin/fslmaths, please fix the settings in the setup script" 1>&2
+    exit 1
+fi
+#add the specified versions of some things to the front of $PATH, so we can stop using absolute paths everywhere
+export PATH="$CARET7DIR:$FSLDIR/bin:$PATH"
 
-export HCPPIPEDIR_PreFS=${HCPPIPEDIR}/PreFreeSurfer/scripts
-export HCPPIPEDIR_FS=${HCPPIPEDIR}/FreeSurfer/scripts
-export HCPPIPEDIR_PostFS=${HCPPIPEDIR}/PostFreeSurfer/scripts
-export HCPPIPEDIR_fMRISurf=${HCPPIPEDIR}/fMRISurface/scripts
-export HCPPIPEDIR_fMRIVol=${HCPPIPEDIR}/fMRIVolume/scripts
-export HCPPIPEDIR_tfMRI=${HCPPIPEDIR}/tfMRI/scripts
-export HCPPIPEDIR_dMRI=${HCPPIPEDIR}/DiffusionPreprocessing/scripts
-export HCPPIPEDIR_dMRITract=${HCPPIPEDIR}/DiffusionTractography/scripts
-export HCPPIPEDIR_Global=${HCPPIPEDIR}/global/scripts
-export HCPPIPEDIR_tfMRIAnalysis=${HCPPIPEDIR}/TaskfMRIAnalysis/scripts
+#source extra stuff that pipelines authors may need to edit, but users shouldn't ever need to
+#by separating them this way, a user can continue to use their previous setup file even if we rearrange some internal things
+if [[ ! -f "$HCPPIPEDIR/global/scripts/finish_hcpsetup.shlib" ]]
+then
+    echo "HCPPIPEDIR ($HCPPIPEDIR) appears to be set to an old version of the pipelines, please check the setting (or start from the older SetUpHCPPipeline.sh to run the older pipelines)"
+    exit 1
+fi
+source "$HCPPIPEDIR/global/scripts/finish_hcpsetup.shlib"
 
-#try to reduce strangeness from locale and other environment settings
-export LC_ALL=C
-export LANGUAGE=C
-#POSIXLY_CORRECT currently gets set by many versions of fsl_sub, unfortunately, but at least don't pass it in if the user has it set in their usual environment
-unset POSIXLY_CORRECT

--- a/global/scripts/RSNregression.m
+++ b/global/scripts/RSNregression.m
@@ -1,8 +1,32 @@
 function RSNregression(InputFile, InputVNFile, GroupMaps, Method, ParamsFile, VAWeightsName, OutputBeta, varargin)
+    optional = myargparse(varargin, {'VolInputFile' 'VolInputVNFile' 'VolCiftiTemplate' 'OldBias' 'OldVolBias' 'GoodBCFile' 'VolGoodBCFile' 'SpectraParams' 'OutputZ' 'OutputVolBeta' 'OutputVolZ' 'SurfString' 'ScaleFactor' 'WRSmoothingSigma'});
+    
+    %InputFile - text file containing filenames of timeseries to concatenate
+    %InputVNFile - text file containing filenames of the variance maps of each input
+    %GroupMaps - file name of maps to use as a template
+    %Method - string, 'weighted' or 'dual'
+    %ParamsFile - text file containing parameters for the selected method - for weighted, it contains the filenames to low-dimensionality files to estimate the alignment quality with
+    %VAWeightsName - filename of spatial weights to use (usually vertex areas normalized to mean 1, and 1s in all voxels)
+    %OutputBeta - filename for output beta maps
+    %
+    %optional - specify like (..., 'WRSmoothingSigma', '5'):
+    %VolInputFile - like InputFile, but volume data (.nii.gz)
+    %VolInputVNFile - like InputVNFile, but volume data
+    %VolCiftiTemplate - cifti dscalar file with a spatial mapping that includes all voxels to consider in the volume data
+    %OldBias - for correcting old bias field method, give the old bias field name
+    %OldVolBias - same as OldBias, but volume data
+    %GoodBCFile - for correcting old bias field method, text file containing the new bias field for each input
+    %VolGoodBCFile - same as GoodBCFile, but volume data
+    %SpectraParams - string, <num>@<tsfile>@<spectrafile> - number of samples, and output filenames for spectra analysis
+    %OutputZ - filename for output of (approximate) Z stat maps
+    %OutputVolBeta - same as OutputBeta, but volume data
+    %OutputVolZ - same as OutputZ, but volume data
+    %SurfString - string, <leftsurf>@<rightsurf>, surfaces to use in weighted method for smoothing the alignment quality map
+    %ScaleFactor - string representation of a number, multiply the input data by this factor before processing (to convert grand mean 10,000 data to % bold, use 0.01)
+    %WRSmoothingSigma - string representation of a number, when using 'weighted' method, smooth the alignment quality map with this sigma (default 14, tuned for human data)
+    
     wbcommand = 'wb_command';
     ScaleFactor = 1;
-    
-    optional = myargparse(varargin, {'VolInputFile' 'VolInputVNFile' 'VolCiftiTemplate' 'OldBias' 'OldVolBias' 'GoodBCFile' 'VolGoodBCFile' 'SpectraParams' 'OutputZ' 'OutputVolBeta' 'OutputVolZ' 'SurfString' 'ScaleFactor' 'WRSmoothingSigma'});
     
     if ~strcmp(optional.ScaleFactor, '')
         ScaleFactor = str2double(optional.ScaleFactor);

--- a/global/scripts/RSNregression.m
+++ b/global/scripts/RSNregression.m
@@ -1,0 +1,296 @@
+function RSNregression(InputFile, InputVNFile, GroupMaps, Method, ParamsFile, VAWeightsName, OutputBeta, varargin)
+    wbcommand = 'wb_command';
+    ScaleFactor = 1;
+    
+    optional = myargparse(varargin, {'VolInputFile' 'VolInputVNFile' 'VolCiftiTemplate' 'OldBias' 'OldVolBias' 'GoodBCFile' 'VolGoodBCFile' 'SpectraParams' 'OutputZ' 'OutputVolBeta' 'OutputVolZ' 'SurfString' 'ScaleFactor' 'WRSmoothingSigma'});
+    
+    if ~strcmp(optional.ScaleFactor, '')
+        ScaleFactor = str2double(optional.ScaleFactor);
+    end
+    inputArray = myreadtext(InputFile);
+    inputVNArray = myreadtext(InputVNFile);
+    if size(inputArray, 1) ~= size(inputVNArray, 1)
+        error('InputVNFile has different number of lines than InputFile');
+    end
+    doFixBC = false;
+    if ~strcmp(optional.OldBias, '')
+        doFixBC = true;
+        goodBCArray = myreadtext(optional.GoodBCFile);
+        if size(goodBCArray, 1) ~= size(inputArray, 1)
+            error('GoodBCFile has different number of lines than InputFile');
+        end
+        oldBC = ciftiopen(optional.OldBias, wbcommand);
+    end
+
+    %tighten doVol detection to check if volume outputs are asked for?
+    doVol = false;
+    doVolFixBC = false;
+    if ~strcmp(optional.VolCiftiTemplate, '')
+        doVol = true;
+        outVolTemplate = ciftiopen(optional.VolCiftiTemplate, wbcommand);
+        clear outVolTemplate.cdata;
+        if ~strcmp(optional.VolInputFile, '')
+            volinputArray = myreadtext(optional.VolInputFile);
+            volinputVNArray = myreadtext(optional.VolInputVNFile);
+            if size(volinputArray, 1) ~= size(inputArray, 1)
+                error('VolInputFile is not empty, but has different number of lines than InputFile');
+            end
+            if size(volinputArray, 1) ~= size(volinputVNArray, 1)
+                error('VolInputVNFile has different number of lines than VolInputFile');
+            end
+            if ~strcmp(optional.OldVolBias, '')
+                doVolFixBC = true;
+                volGoodBCArray = myreadtext(optional.VolGoodBCFile);
+                if size(volGoodBCArray, 1) ~= size(inputArray, 1)
+                    error('VolGoodBCFile is not empty, different number of lines than InputFile');
+                end
+                %use /tmp to convert volume files to voxel cifti
+                oldVolBC = open_vol_as_cifti(optional.OldVolBias, optional.VolCiftiTemplate, wbcommand);
+            end
+        end
+    end
+    
+    %input parsing done, sanity checks go here
+    if doVol && doFixBC ~= doVolFixBC
+        if (doFixBC)
+            warning('volume data is being processed, but old bias fixing mode was only requested for the cifti data');
+        else
+            warning('volume data is being processed, but old bias fixing mode was only requested for the volume data');
+        end
+    end
+    
+    %provide complete filenames in input lists
+    for i = 1:size(inputArray, 1)
+        tempcii = ciftiopen([inputArray{i}], wbcommand);
+        tempvncii = ciftiopen([inputVNArray{i}], wbcommand);
+        % can't use good BC to do the mean of VN properly, because it may not exist
+        tempvncii.cdata = max(tempvncii.cdata / mean(tempvncii.cdata), 0.001);
+        %VN file is really just variance of BC data - to restore to close to original variance, turn the variance back into non-bc space and take the mean
+        tempnorm = ScaleFactor * demean(tempcii.cdata, 2) ./ repmat(tempvncii.cdata, 1, size(tempcii.cdata, 2));
+        clear tempcii.cdata;
+        % for output, make the vn data reference new BC space
+        if doFixBC
+            tempBCcifti = ciftiopen(goodBCArray{i}, wbcommand);
+            tempvncii.cdata = tempvncii.cdata .* oldBC.cdata ./ tempBCcifti.cdata;
+        end
+        if i == 1
+            outTemplate = tempcii;
+            inputConcat = tempnorm;
+            vnsum = tempvncii.cdata;
+        else
+            inputConcat = [inputConcat tempnorm]; %#ok<AGROW>
+            vnsum = vnsum + tempvncii.cdata; % should this use weighted and/or geometric mean?  are there zeros?
+        end
+        clear tempcii tempnorm tempvncii tempBCcifti;
+        if doVol
+            tempvolcii = open_vol_as_cifti(volinputArray{i}, optional.VolCiftiTemplate, wbcommand);
+            tempvolvncii = open_vol_as_cifti(volinputVNArray{i}, optional.VolCiftiTemplate, wbcommand);
+            tempvolmask = std(tempvolcii.cdata, [], 2) ~= 0;
+            tempvolvncii.cdata = max(tempvolvncii.cdata / mean(tempvolvncii.cdata(tempvolmask)), 0.001);
+            tempvolnorm = ScaleFactor * demean(tempvolcii.cdata, 2) ./ repmat(tempvolvncii.cdata, 1, size(tempvolcii.cdata, 2));
+            clear tempvolcii;
+            if doVolFixBC
+                tempvolBCcifti = open_vol_as_cifti(volGoodBCArray{i}, optional.VolCiftiTemplate, wbcommand);
+                tempvolvncii.cdata = tempvolvncii.cdata .* oldVolBC.cdata ./ tempvolBCcifti.cdata;
+            end
+            if i == 1
+                volInputConcat = tempvolnorm;
+                vnvolsum = tempvolvncii.cdata;
+            else
+                volInputConcat = [volInputConcat tempvolnorm]; %#ok<AGROW>
+                vnvolsum = vnvolsum + tempvolvncii.cdata;
+            end
+            clear tempvolnorm tempvolvncii tempvolBCcifti;
+        end
+    end
+    
+    vnmean = vnsum / size(inputArray, 1);
+    clear vnsum;
+    if doVol
+        vnvolmean = vnvolsum / size(inputArray, 1);
+        clear vnvolsum;
+    end
+    
+    GroupMapcii = ciftiopen(GroupMaps, wbcommand);
+    weightscii = ciftiopen(VAWeightsName, wbcommand); %normalized vertex areas, voxels are all 1s
+    AreaWeights = weightscii.cdata;
+    switch Method
+        case 'weighted'
+            if strcmp(optional.WRSmoothingSigma, '')
+                error '"weighted" method requires WRSmoothingSigma to be specified'
+            end
+            WRSmoothingSigma = str2double(optional.WRSmoothingSigma);
+            paramsArray = myreadtext(ParamsFile);
+            if length(paramsArray) <= 1
+                error('"weighted" method needs more parameters, use method "dual" to do only vertex area weighted regression');
+            end
+            surfArray = textscan(optional.SurfString, '%s', 'Delimiter', {'@'}); %left right
+            surfArray = surfArray{1};
+            for i = 1:length(paramsArray)
+                LowDim = paramsArray{i};
+                LowDim = ciftiopen(LowDim, wbcommand);
+                betaICAone = weightedDualRegression(LowDim.cdata, inputConcat, AreaWeights);
+                betaICA = weightedDualRegression(betaICAone, inputConcat, AreaWeights);
+                for j = 1:length(betaICA)
+                    var(j) = atanh(corr(betaICA(j, :)', LowDim.cdata(j, :)')); %#ok<AGROW>
+                end
+                corrs(:, i) = var'; %#ok<AGROW>
+            end
+            outTemplate.cdata = mean(corrs, 2);
+            mytempfile = [tempname() '_tosmooth.dscalar.nii'];
+            ciftisavereset(outTemplate, mytempfile, wbcommand);
+            my_system([wbcommand ' -cifti-smoothing ' mytempfile ' ' num2str(WRSmoothingSigma) ' ' num2str(WRSmoothingSigma) ' COLUMN ' mytempfile ' -left-surface ' surfArray{1} ' -right-surface ' surfArray{2}]);
+            AlignmentQualitySmoothcii = ciftiopen(mytempfile, wbcommand);
+            delete(mytempfile);
+            MEAN = mean(outTemplate.cdata);
+            AlignmentQuality = repmat(MEAN, length(outTemplate.cdata), 1) + outTemplate.cdata - AlignmentQualitySmoothcii.cdata;
+            ScaledAlignmentQuality = (AlignmentQuality .* (AlignmentQuality > 0)) .^ 3;
+            
+            betaICAone = weightedDualRegression(GroupMapcii.cdata, inputConcat, AreaWeights .* ScaledAlignmentQuality);
+            [betaICA, NODEts] = weightedDualRegression(normalise(betaICAone), inputConcat, AreaWeights);
+        case 'dual'
+            [betaICA, NODEts] = weightedDualRegression(GroupMapcii.cdata, inputConcat, AreaWeights);
+        otherwise
+            error(['unrecognized method: "' Method '", use "weighted" or "dual"']);
+    end
+    
+    NODEtsnorm = normalise(NODEts);
+    
+    %outputs
+    %Save Timeseries and Spectra if Desired
+    if ~strcmp(optional.SpectraParams, '')
+        SpectraArray = textscan(optional.SpectraParams, '%s', 'Delimiter', {'@'});
+        nTPsForSpectra = str2double(SpectraArray{1}{1});
+        OutputSpectraTS = SpectraArray{1}{2};
+        OutputSpectraFile = SpectraArray{1}{3};
+        if nTPsForSpectra > 0 && ~strcmp(OutputSpectraTS, '') && ~strcmp(OutputSpectraFile, '')
+           ts.Nnodes = size(NODEts, 2);
+           ts.Nsubjects = size(NODEts, 1) ./ nTPsForSpectra;
+           ts.ts = NODEts;
+           ts.NtimepointsPerSubject = nTPsForSpectra;
+           [ts_spectra] = nets_spectra(ts);
+           dlmwrite(OutputSpectraTS, NODEts, 'delimiter', '\t');
+           dlmwrite(OutputSpectraFile, ts_spectra, 'delimiter', '\t');
+        end
+    end
+    %make sure we don't use the non-normalized timeseries anywhere else
+    clear NODEts;
+    if ~strcmp(OutputBeta, '')
+        %multiply by average vn to get back to BC data
+        outTemplate.cdata = betaICA .* repmat(vnmean, 1, size(betaICA, 2));
+        ciftisavereset(outTemplate, OutputBeta, wbcommand);
+    end
+    %Normalize to input maps - optional, for msmall only (move to msmall script)
+    %if ~strcmp(OutputNorm, '')
+    %    TODO: isolate only the surface data ("Distortion" input is now 91k)
+    %    GMmean = mean(GMorig(1:length(Distortion.cdata), :));
+    %    GMstd = std(GMorig(1:length(Distortion.cdata), :));
+    %    betaICAmean = mean(betaICA(1:length(Distortion.cdata), :));
+    %    betaICAstd = std(betaICA(1:length(Distortion.cdata), :));
+    %    OUTBO.cdata = ((((betaICA - repmat(betaICAmean, length(betaICA), 1)) ./ repmat(betaICAstd, length(betaICA), 1)) .* repmat(GMstd, length(betaICA), 1)) + repmat(GMmean, length(betaICA), 1));
+    %    ciftisavereset(OUTBO, OutputNorm, wbcommand);
+    %end
+    %Z stat
+    if ~strcmp(optional.OutputZ, '')
+        %Convert to Z stat image
+        dof = size(NODEtsnorm, 1) - size(NODEtsnorm, 2) - 1;
+        residuals = demean(inputConcat, 2) - betaICA * NODEtsnorm';
+        pN = pinv(NODEtsnorm); dpN = diag(pN * pN')';
+        t = double(betaICA ./ sqrt(sum(residuals .^ 2, 2) * dpN / dof));
+        Z = zeros(size(t));
+        Z(t > 0) = min(-norminv(tcdf(-t(t > 0), dof)), 38.5);
+        Z(t < 0) = max(norminv(tcdf(t(t < 0), dof)), -38.5);
+        Z(isnan(Z)) = 0;
+        outTemplate.cdata = Z;
+        ciftisavereset(outTemplate, optional.OutputZ, wbcommand);
+    end
+    
+    %volume outputs
+    if doVol
+        VolbetaICA = ((pinv(NODEtsnorm) * demean(volInputConcat')))';
+        if ~strcmp(optional.OutputVolBeta, '')
+            %multiply by vn to get back to BC
+            outVolTemplate.cdata = VolbetaICA .* repmat(vnvolmean, 1, size(VolbetaICA, 2));
+            ciftisavereset(outVolTemplate, optional.OutputVolBeta, wbcommand);
+        end
+        if ~strcmp(optional.OutputVolZ, '')
+            dof = size(NODEtsnorm, 1) - size(NODEtsnorm, 2) - 1;
+            residuals = demean(volInputConcat, 2) - VolbetaICA * NODEtsnorm';
+            t = double(VolbetaICA ./ sqrt(sum(residuals .^ 2, 2) * dpN / dof));
+            Z = zeros(size(t));
+            Z(t > 0) = min(-norminv(tcdf(-t(t > 0), dof)), 38.5);
+            Z(t < 0) = max(norminv(tcdf(t(t < 0), dof)), -38.5);
+            Z(isnan(Z)) = 0;
+            outVolTemplate.cdata = Z;
+            ciftisavereset(outVolTemplate, optional.OutputVolZ, wbcommand);
+        end
+    end
+end
+
+function outstruct = myargparse(myvarargs, allowed)
+    for i = 1:length(allowed)
+        outstruct.(allowed{i}) = '';
+    end
+    for i = 1:2:length(myvarargs)
+        if isfield(outstruct, myvarargs{i})
+            outstruct.(myvarargs{i}) = myvarargs{i + 1};
+        else
+            error(['unknown optional parameter specified: "' myvarargs{i} '"']);
+        end
+    end
+end
+
+function lines = myreadtext(filename)
+    fid = fopen(filename);
+    if fid < 0
+        error(['unable to open file ' filename]);
+    end
+    array = textscan(fid, '%s', 'Delimiter', {'\n'});
+    fclose(fid);
+    lines = array{1};
+end
+
+function [betaMaps, mapTimeseries] = weightedDualRegression(SpatialMaps, Timeseries, Weights)
+    DesignWeights = repmat(sqrt(Weights), 1, size(SpatialMaps, 2));
+    DenseWeights = repmat(sqrt(Weights), 1, size(Timeseries, 2));
+    mapTimeseries = demean((pinv(demean(SpatialMaps .* DesignWeights)) * (demean(Timeseries .* DenseWeights)))');
+    betaMaps = ((pinv(normalise(mapTimeseries)) * demean(Timeseries')))';
+end
+
+function outstruct = open_vol_as_cifti(volName, ciftiTemplate, wbcommand)
+    tempbase = tempname();
+    %don't leave a temporary file around on error/interrupt
+    function cleanupFunc(tempbase)
+        system(['rm -f -- "' tempbase '.dscalar.nii"']);
+    end
+    guardObj = onCleanup(@() cleanupFunc(tempbase));
+    my_system([wbcommand ' -cifti-create-dense-from-template "' ciftiTemplate '" "' tempbase '.dscalar.nii" -volume-all ' volName]);
+    outstruct = ciftiopen([tempbase '.dscalar.nii'], wbcommand);
+end
+
+%like call_fsl, but without sourcing fslconf
+function my_system(command)
+    if ismac()
+        ldsave = getenv('DYLD_LIBRARY_PATH');
+    else
+        ldsave = getenv('LD_LIBRARY_PATH');
+    end
+    %restore it even if we are interrupted
+    function cleanupFunc(ldsave)
+        if ismac()
+            setenv('DYLD_LIBRARY_PATH', ldsave);
+        else
+            setenv('LD_LIBRARY_PATH', ldsave);
+        end
+    end
+    guardObj = onCleanup(@() cleanupFunc(ldsave));
+    if ismac()
+        setenv('DYLD_LIBRARY_PATH');
+    else
+        setenv('LD_LIBRARY_PATH');
+    end
+    if system(command) ~= 0
+        error(['command failed: ' command]);
+    end
+end
+

--- a/global/scripts/RSNregression.sh
+++ b/global/scripts/RSNregression.sh
@@ -29,8 +29,6 @@ function main()
     opts_AddMandatory '--group-maps' 'GroupMaps' 'file' "the group template maps to regress"
     opts_AddMandatory '--subject-timeseries' 'InputList' 'fmri@fmri@fmri...' "the timeseries fmri names to concatenate"
     #matlab arguments should be complete filenames
-    #old script hardcoded naming conventions for hidden inputs (surfaces, vertex areas)
-    #Matt says it should be runnable by itself, so parameters and hidden inputs
     opts_AddOptional '--surf-reg-name' 'RegName' 'name' "the registration string corresponding to the input files"
     opts_AddMandatory '--low-res' 'LowResMesh' 'meshnum' "mesh resolution, like '32' for 32k_fs_LR"
     opts_AddMandatory '--proc-string' 'ProcString' 'string' "part of filename describing processing, like FIXME: EXAMPLE"
@@ -39,21 +37,13 @@ function main()
     opts_AddOptional '--low-ica-dims' 'LowICADims' 'num@num@num...' "when using --method=weighted, the low ICA dimensionality files to use for determining weighting"
     opts_AddOptional '--low-ica-template-name' 'ICATemplateName' 'filename' "filename template where 'REPLACEDIM' will be replaced by each of the --low-ica-dims values in turn to form the low-dim inputs"
     #outputs
-    #opts_AddMandatory '--output-beta' 'OutputBeta' 'filename' "what name to use for the output beta maps"
     opts_AddMandatory '--output-string' 'OutString' 'name' "filename part to describe the outputs, like FIXME: EXAMPLE_d127"
     opts_AddOptional '--output-spectra' 'nTPsForSpectra' 'number' "FIXME: what does this do?" '0'
     opts_AddOptional '--volume-template-cifti' 'VolCiftiTemplate' 'file' "to generate voxel-based outputs, provide a cifti file setting the voxels to use"
     opts_AddOptional '--output-z' 'DoZString' 'YES or NO' "also create Z maps from the regression" 'NO'
     #opts_AddOptional '--output-norm' 'DoNorm' '1 or 0' "also create maps normalized to match the group maps" '0'
-    #opts_AddOptional '--output-beta-vol' 'OutputVolBeta' 'filename' "what name to use for the output beta maps"
-    #opts_AddOptional '--output-z-vol' 'OutputVolZ' 'filename' "also create Z maps from the regression"
-    #opts_AddOptional '--output-norm-vol' 'OutputVolNorm' 'filename' "also create maps normalized to match the group maps"
     #old bias field
     opts_AddOptional '--fix-legacy-bias' 'DoFixBiasString' 'YES or NO' "use YES if you are using HCP YA data (because it used an older bias field computation)" 'NO'
-    #opts_AddOptional '--old-bias' 'OldBias' 'file' "for fixing data using older bias fields, specify the data's bias field here"
-    #opts_AddOptional '--new-bias-list' 'NewBiasList' 'file@file@file...' "when using --old-bias, specify each run's new bias field file here"
-    #opts_AddOptional '--old-vol-bias' 'OldVolBias' 'file' "for fixing volume data with older bias fields, specify the data's bias field here"
-    #opts_AddOptional '--new-vol-bias-list' 'NewVolBiasList' 'file@file@file...' "when using --old-vol-bias, specify each run's new bias field file here"
     opts_AddOptional '--scale-factor' 'ScaleFactor' 'number' "multiply the input timeseries by some factor before processing"
     #FIXME: compiled matlab
     opts_AddOptional '--matlab-run-mode' 'MatlabMode' '0, 1, or 2' "defaults to $g_matlab_default_mode
@@ -122,8 +112,6 @@ function main()
         if ((DoFixBias))
         then
             echo "$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}_real_bias.dscalar.nii" >> "$tempname.goodbias.txt"
-        #else
-        #    echo "$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}_sebased_bias.dscalar.nii" >> "$tempname.goodbias.txt"
         fi
         if ((DoVol))
         then
@@ -132,8 +120,6 @@ function main()
             if ((DoFixBias))
             then
                 echo "$MNIFolder/Results/$fmri/${fmri}_real_bias.nii.gz" >> "$tempname.volgoodbias.txt"
-            #else
-            #    echo "$MNIFolder/Results/$fmri/${fmri}_sebased_bias.nii.gz" >> "$tempname.volgoodbias.txt"
             fi
         fi
     done

--- a/global/scripts/RSNregression.sh
+++ b/global/scripts/RSNregression.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+set -eu
+
+source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
+
+#FIXME: no compiled matlab support
+g_matlab_default_mode=1
+
+#this function gets called by opts_ParseArguments when --help is specified
+function usage()
+{
+    #header text
+    echo "
+$log_ToolName: does stuff
+
+Usage: $log_ToolName PARAMETER...
+
+PARAMETERs are [ ] = optional; < > = user supplied value
+"
+    #automatic argument descriptions
+    opts_ShowArguments
+}
+
+function main()
+{
+    #arguments to opts_Add*: switch, variable to set, name for inside of <> in help text, description, [default value other than empty string if AddOptional], [compatibility flag, ...]
+    opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder containing all subjects"
+    opts_AddMandatory '--subject' 'Subject' 'subject ID' ""
+    opts_AddMandatory '--group-maps' 'GroupMaps' 'file' "the group template maps to regress"
+    opts_AddMandatory '--subject-timeseries' 'InputList' 'fmri@fmri@fmri...' "the timeseries fmri names to concatenate"
+    #matlab arguments should be complete filenames
+    #old script hardcoded naming conventions for hidden inputs (surfaces, vertex areas)
+    #Matt says it should be runnable by itself, so parameters and hidden inputs
+    opts_AddOptional '--surf-reg-name' 'RegName' 'name' "the registration string corresponding to the input files"
+    opts_AddMandatory '--low-res' 'LowResMesh' 'meshnum' "mesh resolution, like '32' for 32k_fs_LR"
+    opts_AddMandatory '--proc-string' 'ProcString' 'string' "part of filename describing processing, like FIXME: EXAMPLE"
+    opts_AddMandatory '--method' 'Method' 'regression method' "'weighted' or 'dual' - weighted regression finds locations in the subject that don't match the template well and downweights them; dual is simpler, both methods use vertex area information"
+    opts_AddOptional '--weighted-smoothing-sigma' 'WRSmoothingSigma' 'number' "default 14 for human data - when using --method=weighted, the smoothing sigma, in mm, to apply to the 'alignment quality' weighting map" '14'
+    opts_AddOptional '--low-ica-dims' 'LowICADims' 'num@num@num...' "when using --method=weighted, the low ICA dimensionality files to use for determining weighting"
+    opts_AddOptional '--low-ica-template-name' 'ICATemplateName' 'filename' "filename template where 'REPLACEDIM' will be replaced by each of the --low-ica-dims values in turn to form the low-dim inputs"
+    #outputs
+    #opts_AddMandatory '--output-beta' 'OutputBeta' 'filename' "what name to use for the output beta maps"
+    opts_AddMandatory '--output-string' 'OutString' 'name' "filename part to describe the outputs, like FIXME: EXAMPLE_d127"
+    opts_AddOptional '--output-spectra' 'nTPsForSpectra' 'number' "FIXME: what does this do?" '0'
+    opts_AddOptional '--volume-template-cifti' 'VolCiftiTemplate' 'file' "to generate voxel-based outputs, provide a cifti file setting the voxels to use"
+    opts_AddOptional '--output-z' 'DoZString' 'YES or NO' "also create Z maps from the regression" 'NO'
+    #opts_AddOptional '--output-norm' 'DoNorm' '1 or 0' "also create maps normalized to match the group maps" '0'
+    #opts_AddOptional '--output-beta-vol' 'OutputVolBeta' 'filename' "what name to use for the output beta maps"
+    #opts_AddOptional '--output-z-vol' 'OutputVolZ' 'filename' "also create Z maps from the regression"
+    #opts_AddOptional '--output-norm-vol' 'OutputVolNorm' 'filename' "also create maps normalized to match the group maps"
+    #old bias field
+    opts_AddOptional '--fix-legacy-bias' 'DoFixBiasString' 'YES or NO' "use YES if you are using HCP YA data (because it used an older bias field computation)" 'NO'
+    #opts_AddOptional '--old-bias' 'OldBias' 'file' "for fixing data using older bias fields, specify the data's bias field here"
+    #opts_AddOptional '--new-bias-list' 'NewBiasList' 'file@file@file...' "when using --old-bias, specify each run's new bias field file here"
+    #opts_AddOptional '--old-vol-bias' 'OldVolBias' 'file' "for fixing volume data with older bias fields, specify the data's bias field here"
+    #opts_AddOptional '--new-vol-bias-list' 'NewVolBiasList' 'file@file@file...' "when using --old-vol-bias, specify each run's new bias field file here"
+    opts_AddOptional '--scale-factor' 'ScaleFactor' 'number' "multiply the input timeseries by some factor before processing"
+    #FIXME: compiled matlab
+    opts_AddOptional '--matlab-run-mode' 'MatlabMode' '0, 1, or 2' "defaults to $g_matlab_default_mode
+0 = compiled MATLAB (not implemented)
+1 = interpreted MATLAB
+2 = Octave" "$g_matlab_default_mode"
+    opts_ParseArguments "$@"
+    
+    #display the parsed/default values
+    opts_ShowValues
+    
+    #sanity check boolean strings and convert to 1 and 0
+    DoZ=$(opts_StringToBool "$DoZString")
+    DoFixBias=$(opts_StringToBool "$DoFixBiasString")
+
+	if [[ -L "$0" ]]
+	then
+		this_script_dir=$(dirname "$(readlink "$0")")
+	else
+		this_script_dir=$(dirname "$0")
+	fi
+    case "$MatlabMode" in
+        (0)
+            log_Err_Abort "FIXME: compiled matlab support not yet implemented"
+            ;;
+        (1)
+            #NOTE: figure() is required by the spectra option, and -nojvm prevents using figure()
+            matlab_interpreter=(matlab -nodisplay -nosplash)
+            ;;
+        (2)
+            matlab_interpreter=(octave-cli -q --no-window-system)
+            ;;
+        (*)
+            log_Err_Abort "unrecognized matlab mode '$MatlabMode', use 0, 1, or 2"
+            ;;
+    esac
+    matlab_paths="addpath('$FSLDIR/etc/matlab'); addpath('$HCPPIPEDIR/global/matlab'); addpath('$this_script_dir');
+"
+    
+    RegString=""
+    if [[ "$RegName" != "" ]]
+    then
+        RegString="_$RegName"
+    fi
+    
+    DoVol=0
+    if [[ "$VolCiftiTemplate" != "" ]]
+    then
+        DoVol=1
+    fi
+    
+    MNIFolder="$StudyFolder/$Subject/MNINonLinear"
+    T1wFolder="$StudyFolder/$Subject/T1w"
+    DownSampleMNIFolder="$MNIFolder/fsaverage_LR${LowResMesh}k"
+    DownSampleT1wFolder="$T1wFolder/fsaverage_LR${LowResMesh}k"
+    
+    tempname=$(mktemp --tmpdir rsn_regr_matlab_XXXXXX)
+    addtemp "$tempname" "$tempname.input.txt" "$tempname.inputvn.txt" "$tempname.volinput.txt" "$tempname.volinputvn.txt" "$tempname.params.txt" "$tempname.goodbias.txt" "$tempname.volgoodbias.txt" "$tempname.mapnames.txt"
+    IFS='@' read -a InputArray <<< "$InputList"
+    #use newline-delimited text files for matlab
+    #matlab chokes on more than 4096 characters in an input line, so use text files for safety
+    for fmri in "${InputArray[@]}"
+    do
+        echo "$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}${ProcString}.dtseries.nii" >> "$tempname.input.txt"
+        echo "$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}${ProcString}_vn.dscalar.nii" >> "$tempname.inputvn.txt"
+        if ((DoFixBias))
+        then
+            echo "$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}_real_bias.dscalar.nii" >> "$tempname.goodbias.txt"
+        #else
+        #    echo "$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}_sebased_bias.dscalar.nii" >> "$tempname.goodbias.txt"
+        fi
+        if ((DoVol))
+        then
+            echo "$MNIFolder/Results/$fmri/${fmri}${ProcString}.nii.gz" >> "$tempname.volinput.txt"
+            echo "$MNIFolder/Results/$fmri/${fmri}${ProcString}_vn.nii.gz" >> "$tempname.volinputvn.txt"
+            if ((DoFixBias))
+            then
+                echo "$MNIFolder/Results/$fmri/${fmri}_real_bias.nii.gz" >> "$tempname.volgoodbias.txt"
+            #else
+            #    echo "$MNIFolder/Results/$fmri/${fmri}_sebased_bias.nii.gz" >> "$tempname.volgoodbias.txt"
+            fi
+        fi
+    done
+    #only used if DoFixBias
+    OldBias="$MNIFolder/Results/$fmri/${fmri}_Atlas${RegString}_bias.dscalar.nii"
+    OldVolBias="$MNIFolder/Results/$fmri/${fmri}_bias.nii.gz"
+    #spectra output files want the correct TR, so save the first input filename
+    SpectraTRFile="$MNIFolder/Results/${InputArray[0]}/${InputArray[0]}_Atlas${RegString}${ProcString}.dtseries.nii"
+    
+    #matlab can't take strings containing newlines, so it is left@right
+    SurfString="$DownSampleT1wFolder/${Subject}.L.midthickness${RegString}.${LowResMesh}k_fs_LR.surf.gii@$DownSampleT1wFolder/${Subject}.R.midthickness${RegString}.${LowResMesh}k_fs_LR.surf.gii"
+    VANormOnlySurf="$DownSampleT1wFolder/${Subject}.midthickness${RegString}_va_norm.${LowResMesh}k_fs_LR.dscalar.nii"
+    
+    case "$Method" in
+        (weighted)
+            MethodStr="WR"
+            if [[ "$LowICADims" == "" || "$ICATemplateName" == "" ]]
+            then
+                log_Err_Abort "When using 'weighted' method, you must use --low-ica-dims and --low-ica-template-name"
+            fi
+            IFS='@' read -a LowDimArray <<< "$LowICADims"
+            for dim in "${LowDimArray[@]}"
+            do
+                #yes, quotes can nest when there is a $() separating them
+                echo "$ICATemplateName" | sed "s/REPLACEDIM/$dim/g" >> "$tempname.params.txt"
+            done
+            ;;
+        (dual)
+            MethodStr="DR"
+            ;;
+        (*)
+            log_Err_Abort "unknown method string: '$Method'"
+            ;;
+    esac
+    
+    OutBeta="$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}.${LowResMesh}k_fs_LR.dscalar.nii"
+    OutputVolBeta=""
+    if ((DoVol))
+    then
+        #no reason for it to have the mesh on the name, but that is what the old script said...
+        OutputVolBeta="$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_vol.${LowResMesh}k_fs_LR.dscalar.nii"
+    fi
+    OutputZ=""
+    OutputVolZ=""
+    if ((DoZ))
+    then
+        OutputZ="$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}Z${RegString}.${LowResMesh}k_fs_LR.dscalar.nii"
+        if ((DoVol))
+        then
+            OutputVolZ="$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}Z${RegString}_vol.${LowResMesh}k_fs_LR.dscalar.nii"
+        fi
+    fi
+    SpectraParams=""
+    if ((nTPsForSpectra > 0))
+    then
+        #these files are temporary anyway
+        SpectraParams="$nTPsForSpectra@$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_ts.${LowResMesh}k_fs_LR.txt@$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_spectra.${LowResMesh}k_fs_LR.txt"
+    fi
+    #the msmall script should do this for itself instead
+    #OutputNorm=""
+    #if ((DoNorm))
+    #then
+    #    OutputNorm="$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}N${RegString}.${LowResMesh}k_fs_LR.dscalar.nii"
+        #probably can't trust the volume outputs to be the same scaling as the surface outputs, and we don't need this except for MSMAll anyway
+    #fi
+    
+    #fix the _va_norm file being surface-only
+    #extract the all-voxels ROI file and use it in -from-template
+    tempfile="$(mktemp --tmpdir XXXXXX.roi.nii.gz)"
+    addtemp "$tempfile" "$tempfile.junk.nii.gz" "$tempfile.91k.dscalar.nii"
+    wb_command -cifti-separate "$GroupMaps" COLUMN -volume-all "$tempfile.junk.nii.gz" -roi "$tempfile" -crop
+    wb_command -cifti-create-dense-from-template "$GroupMaps" "$tempfile.91k.dscalar.nii" -cifti "$VANormOnlySurf" -volume-all "$tempfile" -from-cropped
+    
+    case "$MatlabMode" in
+        (0)
+            log_Err_Abort "FIXME: compiled matlab support not yet implemented"
+            ;;
+        (1 | 2)
+            #SurfString and WRSmoothingSigma are optional to the matlab function (needed only for weighted), but we will always have it, so always providing it is simpler here
+            matlab_args="'$tempname.input.txt', '$tempname.inputvn.txt', '$GroupMaps', '$Method', '$tempname.params.txt', '$tempfile.91k.dscalar.nii', '$OutBeta', 'SurfString', '$SurfString', 'WRSmoothingSigma', '$WRSmoothingSigma'"
+            if ((DoZ))
+            then
+                matlab_args+=", 'OutputZ', '$OutputZ'"
+            fi
+            if [[ "$SpectraParams" != "" ]]
+            then
+                matlab_args+=", 'SpectraParams', '$SpectraParams'"
+            fi
+            if ((DoFixBias))
+            then
+                matlab_args+=", 'GoodBCFile', '$tempname.goodbias.txt', 'OldBias', '$OldBias'"
+            fi
+            if [[ "$ScaleFactor" != "" ]]
+            then
+                matlab_args+=", 'ScaleFactor', '$ScaleFactor'"
+            fi
+            if ((DoVol))
+            then
+                matlab_args+=", 'VolCiftiTemplate', '$VolCiftiTemplate', 'VolInputFile', '$tempname.volinput.txt', 'VolInputVNFile', '$tempname.volinputvn.txt', 'OutputVolBeta', '$OutputVolBeta'"
+                if ((DoZ))
+                then
+                    matlab_args+=", 'OutputVolZ', '$OutputVolZ'"
+                fi
+                if ((DoFixBias))
+                then
+                    matlab_args+=", 'VolGoodBCFile', '$tempname.volgoodbias.txt', 'OldVolBias', '$OldVolBias'"
+                fi
+            fi
+            matlab_code="$matlab_paths RSNregression($matlab_args);"
+            
+            log_Msg "running matlab code: $matlab_code"
+            "${matlab_interpreter[@]}" <<<"$matlab_code"
+            #matlab leaves a prompt and no newline when it finishes, so do an echo
+            echo
+            ;;
+    esac
+    
+    if [[ "$SpectraParams" != "" ]]
+    then
+        wb_command -file-information "$GroupMaps" -only-map-names > "$tempname.mapnames.txt"
+        TR=$(wb_command -file-information "$SpectraTRFile" -only-step-interval)
+        FTmixStep=$(echo "scale = 7; 1 / ($nTPsForSpectra * $TR)" | bc -l)
+        wb_command -cifti-create-scalar-series "$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_ts.${LowResMesh}k_fs_LR.txt" "$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_ts.${LowResMesh}k_fs_LR.sdseries.nii" -transpose -name-file "$tempname.mapnames.txt" -series SECOND 0 "$TR"
+        wb_command -cifti-create-scalar-series "$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_spectra.${LowResMesh}k_fs_LR.txt" "$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_spectra.${LowResMesh}k_fs_LR.sdseries.nii" -transpose -name-file "$tempname.mapnames.txt" -series HERTZ 0 "$FTmixStep"
+        rm -f -- "$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_ts.${LowResMesh}k_fs_LR.txt" "$DownSampleMNIFolder/${Subject}.${OutString}_${MethodStr}${RegString}_spectra.${LowResMesh}k_fs_LR.txt"
+    fi
+}
+
+#these few lines to record and delete temp files could maybe go in some shell library
+g_temp_files=()
+function addtemp()
+{
+    g_temp_files+=("$@")
+}
+function cleanup()
+{
+    if ((${#g_temp_files[@]} > 0))
+    then
+        rm -f -- "${g_temp_files[@]}"
+    fi
+}
+#disabled for debug
+trap cleanup EXIT
+
+if (($# == 0)) || [[ "$1" == --* ]]
+then
+    #named parameters
+    main "$@"
+else
+    #positional support goes here - just call main with named parameters built from $1, etc
+    log_Err_Abort "positional parameter support is not currently implemented"
+    main --foo="$1" --bar="$2"
+fi
+

--- a/global/scripts/RSNregression.sh
+++ b/global/scripts/RSNregression.sh
@@ -11,7 +11,7 @@ function usage()
 {
     #header text
     echo "
-$log_ToolName: does stuff
+$log_ToolName: regresses group ICA spatial maps into individual data in order to obtain individual spatial maps of where the subject's similar function is
 
 Usage: $log_ToolName PARAMETER...
 
@@ -28,17 +28,16 @@ function main()
     opts_AddMandatory '--subject' 'Subject' 'subject ID' ""
     opts_AddMandatory '--group-maps' 'GroupMaps' 'file' "the group template maps to regress"
     opts_AddMandatory '--subject-timeseries' 'InputList' 'fmri@fmri@fmri...' "the timeseries fmri names to concatenate"
-    #matlab arguments should be complete filenames
     opts_AddOptional '--surf-reg-name' 'RegName' 'name' "the registration string corresponding to the input files"
     opts_AddMandatory '--low-res' 'LowResMesh' 'meshnum' "mesh resolution, like '32' for 32k_fs_LR"
-    opts_AddMandatory '--proc-string' 'ProcString' 'string' "part of filename describing processing, like FIXME: EXAMPLE"
+    opts_AddMandatory '--proc-string' 'ProcString' 'string' "part of filename describing processing, like '_hp2000_clean'"
     opts_AddMandatory '--method' 'Method' 'regression method' "'weighted' or 'dual' - weighted regression finds locations in the subject that don't match the template well and downweights them; dual is simpler, both methods use vertex area information"
     opts_AddOptional '--weighted-smoothing-sigma' 'WRSmoothingSigma' 'number' "default 14 for human data - when using --method=weighted, the smoothing sigma, in mm, to apply to the 'alignment quality' weighting map" '14'
     opts_AddOptional '--low-ica-dims' 'LowICADims' 'num@num@num...' "when using --method=weighted, the low ICA dimensionality files to use for determining weighting"
     opts_AddOptional '--low-ica-template-name' 'ICATemplateName' 'filename' "filename template where 'REPLACEDIM' will be replaced by each of the --low-ica-dims values in turn to form the low-dim inputs"
     #outputs
-    opts_AddMandatory '--output-string' 'OutString' 'name' "filename part to describe the outputs, like FIXME: EXAMPLE_d127"
-    opts_AddOptional '--output-spectra' 'nTPsForSpectra' 'number' "FIXME: what does this do?" '0'
+    opts_AddMandatory '--output-string' 'OutString' 'name' "filename part to describe the outputs, like group_ICA_d127"
+    opts_AddOptional '--output-spectra' 'nTPsForSpectra' 'number' "number of samples to use when computing frequency spectrum" '0'
     opts_AddOptional '--volume-template-cifti' 'VolCiftiTemplate' 'file' "to generate voxel-based outputs, provide a cifti file setting the voxels to use"
     opts_AddOptional '--output-z' 'DoZString' 'YES or NO' "also create Z maps from the regression" 'NO'
     #opts_AddOptional '--output-norm' 'DoNorm' '1 or 0' "also create maps normalized to match the group maps" '0'

--- a/global/scripts/finish_hcpsetup.shlib
+++ b/global/scripts/finish_hcpsetup.shlib
@@ -1,0 +1,28 @@
+#!/bin/echo This script should not be run directly:
+
+#extra setup bits that the user should never need to edit
+
+#make sure fsl generates .nii.gz files
+export FSLOUTPUTTYPE=NIFTI_GZ
+
+export HCPPIPEDIR_Templates=${HCPPIPEDIR}/global/templates
+export HCPPIPEDIR_Bin=${HCPPIPEDIR}/global/binaries
+export HCPPIPEDIR_Config=${HCPPIPEDIR}/global/config
+
+export HCPPIPEDIR_PreFS=${HCPPIPEDIR}/PreFreeSurfer/scripts
+export HCPPIPEDIR_FS=${HCPPIPEDIR}/FreeSurfer/scripts
+export HCPPIPEDIR_PostFS=${HCPPIPEDIR}/PostFreeSurfer/scripts
+export HCPPIPEDIR_fMRISurf=${HCPPIPEDIR}/fMRISurface/scripts
+export HCPPIPEDIR_fMRIVol=${HCPPIPEDIR}/fMRIVolume/scripts
+export HCPPIPEDIR_tfMRI=${HCPPIPEDIR}/tfMRI/scripts
+export HCPPIPEDIR_dMRI=${HCPPIPEDIR}/DiffusionPreprocessing/scripts
+export HCPPIPEDIR_dMRITract=${HCPPIPEDIR}/DiffusionTractography/scripts
+export HCPPIPEDIR_Global=${HCPPIPEDIR}/global/scripts
+export HCPPIPEDIR_tfMRIAnalysis=${HCPPIPEDIR}/TaskfMRIAnalysis/scripts
+
+#try to reduce strangeness from locale and other environment settings
+export LC_ALL=C
+export LANGUAGE=C
+#POSIXLY_CORRECT currently gets set by many versions of fsl_sub, unfortunately, but at least don't pass it in if the user has it set in their usual environment
+unset POSIXLY_CORRECT
+

--- a/global/scripts/log.shlib
+++ b/global/scripts/log.shlib
@@ -1,3 +1,11 @@
+#use 'source $HCPPIPEDIR/global/scripts/log.shlib "$@"' to log the full command line originally run on error or abort
+if (($# > 0))
+then
+    log_FullCommand="$0 $@"
+else
+    log_FullCommand=""
+fi
+
 #
 # Description:
 #   sets the name of the tool to use for future logging
@@ -9,6 +17,8 @@ log_SetToolName()
 {
 	log_ToolName="$1"
 }
+#also set the default toolname on sourcing
+log_SetToolName "$(basename $0)"
 
 #
 # Description:
@@ -18,6 +28,7 @@ log_SetShowDateTime()
 {
 	log_ShowDateTime="TRUE"
 }
+log_SetShowDateTime
 
 #
 # Description:
@@ -36,6 +47,7 @@ log_SetShowToolName()
 {
 	log_ShowToolName="TRUE"
 }
+log_SetShowToolName
 
 #
 # Description:
@@ -63,6 +75,7 @@ log_ClearShowFunctionName()
 {
 	log_ShowFunctionName="FALSE"
 }
+log_ClearShowFunctionName
 
 #
 # Description:
@@ -143,6 +156,10 @@ log_Msg()
 log_Err_Abort()
 {
 	local msg="$*"
+	if [[ ! -z "$log_FullCommand" ]]
+	then
+	    log_Msg "While running '$log_FullCommand':"
+	fi
 	log_Msg "ABORTING: ${msg}"
 	exit 1
 }
@@ -150,6 +167,10 @@ log_Err_Abort()
 log_Err()
 {
 	local msg="$*"
+	if [[ ! -z "$log_FullCommand" ]]
+	then
+	    log_Msg "While running '$log_FullCommand':"
+	fi
 	log_Msg "ERROR: ${msg}"
 }
 

--- a/global/scripts/newopts.shlib
+++ b/global/scripts/newopts.shlib
@@ -262,7 +262,7 @@ function opts_print_help_line()
             local string=""
             if ((firstline == 1))
             then
-                if [[ "${line}" == [* ]]
+                if [[ "${linemod}" == [* ]]
                 then
                     string="  "
                 else

--- a/global/scripts/newopts.shlib
+++ b/global/scripts/newopts.shlib
@@ -1,0 +1,298 @@
+#!/bin/echo This script should not be run directly:
+
+#new named parameter parsing code: you write one line per argument, write just the tool's description into a "usage" function, and it does everything else except process the data (parameter descriptions in usage, parsing, logging parsed inputs, showing help info with --help or no arguments)
+#use the lines between EXAMPLE_START and EXAMPLE_END as a template when making a new script
+true <<"EXAMPLE_END"
+EXAMPLE_START
+#!/bin/bash
+set -eu
+
+source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
+
+#this function gets called by opts_ParseArguments when --help is specified
+function usage()
+{
+    #header text
+    echo "
+$log_ToolName: does stuff
+
+Usage: $log_ToolName PARAMETER...
+
+PARAMETERs are [ ] = optional; < > = user supplied value
+"
+    #automatic argument descriptions
+    opts_ShowArguments
+}
+
+function main()
+{
+    #arguments to opts_Add*: switch, variable to set, name for inside of <> in help text, description, [default value if AddOptional], [compatibility flag], ...
+    opts_AddOptional '--foo' 'myfoo' 'my foo' "give me a value, and i'll store it in myfoo" 'defaultfoo' '--oldoptionname' '--evenoldername'
+    opts_AddMandatory '--bar' 'mybar' 'your bar' "a required value, and this description is really long, but the opts_ShowArguments function automatically splits at spaces, or hyphenates if there aren't enough spaces"
+    opts_ParseArguments "$@"
+    
+    #display the parsed/default values
+    opts_ShowValues
+    
+    #processing code goes here
+}
+
+if (($# == 0)) || [[ "$1" == --* ]]
+then
+    #named parameters
+    main "$@"
+else
+    #positional support goes here - just call main with named parameters built from $1, etc
+    log_Err_Abort "positional parameter support is not currently implemented"
+    main --foo="$1" --bar="$2"
+fi
+EXAMPLE_END
+
+#we want a "log error and abort" function, so use the shlib for that
+if [[ "$(type -t log_Err_Abort)" != "function" ]]
+then
+    source "$HCPPIPEDIR/global/scripts/log.shlib" "$@"
+fi
+
+#takes things like "true", "YES", and outputs "1", "NO" is "0", throws error if unrecognized
+function opts_StringToBool()
+{
+    case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+        (yes | true | 1)
+            echo 1
+            ;;
+        (no | false | 0)
+            echo 0
+            ;;
+        (*)
+            log_Err_Abort "unrecognized boolean '$1', please use yes/no, true/false, or 1/0"
+            ;;
+    esac
+}
+
+#switch, variable to set, name for inside of <> in help text, description, [default value], [compatibility flag, ...]
+function opts_AddOptional()
+{
+    local switch="$1"
+    local varname="$2"
+    local vardescrip="$3"
+    local descrip="$4"
+    shift 4
+    opts_add_switch "$switch" "$varname" 1 "$vardescrip" "$descrip" "$@"
+}
+
+#switch, variable to set, name for inside of <> in help text, description, [compatibility flag, ...]
+function opts_AddMandatory()
+{
+    local switch="$1"
+    local varname="$2"
+    local vardescrip="$3"
+    local descrip="$4"
+    shift 4
+    opts_add_switch "$switch" "$varname" 0 "$vardescrip" "$descrip" '' "$@"
+}
+
+opts_param_switches=()
+opts_compat_aliases=()
+function opts_add_switch()
+{
+    if (($# < 5))
+    then
+        error "parameter '$1' added improperly, check number of arguments and quoting"
+    fi
+    if [[ "$1" != --* ]]
+    then
+        error "parameter switches must start with --, attempted to create switch '$1'"
+    fi
+    #only the index is local, the arrays must be global
+    local new_index="${#opts_param_switches[@]}"
+    opts_param_switches["$new_index"]="$1"
+    opts_param_variable_names["$new_index"]="$2"
+    opts_param_optional["$new_index"]="$3"
+    opts_param_vardescrip["$new_index"]="$4"
+    opts_param_descrip["$new_index"]="$5"
+    #yes, it takes and sets a default value for mandatory parameters - doesn't matter because it checks that all mandatory are provided, and the code is simpler this way
+    if (($# >= 6))
+    then
+        opts_default["$new_index"]="$6"
+    else
+        opts_default["$new_index"]=""
+    fi
+    for ((index = 7; index <= $#; ++index))
+    do
+        opts_compat_aliases+=("${!index}" "$new_index")
+    done
+}
+
+function opts_ParseArguments()
+{
+    if (($# == 0))
+    then
+        #"usage" must be defined by the actual tool script
+        usage
+        exit 2
+    fi
+    #initialize all output variables to empty string, so optional ones don't error with 'set -eu')
+    #print -v sets global variables without having declare -g
+    #use opts_ even for local variables in this function to reduce chance of collision with the output variable names
+    for ((opts_index = 0; opts_index < ${#opts_param_switches[@]}; ++opts_index))
+    do
+        #note: empty format string does not actually set the variable
+        printf -v "${opts_param_variable_names[$opts_index]}" '%s' "${opts_default[$opts_index]}"
+    done
+    local -a opts_used_params
+    local opts_myswitch
+    for opts_myswitch in "${opts_param_switches[@]}"
+    do
+        opts_used_params+=(0)
+    done
+    while (($# > 0))
+    do
+        local opts_switch="${1%%=*}"
+        local opts_argument="${1#*=}"
+        shift
+        #the convention of "--help"
+        if [[ "$opts_switch" == "--help" ]]
+        then
+            usage
+            exit 2
+        fi
+        local opts_found=0
+        local opts_index
+        for ((opts_index = 0; opts_index < ${#opts_param_switches[@]}; ++opts_index))
+        do
+            if [[ "${opts_param_switches[$opts_index]}" == "$opts_switch" ]]
+            then
+                opts_found=1
+                break
+            fi
+        done
+        if ((opts_found == 0))
+        then
+            local opts_index2
+            for ((opts_index2 = 0; opts_index2 < ${#opts_compat_aliases[@]}; opts_index2 += 2))
+            do
+                if [[ "${opts_compat_aliases[$opts_index2]}" == "$opts_switch" ]]
+                then
+                    opts_found=1
+                    opts_index=$((${opts_compat_aliases[opts_index2 + 1]}))
+                    break
+                fi
+            done
+        fi
+        if ((opts_found == 1))
+        then
+            printf -v "${opts_param_variable_names[$opts_index]}" '%s' "$opts_argument"
+            if ((opts_used_params[opts_index] == 1))
+            then
+                error "parameter specified multiple times: '$opts_switch'"
+            fi
+            opts_used_params["$opts_index"]=1
+        else
+            log_Err_Abort "unrecognized option: '$opts_switch'"
+        fi
+    done
+    local opts_missing_mandatory=0
+    for ((opts_index = 0; opts_index < ${#opts_param_switches[@]}; ++opts_index))
+    do
+        if ((opts_param_optional[opts_index] == 0 && opts_used_params[opts_index] == 0))
+        then
+            opts_missing_mandatory=1
+            echo "missing mandatory parameter '${opts_param_switches[$opts_index]}'" 1>&2
+        fi
+    done
+    if ((opts_missing_mandatory == 1))
+    then
+        log_Err_Abort "missing at least one mandatory parameter"
+    fi
+}
+
+#after parsing, call this to log all values
+function opts_ShowValues()
+{
+    local opts_index
+    for ((opts_index = 0; opts_index < ${#opts_param_switches[@]}; ++opts_index))
+    do
+        local opts_varname="${opts_param_variable_names[$opts_index]}"
+        log_Msg "$opts_varname: ${!opts_varname}"
+    done
+}
+
+function opts_ShowArguments()
+{
+    opts_print_help_line '[--help] - show usage information and exit'
+    local index
+    for ((index = 0; index < ${#opts_param_switches[@]}; ++index))
+    do
+        local string="${opts_param_switches[$index]}=<${opts_param_vardescrip[$index]}>"
+        if ((opts_param_optional[index] == 1))
+        then
+            string="[$string]"
+        fi
+        if [[ "${opts_param_descrip[$index]}" != "" ]]
+        then
+            string+=" - ${opts_param_descrip[$index]}"
+        fi
+        opts_print_help_line "$string"
+    done
+    #extra line for aesthetics
+    echo
+}
+
+function opts_print_help_line()
+{
+    local maxwidth=79
+    local -a mylines
+    #read -a only reads one line, and mac's old bash doesn't have readarray, so time for some trickery
+    #could use just IFS without quoting, but this removes intentional blank lines
+    #turn % into %p, @ into %a, and newline into @ - need to escape % first, and undo it last
+    #then we can use read -a with IFS=@
+    escaped=$(echo "$1" | sed -e 's/%/%p/g' -e 's/@/%a/g' | tr $'\n' @)
+    IFS='@' read -a mylinesescaped <<<"$escaped"
+    local firstline=1
+    local line
+    for line in "${mylinesescaped[@]}"
+    do
+        #undo escaping
+        local linemod=$(echo "$line" | sed -e 's/%a/@/g' -e 's/%p/%/g')
+        local firstloop=1
+        while ((firstloop || ${#linemod} > 0))
+        do
+            firstloop=0
+            local string=""
+            if ((firstline == 1))
+            then
+                if [[ "${line}" == [* ]]
+                then
+                    string="  "
+                else
+                    string="   "
+                fi
+            else
+                string="        "
+            fi
+            string+="$linemod"
+            if ((${#string} < maxwidth))
+            then
+                local toprint="$string"
+                local linemod=""
+            else
+                local chopped="${string:0:$((maxwidth + 1))}"
+                local untilspace="${chopped% *}"
+                #this test also prevents the leading spaces from being accepted as the splitting location
+                if ((${#untilspace} < (maxwidth * 2 / 3)))
+                then
+                    local toprint="${string:0:$((maxwidth - 1))}-"
+                    linemod="${string:$((maxwidth - 1))}"
+                else
+                    local divide="${#untilspace}"
+                    local toprint="${untilspace}"
+                    linemod=$(echo "${string:$((divide))}" | sed 's/^ *//')
+                fi
+            fi
+            echo "$toprint"
+            firstline=0
+        done
+    done
+}
+

--- a/global/scripts/newopts.shlib
+++ b/global/scripts/newopts.shlib
@@ -159,6 +159,7 @@ function opts_ParseArguments()
         fi
         local opts_found=0
         local opts_index
+        #check main switches
         for ((opts_index = 0; opts_index < ${#opts_param_switches[@]}; ++opts_index))
         do
             if [[ "${opts_param_switches[$opts_index]}" == "$opts_switch" ]]
@@ -167,6 +168,7 @@ function opts_ParseArguments()
                 break
             fi
         done
+        #check compatibility switches
         if ((opts_found == 0))
         then
             local opts_index2
@@ -182,12 +184,12 @@ function opts_ParseArguments()
         fi
         if ((opts_found == 1))
         then
-            printf -v "${opts_param_variable_names[$opts_index]}" '%s' "$opts_argument"
             if ((opts_used_params[opts_index] == 1))
             then
                 error "parameter specified multiple times: '$opts_switch'"
             fi
             opts_used_params["$opts_index"]=1
+            printf -v "${opts_param_variable_names[$opts_index]}" '%s' "$opts_argument"
         else
             log_Err_Abort "unrecognized option: '$opts_switch'"
         fi
@@ -244,7 +246,7 @@ function opts_print_help_line()
     local maxwidth=79
     local -a mylines
     #read -a only reads one line, and mac's old bash doesn't have readarray, so time for some trickery
-    #could use just IFS without quoting, but this removes intentional blank lines
+    #could use just IFS without quoting inside =(), but that would remove intentional blank lines
     #turn % into %p, @ into %a, and newline into @ - need to escape % first, and undo it last
     #then we can use read -a with IFS=@
     escaped=$(echo "$1" | sed -e 's/%/%p/g' -e 's/@/%a/g' | tr $'\n' @)


### PR DESCRIPTION
In order to code up the new RSN script in a style I consider better, I had to write some new option parsing functions and make some edits to the setup script (to set $PATH as previously discussed).  The end of the setup script now sources something from global/scripts, which contains some bits that the user should never need to edit, but that pipeline maintainers may want to update - this way, in the future, updating the pipelines can add some variables to the user's effective setup without the user needing to restart from the template version again.  Since existing users will need at least a few lines from my new version of the setup script to run this new script, this is an attempt to reduce future occurrences of this situation (it could be argued that some more of the sanity checking and path setting could be moved into the part that the user shouldn't need to edit).