### PR TITLE
Fix diffusion mask in voxels outside the FOV

### DIFF
--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -95,13 +95,13 @@ done
 ${GlobalScripts}/Rotate_bvecs.sh "$DataDirectory"/bvecs "$WorkingDirectory"/diff2str.mat "$T1wOutputDirectory"/bvecs
 cp "$DataDirectory"/bvals "$T1wOutputDirectory"/bvals
 
-DILATE_DISTANCE=`echo "$DiffRes * 4" | bc`  # Extrapolates the diffusion data up to 4 voxels outside of the FOV
+DilateDistance=`echo "$DiffRes * 4" | bc`  # Extrapolates the diffusion data up to 4 voxels outside of the FOV
 
 #Register diffusion data to T1w space. Account for gradient nonlinearities if requested
 if [ ${GdcorrectionFlag} -eq 1 ]; then
     echo "Correcting Diffusion data for gradient nonlinearities and registering to structural space"
     ${FSLDIR}/bin/convertwarp --rel --relout --warp1="$DataDirectory"/warped/fullWarp --postmat="$WorkingDirectory"/diff2str.mat --ref="$T1wRestoreImage"_${DiffRes} --out="$WorkingDirectory"/grad_unwarp_diff2str
-    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/warped/data_warped.nii.gz $DILATE_DISTANCE NEAREST $DataDirectory/warped/data_warped_dilated.nii.gz
+    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/warped/data_warped.nii.gz $DilateDistance NEAREST $DataDirectory/warped/data_warped_dilated.nii.gz
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped_dilated -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
@@ -113,7 +113,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/grad_dev -mas "$T1wOutputDirectory"/nodif_brain_mask_temp "$T1wOutputDirectory"/grad_dev  #Mask-out values outside the brain 
 else
     #Register diffusion data to T1w space without considering gradient nonlinearities
-    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/data.nii.gz $DILATE_DISTANCE NEAREST $DataDirectory/data_dilated.nii.gz
+    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/data.nii.gz $DilateDistance NEAREST $DataDirectory/data_dilated.nii.gz
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data_dilated -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -105,8 +105,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped_dilated -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslroi "$DataDirectory"/warped/data_warped "$DataDirectory"/warped/nodif_warped 0 1
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/nodif_warped -abs -bin "$DataDirectory"/warped/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -abs -Tmax -bin "$DataDirectory"/warped/fov_mask
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
 
     #Now register the grad_dev tensor 
@@ -118,7 +117,7 @@ else
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data_dilated -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/nodif -abs -bin "$DataDirectory"/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -abs -Tmax -bin "$DataDirectory"/fov_mask
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/fov_mask -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp trilinear -out "$T1wOutputDirectory"/fov_mask
 fi
 

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -120,7 +120,7 @@ else
 fi
 
 # only include voxels fully(!) within the field of view for every volume
-${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/fov_mask -thr 1 -bin "$T1wOutputDirectory"/fov_mask
+${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/fov_mask -thr 0.999 -bin "$T1wOutputDirectory"/fov_mask
 
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/data -mas "$T1wOutputDirectory"/nodif_brain_mask_temp -mas "$T1wOutputDirectory"/fov_mask "$T1wOutputDirectory"/data  #Mask-out data outside the brain
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/data -thr 0 "$T1wOutputDirectory"/data      #Remove negative intensity values (caused by spline interpolation) from final data

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -104,7 +104,8 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -abs -Tmin -bin "$DataDirectory"/warped/fov_mask
+    ${FSLDIR}/bin/fslroi "$DataDirectory"/warped/data_warped "$DataDirectory"/warped/nodif_warped
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/nodif_warped -abs -bin "$DataDirectory"/warped/fov_mask
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
 
     #Now register the grad_dev tensor 
@@ -115,7 +116,7 @@ else
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -abs -Tmin -bin "$DataDirectory"/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/nodif -abs -bin "$DataDirectory"/fov_mask
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/fov_mask -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp trilinear -out "$T1wOutputDirectory"/fov_mask
 fi
 

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -107,21 +107,19 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/warped/data_warped.nii.gz $DilateDistance NEAREST $DataDirectory/warped/data_warped_dilated.nii.gz
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped_dilated -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
-    #Create a mask representing voxels within the field of view for all volumes prior to dilation
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -abs -Tmin -bin -fillh "$DataDirectory"/warped/fov_mask
+    # Transforms field of view mask to T1-weighted space
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
 
-    #Now register the grad_dev tensor 
+    # Now register the grad_dev tensor
     ${FSLDIR}/bin/vecreg -i "$DataDirectory"/grad_dev -o "$T1wOutputDirectory"/grad_dev -r "$T1wRestoreImage"_${DiffRes} -t "$WorkingDirectory"/diff2str.mat --interp=spline
     ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/grad_dev -mas "$T1wOutputDirectory"/nodif_brain_mask_temp "$T1wOutputDirectory"/grad_dev  #Mask-out values outside the brain 
 else
     # Dilation outside of the field of view to minimise the effect of the hard field of view edge on the interpolation
     ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/data.nii.gz $DilateDistance NEAREST $DataDirectory/data_dilated.nii.gz
-    #Register diffusion data to T1w space without considering gradient nonlinearities
+    # Register diffusion data to T1w space without considering gradient nonlinearities
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data_dilated -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
-    #Create a mask representing voxels within the field of view for all volumes prior to dilation
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -abs -Tmin -bin -fillh "$DataDirectory"/fov_mask
+    # Transforms field of view mask to T1-weighted space
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/fov_mask -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp trilinear -out "$T1wOutputDirectory"/fov_mask
 fi
 

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -146,7 +146,6 @@ echo "${PctCoverage}, ${NvoxFinalMask}, ${NvoxBrainMask}" >> "$T1wOutputDirector
 
 ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/temp
 ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/nodif_brain_mask_old
-${FSLDIR}/bin/imrm "$T1wOutputDirectory"/fov_mask
 if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/imrm $DataDirectory/warped/data_warped_dilated
 else

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -134,6 +134,14 @@ ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/nodif_brain_mask_temp
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/data -Tmean "$T1wOutputDirectory"/temp
 ${FSLDIR}/bin/immv "$T1wOutputDirectory"/nodif_brain_mask.nii.gz "$T1wOutputDirectory"/nodif_brain_mask_old.nii.gz
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/nodif_brain_mask_old.nii.gz -mas "$T1wOutputDirectory"/temp "$T1wOutputDirectory"/nodif_brain_mask
+
+# Create a simple summary text file of the percentage of spatial coverage of the dMRI data inside the FS-derived brain mask
+NvoxBrainMask=`fslstats  -V "$T1wOutputDirectory"/nodif_brain_mask_old | awk '{print $1}'`
+NvoxFinalMask=`fslstats  -V "$T1wOutputDirectory"/nodif_brain_mask | awk '{print $1}'`
+PctCoverage=`echo "scale=4; 100 * ${NvoxFinalMask} / ${NvoxBrainMask}" | bc -l`
+echo "PctCoverage, NvoxFinalMask, NvoxBrainMask" >| "$T1wOutputDirectory"/nodif_brain_mask.stats.txt
+echo "${PctCoverage}, ${NvoxFinalMask}, ${NvoxBrainMask}" >> fov_mask.stats.txt
+
 ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/temp
 ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/nodif_brain_mask_old
 ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/fov_mask

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -104,7 +104,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -Tmin -bin "$DataDirectory"/warped/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -abs -Tmin -bin "$DataDirectory"/warped/fov_mask
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
 
     #Now register the grad_dev tensor 
@@ -115,7 +115,7 @@ else
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -Tmin -bin "$DataDirectory"/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -abs -Tmin -bin "$DataDirectory"/fov_mask
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/fov_mask -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp trilinear -out "$T1wOutputDirectory"/fov_mask
 fi
 

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -103,7 +103,7 @@ DILATE_DISTANCE=echo "$DiffRes * 12"  # Extrapolates the diffusion data up to 12
 if [ ${GdcorrectionFlag} -eq 1 ]; then
     echo "Correcting Diffusion data for gradient nonlinearities and registering to structural space"
     ${FSLDIR}/bin/convertwarp --rel --relout --warp1="$DataDirectory"/warped/fullWarp --postmat="$WorkingDirectory"/diff2str.mat --ref="$T1wRestoreImage"_${DiffRes} --out="$WorkingDirectory"/grad_unwarp_diff2str
-    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/warped/data_warped $DILATE_DISTANCE NEAREST $DataDirectory/warped/data_warped_dilated
+    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/warped/data_warped.nii.gz $DILATE_DISTANCE NEAREST $DataDirectory/warped/data_warped_dilated.nii.gz
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped_dilated -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
@@ -116,7 +116,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/grad_dev -mas "$T1wOutputDirectory"/nodif_brain_mask_temp "$T1wOutputDirectory"/grad_dev  #Mask-out values outside the brain 
 else
     #Register diffusion data to T1w space without considering gradient nonlinearities
-    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/data $DILATE_DISTANCE NEAREST $DataDirectory/data_dilated
+    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/data.nii.gz $DILATE_DISTANCE NEAREST $DataDirectory/data_dilated.nii.gz
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data_dilated -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -107,7 +107,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped_dilated -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -abs -Tmax -bin "$DataDirectory"/warped/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/warped/data_warped -abs -Tmin -bin -fillh "$DataDirectory"/warped/fov_mask
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
 
     #Now register the grad_dev tensor 
@@ -119,7 +119,7 @@ else
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data_dilated -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
-    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -abs -Tmax -bin "$DataDirectory"/fov_mask
+    ${FSLDIR}/bin/fslmaths "$DataDirectory"/data -abs -Tmin -bin -fillh "$DataDirectory"/fov_mask
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/fov_mask -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp trilinear -out "$T1wOutputDirectory"/fov_mask
 fi
 

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -103,7 +103,7 @@ DILATE_DISTANCE=echo "$DiffRes * 12"  # Extrapolates the diffusion data up to 12
 if [ ${GdcorrectionFlag} -eq 1 ]; then
     echo "Correcting Diffusion data for gradient nonlinearities and registering to structural space"
     ${FSLDIR}/bin/convertwarp --rel --relout --warp1="$DataDirectory"/warped/fullWarp --postmat="$WorkingDirectory"/diff2str.mat --ref="$T1wRestoreImage"_${DiffRes} --out="$WorkingDirectory"/grad_unwarp_diff2str
-    ${CARET7DIR}/wb_command -volume_dilate $DataDirectory/warped/data_warped $DILATE_DISTANCE NEAREST $DataDirectory/warped/data_warped_dilated
+    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/warped/data_warped $DILATE_DISTANCE NEAREST $DataDirectory/warped/data_warped_dilated
     ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/data_warped_dilated -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=spline -o "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes
@@ -116,7 +116,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
     ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/grad_dev -mas "$T1wOutputDirectory"/nodif_brain_mask_temp "$T1wOutputDirectory"/grad_dev  #Mask-out values outside the brain 
 else
     #Register diffusion data to T1w space without considering gradient nonlinearities
-    ${CARET7DIR}/wb_command -volume_dilate $DataDirectory/data $DILATE_DISTANCE NEAREST $DataDirectory/data_dilated
+    ${CARET7DIR}/wb_command -volume-dilate $DataDirectory/data $DILATE_DISTANCE NEAREST $DataDirectory/data_dilated
     ${FSLDIR}/bin/flirt -in "$DataDirectory"/data_dilated -ref "$T1wRestoreImage"_${DiffRes} -applyxfm -init "$WorkingDirectory"/diff2str.mat -interp spline -out "$T1wOutputDirectory"/data
 
     #Create a mask covering voxels within the field of view for all volumes

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -97,7 +97,7 @@ done
 ${GlobalScripts}/Rotate_bvecs.sh "$DataDirectory"/bvecs "$WorkingDirectory"/diff2str.mat "$T1wOutputDirectory"/bvecs
 cp "$DataDirectory"/bvals "$T1wOutputDirectory"/bvals
 
-DILATE_DISTANCE=echo "$DiffRes * 12"  # Extrapolates the diffusion data up to 12 voxels outside of the FOV
+DILATE_DISTANCE=echo "$DiffRes * 4" | bc  # Extrapolates the diffusion data up to 4 voxels outside of the FOV
 
 #Register diffusion data to T1w space. Account for gradient nonlinearities if requested
 if [ ${GdcorrectionFlag} -eq 1 ]; then

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -109,7 +109,7 @@ if [ ${GdcorrectionFlag} -eq 1 ]; then
 
     # Transforms field of view mask to T1-weighted space
     # (Be sure to use the fov_mask derived prior to application of GDC)
-    ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
+    ${FSLDIR}/bin/applywarp --rel -i "$DataDirectory"/warped/fov_mask_warped -r "$T1wRestoreImage"_${DiffRes} -w "$WorkingDirectory"/grad_unwarp_diff2str --interp=trilinear -o "$T1wOutputDirectory"/fov_mask
 
     # Now register the grad_dev tensor
     ${FSLDIR}/bin/vecreg -i "$DataDirectory"/grad_dev -o "$T1wOutputDirectory"/grad_dev -r "$T1wRestoreImage"_${DiffRes} -t "$WorkingDirectory"/diff2str.mat --interp=spline
@@ -129,7 +129,7 @@ fi
 # only include voxels fully(!) within the field of view for every volume
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/fov_mask -thr 0.999 -bin "$T1wOutputDirectory"/fov_mask
 
-# Mask out data outside the brain adn outside the fov
+# Mask out data outside the brain and outside the fov
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/data -mas "$T1wOutputDirectory"/nodif_brain_mask_temp -mas "$T1wOutputDirectory"/fov_mask "$T1wOutputDirectory"/data
 ${FSLDIR}/bin/fslmaths "$T1wOutputDirectory"/data -thr 0 "$T1wOutputDirectory"/data      #Remove negative intensity values (from eddy) from final data
 ${FSLDIR}/bin/imrm "$T1wOutputDirectory"/nodif_brain_mask_temp

--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -100,9 +100,9 @@ if [ ! $GdCoeffs = "NONE" ] ; then
     ${FSLDIR}/bin/immv ${datadir}/data ${datadir}/data_warped
 
     # Dilation outside of the field of view to minimise the effect of the hard field of view edge on the interpolation
-	  DiffRes=`${FSLDIR}/bin/fslval ${datadir}/data pixdim1`
+	DiffRes=`${FSLDIR}/bin/fslval ${datadir}/data_warped pixdim1`
     DilateDistance=`echo "$DiffRes * 4" | bc`  # Extrapolates the diffusion data up to 4 voxels outside of the FOV
-    ${CARET7DIR}/wb_command -volume-dilate ${datadir}/warped/data_warped.nii.gz $DilateDistance NEAREST ${datadir}/warped/data_warped_dilated.nii.gz
+    ${CARET7DIR}/wb_command -volume-dilate ${datadir}/data_warped.nii.gz $DilateDistance NEAREST ${datadir}/data_warped_dilated.nii.gz
 
     # apply gradient distortion correction
     ${globalscriptsdir}/GradientDistortionUnwarp.sh --workingdir="${datadir}" --coeffs="${GdCoeffs}" --in="${datadir}/data_warped_dilated" --out="${datadir}/data" --owarp="${datadir}/fullWarp"

--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -87,13 +87,31 @@ else
 fi
 #fi
 
+
+#Create a mask representing voxels within the field of view for all volumes prior to dilation
+${FSLDIR}/bin/fslmaths ${datadir}/data -abs -Tmin -bin -fillh ${datadir}/fov_mask
+
 	 
 if [ ! $GdCoeffs = "NONE" ] ; then
     echo "Correcting for gradient nonlinearities"
 	# Note: "data_warped" is eddy-current and suspectibility distortion corrected (via 'eddy'), but prior to gradient distortion correction
 	# i.e., "data_posteddy_preGDC" would be another way to think of it
     ${FSLDIR}/bin/immv ${datadir}/data ${datadir}/data_warped
-    ${globalscriptsdir}/GradientDistortionUnwarp.sh --workingdir="${datadir}" --coeffs="${GdCoeffs}" --in="${datadir}/data_warped" --out="${datadir}/data" --owarp="${datadir}/fullWarp"
+
+    # Dilation outside of the field of view to minimise the effect of the hard field of view edge on the interpolation
+	  DiffRes=`${FSLDIR}/bin/fslval ${datadir}/data pixdim1`
+    DilateDistance=`echo "$DiffRes * 4" | bc`  # Extrapolates the diffusion data up to 4 voxels outside of the FOV
+    ${CARET7DIR}/wb_command -volume-dilate ${datadir}/warped/data_warped.nii.gz $DilateDistance NEAREST ${datadir}/warped/data_warped_dilated.nii.gz
+
+    # apply gradient distortion correction
+    ${globalscriptsdir}/GradientDistortionUnwarp.sh --workingdir="${datadir}" --coeffs="${GdCoeffs}" --in="${datadir}/data_warped_dilated" --out="${datadir}/data" --owarp="${datadir}/fullWarp"
+
+    # Transform field of view mask (using conservative trilinear interolation with high threshold)
+    ${FSLDIR}/bin/immv ${datadir}/fov_mask ${datadir}/fov_mask_warped
+    ${FSLDIR}/bin/applywarp --rel --interp=trilinear -i ${datadir}/fov_mask_warped -r ${datadir}/fov_mask_warped -w ${datadir}/fullWarp -o ${datadir}/fov_mask
+    ${FSLDIR}/bin/fslmaths ${datadir}/fov_mask -thr 0.999 -bin ${datadir}/fov_mask
+    # mask out any data outside the field of view
+    ${FSLDIR}/bin/fslmaths ${datadir}/data -mas ${datadir}/fov_mask ${datadir}/data
 
     echo "Computing gradient coil tensor to correct for gradient nonlinearities"
     ${FSLDIR}/bin/calc_grad_perc_dev --fullwarp=${datadir}/fullWarp -o ${datadir}/grad_dev
@@ -102,10 +120,12 @@ if [ ! $GdCoeffs = "NONE" ] ; then
     ${FSLDIR}/bin/imrm ${datadir}/grad_dev_?
     ${FSLDIR}/bin/imrm ${datadir}/trilinear
     ${FSLDIR}/bin/imrm ${datadir}/data_warped_vol1
-    
+    ${FSLDIR}/bin/imrm ${datadir}/data_warped_dilated
+
     #Keep the original warped data and warp fields
     mkdir -p ${datadir}/warped
     ${FSLDIR}/bin/immv ${datadir}/data_warped ${datadir}/warped
+    ${FSLDIR}/bin/immv ${datadir}/fov_mask_warped ${datadir}/warped
     ${FSLDIR}/bin/immv ${datadir}/fullWarp ${datadir}/warped
     ${FSLDIR}/bin/immv ${datadir}/fullWarp_abs ${datadir}/warped
 fi


### PR DESCRIPTION
The voxels inside the FOV at the first b0 might not be included in some other volumes due to movement. In eddy the signal these voxels, which are not included in all the volumes, are set to zero. In the HCP pipeline the output of eddy is resampled to T1 space. During this resampling, these voxels become non-zero due to the spline interpolation and are included within the final nodif_brain_mask.

This patch fixes this by:
1. Creating a mask which includes only those voxels consistently within the FOV across all volumes as determined by eddy (called fov_mask). This mask is created from the eddy (or eddy_combine) output before resampling. 
2. Transforming this mask to T1-weighted space using trilinear interpolation. This is then thresholded at a value of 1, so that any voxel which are at the edge of the FOV are excluded.
3. Setting to zero any data outside this transformed FOV mask

![fix_mask](https://user-images.githubusercontent.com/4652580/64548006-b2e34400-d325-11e9-916f-821e42582792.png)

This image shows the change in the final mask for subject 101309, which was the first subject where I noticed this issue, when looking at DTI fits. Note the very low range of the colour bar when plotting the B0 on the left. This is to visualise the striping caused by the spline interpolation.
