### PR TITLE
PreFreeSurfer Pipeline related pull request

### DIFF
--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -846,7 +846,8 @@ if [ "$CustomBrain" = "NONE" ] ; then
 elif [ "$CustomBrain" = "MASK" ] ; then
 
   log_Msg "Skipping all the steps to Atlas registration, applying custom mask."
-  ceho "---> Applying custom mask"
+  # ceho "---> Applying custom mask"
+  echo "---> Applying custom mask"
 
   ${FSLDIR}/bin/fslmaths ${T1wFolder}/${T1wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain
 
@@ -859,7 +860,8 @@ elif [ "$CustomBrain" = "MASK" ] ; then
 else
 
   log_Msg "Skipping all the steps to Atlas registration, using existing images."
-  ceho "---> Using existing images"
+  # ceho "---> Using existing images"
+  echo "---> Using existing images"
 
 fi  # --- skipped to here if we are using custom brain
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -785,8 +785,8 @@ if [ "$CustomBrain" = "NONE" ] ; then
       log_Warn "${T1wImage}_acpc_dc_restore* images should be considered misnamed and ARE NOT bias field corrected!"
       log_Warn "${T1wFolder}/BiasField_acpc_dc IS NOT an estimate of the bias field!"
 
-      cp ${T1wFolder}/${T1wImage}_acpc_dc.nii.gz ${T1wFolder}/${T1wImage}_acpc_dc_restore.nii.gz
-      cp ${T1wFolder}/${T1wImage}_acpc_dc_brain.nii.gz ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain.nii.gz
+      ${FSLDIR}/bin/imcp ${T1wFolder}/${T1wImage}_acpc_dc ${T1wFolder}/${T1wImage}_acpc_dc_restore
+      ${FSLDIR}/bin/imcp ${T1wFolder}/${T1wImage}_acpc_dc_brain ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain
       fslmaths ${T1wFolder}/${T1wImage}_acpc_dc -div ${T1wFolder}/${T1wImage}_acpc_dc ${T1wFolder}/BiasField_acpc_dc
 
     fi

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -225,7 +225,8 @@ Usage: PreeFreeSurferPipeline.sh [options]
   --t1=<T1w images>                   An @ symbol separated list of full paths to T1-weighted
                                       (T1w) structural images for the subject (required)
   --t2=<T2w images>                   An @ symbol separated list of full paths to T2-weighted
-                                      (T2w) structural images for the subject (required)
+                                      (T2w) structural images for the subject (required for 
+                                      hcp-style data, can be NONE for legacy-style data)
   --t1template=<file path>            MNI T1w template
   --t1templatebrain=<file path>       Brain extracted MNI T1wTemplate
   --t1template2mm=<file path>         MNI 2mm T1wTemplate
@@ -266,19 +267,6 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       coefficients, Set to "NONE" to turn off
   --avgrdcmethod=<avgrdcmethod>       Averaging and readout distortion correction
                                       method. See below for supported values.
-  [--custombrain=(NONE|MASK|CUSTOM)]  If PreFreeSurfer has been run before and you have created a custom
-                                      brain mask saved as "<path>/T1w/custom_acpc_dc_restore_mask.nii.gz", specify "MASK". 
-                                      If PreFreeSurfer has been run before and you have created custom structural images, e.g.: 
-                                      - "<path>/T1w/T1w_acpc_dc_restore_brain.nii.gz"
-                                      - "<path>/T1w/T1w_acpc_dc_restore.nii.gz"
-                                      - "<path>/T1w/T2w_acpc_dc_restore_brain.nii.gz"
-                                      - "<path>/T1w/T2w_acpc_dc_restore.nii.gz"
-                                      to be used when peforming MNI152 Atlas registration, specify "CUSTOM".
-                                      When "MASK" or "CUSTOM" is specified, all the steps until Atlas registration 
-                                      are skipped.
-                                      If the parameter is omitted or set to NONE (the default), 
-                                      standard image processing will take place.
-
 
     "${NONE_METHOD_OPT}"
      average any repeats with no readout distortion correction
@@ -302,6 +290,18 @@ Usage: PreeFreeSurferPipeline.sh [options]
 
   --topupconfig=<file path>           Configuration file for topup or "NONE" if not used
   [--bfsigma=<value>]                 Bias Field Smoothing Sigma (optional)
+  [--custombrain=(NONE|MASK|CUSTOM)]  If PreFreeSurfer has been run before and you have created a custom
+                                      brain mask saved as "<path>/T1w/custom_acpc_dc_restore_mask.nii.gz", specify "MASK". 
+                                      If PreFreeSurfer has been run before and you have created custom structural images, e.g.: 
+                                      - "<path>/T1w/T1w_acpc_dc_restore_brain.nii.gz"
+                                      - "<path>/T1w/T1w_acpc_dc_restore.nii.gz"
+                                      - "<path>/T1w/T2w_acpc_dc_restore_brain.nii.gz"
+                                      - "<path>/T1w/T2w_acpc_dc_restore.nii.gz"
+                                      to be used when peforming MNI152 Atlas registration, specify "CUSTOM".
+                                      When "MASK" or "CUSTOM" is specified, all the steps until Atlas registration 
+                                      are skipped.
+                                      If the parameter is omitted or set to NONE (the default), 
+                                      standard image processing will take place.
   [--mpp-mode=(HCPStyleData|          Which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps
                LegacyStyleData)]      described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. 
                                       "LegacyStyleData" allows additional processing functionality and use of some acquisitions 
@@ -591,7 +591,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         ${RUN} ${HCPPIPEDIR_PreFS}/AnatomicalAverage.sh -o ${TXwFolder}/${TXwImage} -s ${TXwTemplate} -m ${TemplateMask} -n -w ${TXwFolder}/Average${TXw}Images --noclean -v -b $BrainSize $OutputTXwImageSTRING
       else
         log_Msg "Not Averaging ${TXw} Images"
-        log_Msg "ONLY ONE AVERAGE FOUND: COPYING"
+        log_Msg "ONLY ONE IMAGE FOUND: COPYING"
         ${RUN} ${FSLDIR}/bin/imcp ${TXwFolder}/${TXwImage}1_gdc ${TXwFolder}/${TXwImage}
       fi
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -301,6 +301,8 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       When "MASK" or "CUSTOM" is specified, only the AtlasRegistration step is run.
                                       If the parameter is omitted or set to NONE (the default), 
                                       standard image processing will take place.
+                                      If using "MASK" or "CUSTOM", the data still needs to be staged properly by 
+                                      running FreeSurfer and PostFreeSurfer afterwards.
   [--mpp-mode=(HCPStyleData|          Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" 
                LegacyStyleData)]      (the default) follows the processing stepsdescribed in Glasser et al. (2013) 
                                       and requires 'HCP-Style' data acquistion. "LegacyStyleData" allows additional 
@@ -799,10 +801,12 @@ elif [ "$CustomBrain" = "MASK" ] ; then
   log_Msg "Skipping all the steps to Atlas registration, applying custom mask."
   verbose_red_echo "---> Applying custom mask"
 
-  fslmaths ${T1wFolder}/${T1wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain
+  OutputT1wImage=${T1wFolder}/${T1wImage}_acpc_dc
+  fslmaths ${OutputT1wImage}_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${OutputT1wImage}_restore_brain
 
   if [ ! "${T2wInputImages}" = "NONE" ] ; then
-    fslmaths ${T1wFolder}/${T2wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T2wImage}_acpc_dc_restore_brain
+    OutputT2wImage=${T1wFolder}/${T2wImage}_acpc_dc
+    fslmaths ${OutputT2wImage}_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${OutputT2wImage}_restore_brain
   fi
 
 # -- Then we are using existing images
@@ -816,9 +820,14 @@ fi  # --- skipped all the way to here if using customized structural images (--c
 
 # Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
 # i.e., whether the T1w/T1w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
-# or the PostFreeSurferPipeline versions
+# or the PostFreeSurferPipeline versions.
+# Make sure that you rerun FreeSurfer and PostFreeSurfer if using --custombrain={CUSTOM|MASK}
+# or if otherwise simply re-running PreFreeSurfer on top of existing data [which is not advised; 
+# in the --custombrain=NONE condition, the recommendation would be to simply delete the existing data, 
+# and run PreFreeSurfer (and then FreeSurfer and PostFreeSurfer) de novo].
+
 OutputOrigT1wToT1wPostFS=OrigT1w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
-imrm ${OutputOrigT1wToT1wPostFS}
+imrm ${T1wFolder}/xfms/${OutputOrigT1wToT1wPostFS}
 
 
 # ------------------------------------------------------------------------------

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -303,7 +303,11 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       standard image processing will take place.
                                       If using "MASK" or "CUSTOM", the data still needs to be staged properly by 
                                       running FreeSurfer and PostFreeSurfer afterwards.
-  [--mpp-mode=(HCPStyleData|          Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" 
+                                      NOTE: This option allows manual correction of brain images in cases when they
+                                      were not successfully processed and/or masked by the regular use of the pipelines.
+                                      Before using this option, first ensure that the pipeline arguments used were 
+                                      correct and that templates are a good match to the data.
+  [--processing-mode=(HCPStyleData|   Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" 
                LegacyStyleData)]      (the default) follows the processing stepsdescribed in Glasser et al. (2013) 
                                       and requires 'HCP-Style' data acquistion. "LegacyStyleData" allows additional 
                                       processing functionality and use of some acquisitions that do not conform to 
@@ -364,10 +368,11 @@ AvgrdcSTRING=`opts_GetOpt1 "--avgrdcmethod" $@`
 TopupConfig=`opts_GetOpt1 "--topupconfig" $@`
 BiasFieldSmoothingSigma=`opts_GetOpt1 "--bfsigma" $@`
 CustomBrain=`opts_GetOpt1 "--custombrain" $@`
-MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
+MPPMode=`opts_GetOpt1 "--processing-mode" $@`
 
-#NOTE: currently is only used in gradient distortion correction of spin echo fieldmaps to topup
-#not currently in usage, either, because of this very limited use
+# NOTE: UseJacobian only affects whether the spin echo field maps 
+# get modulated by the gradient distortion correction warpfield 
+# (T2wToT1wDistortionCorrectAndReg -> TopupPreprocessingAll)
 UseJacobian=`opts_GetOpt1 "--usejacobian" $@`
 # Convert UseJacobian value to all lowercase (to allow the user the flexibility to use True, true, TRUE, False, False, false, etc.)
 UseJacobian="$(echo ${UseJacobian} | tr '[:upper:]' '[:lower:]')"
@@ -392,13 +397,6 @@ ComplianceMsg=""
 
 if [ "${T2wInputImages}" = "NONE" ]; then
   ComplianceMsg+=" --t2=NONE"
-  Compliance="LegacyStyleData"
-fi
-
-# -- Use of custom brain
-
-if [ ! "${CustomBrain}" = "NONE" ]; then
-  ComplianceMsg+=" --custombrain=${CustomBrain}"
   Compliance="LegacyStyleData"
 fi
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -291,21 +291,20 @@ Usage: PreeFreeSurferPipeline.sh [options]
   --topupconfig=<file path>           Configuration file for topup or "NONE" if not used
   [--bfsigma=<value>]                 Bias Field Smoothing Sigma (optional)
   [--custombrain=(NONE|MASK|CUSTOM)]  If PreFreeSurfer has been run before and you have created a custom
-                                      brain mask saved as "<path>/T1w/custom_acpc_dc_restore_mask.nii.gz", specify "MASK". 
+                                      brain mask saved as "<subject>/T1w/custom_acpc_dc_restore_mask.nii.gz", specify "MASK". 
                                       If PreFreeSurfer has been run before and you have created custom structural images, e.g.: 
-                                      - "<path>/T1w/T1w_acpc_dc_restore_brain.nii.gz"
-                                      - "<path>/T1w/T1w_acpc_dc_restore.nii.gz"
-                                      - "<path>/T1w/T2w_acpc_dc_restore_brain.nii.gz"
-                                      - "<path>/T1w/T2w_acpc_dc_restore.nii.gz"
+                                      - "<subject>/T1w/T1w_acpc_dc_restore_brain.nii.gz"
+                                      - "<subject>/T1w/T1w_acpc_dc_restore.nii.gz"
+                                      - "<subject>/T1w/T2w_acpc_dc_restore_brain.nii.gz"
+                                      - "<subject>/T1w/T2w_acpc_dc_restore.nii.gz"
                                       to be used when peforming MNI152 Atlas registration, specify "CUSTOM".
-                                      When "MASK" or "CUSTOM" is specified, all the steps until Atlas registration 
-                                      are skipped.
+                                      When "MASK" or "CUSTOM" is specified, only the AtlasRegistration step is run.
                                       If the parameter is omitted or set to NONE (the default), 
                                       standard image processing will take place.
   [--mpp-mode=(HCPStyleData|          Which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps
                LegacyStyleData)]      described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. 
                                       "LegacyStyleData" allows additional processing functionality and use of some acquisitions 
-                                      that do not conform to 'HCP-Style' expectations:
+                                      that do not conform to 'HCP-Style' expectations i.e., in this case:
                                       - missing high-resolution T2w image, 
                                       - use of custom adjusted brain images or custom adjusted brain mask.
 EOF

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -226,7 +226,7 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       (T1w) structural images for the subject (required)
   --t2=<T2w images>                   An @ symbol separated list of full paths to T2-weighted
                                       (T2w) structural images for the subject (required for 
-                                      hcp-style data, can be NONE for legacy-style data)
+                                      hcp-style data, can be NONE for legacy-style data, see --mpp-mode option)
   --t1template=<file path>            MNI T1w template
   --t1templatebrain=<file path>       Brain extracted MNI T1wTemplate
   --t1template2mm=<file path>         MNI 2mm T1wTemplate

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -308,12 +308,12 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       were not successfully processed and/or masked by the regular use of the pipelines.
                                       Before using this option, first ensure that the pipeline arguments used were 
                                       correct and that templates are a good match to the data.
-  [--processing-mode=(HCPStyleData|   Which processing mode to use. "HCPStyleData" (the default) follows the processing
-               LegacyStyleData)]      steps described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion.
-                                      "LegacyStyleData" allows additional processing functionality and use of some 
-                                      acquisitions that do not conform to 'HCP-Style' expectations i.e., in this case:                                      
-                                      - missing high-resolution T2w image, 
-                                      - use of custom adjusted brain images or custom adjusted brain mask.
+  [--processing-mode=(HCPStyleData|   Controls whether the HCP acquisition and processing guidelines should be treated as requirements.
+               LegacyStyleData)]      "HCPStyleData" (the default) follows the processing steps described in Glasser et al. (2013) 
+                                         and requires 'HCP-Style' data acquistion. 
+                                      "LegacyStyleData" allows additional processing functionality and use of some acquisitions
+                                         that do not conform to 'HCP-Style' expectations.
+                                         i.e., in this case no high-resolution T2w image acquisition
 EOF
   exit 1
 }

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -380,13 +380,26 @@ UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
 
 
 # ------------------------------------------------------------------------------
-#  Check MMP Mode
+#  Compliance check
 # ------------------------------------------------------------------------------
 
 MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
 MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+ComplianceMsg=""
 
-check_mpp_compliance "PreFreeSurfer"
+# -- T2w image
+
+if [ "${T2wInputImages}" = "NONE" ]; then
+  ComplianceMsg+=" --t2=NONE"
+fi
+
+# -- Use of custom brain
+
+if [ ! "${CustomBrain}" = "NONE" ]; then
+  ComplianceMsg+=" --custombrain=${CustomBrain}"
+fi
+
+check_mpp_compliance "${MPPMode}" "${ComplianceMsg}"
 
 
 # ------------------------------------------------------------------------------

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -371,7 +371,7 @@ CustomBrain=`opts_GetOpt1 "--custombrain" $@`
 ProcessingMode=`opts_GetOpt1 "--processing-mode" $@`
 
 # NOTE: UseJacobian only affects whether the spin echo field maps 
-# get modulated by the gradient distortion correction warpfield 
+# get intensity modulated by the gradient distortion correction warpfield 
 # (T2wToT1wDistortionCorrectAndReg -> TopupPreprocessingAll)
 UseJacobian=`opts_GetOpt1 "--usejacobian" $@`
 # Convert UseJacobian value to all lowercase (to allow the user the flexibility to use True, true, TRUE, False, False, false, etc.)

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -362,6 +362,7 @@ AvgrdcSTRING=`opts_GetOpt1 "--avgrdcmethod" $@`
 TopupConfig=`opts_GetOpt1 "--topupconfig" $@`
 BiasFieldSmoothingSigma=`opts_GetOpt1 "--bfsigma" $@`
 CustomBrain=`opts_GetOpt1 "--custombrain" $@`
+MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
 
 #NOTE: currently is only used in gradient distortion correction of spin echo fieldmaps to topup
 #not currently in usage, either, because of this very limited use
@@ -375,15 +376,13 @@ RUN=`opts_GetOpt1 "--printcom" $@`
 
 # Defaults
 UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
-CustomBrain=`opts_DefaultOpt $CustomBrain NONE`
-
+CustomBrain=`opts_DefaultOpt $CustomBrain "NONE"`
+MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
 
 # ------------------------------------------------------------------------------
 #  Compliance check
 # ------------------------------------------------------------------------------
 
-MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
-MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
 Compliance="HCPStyleData"
 ComplianceMsg=""
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -709,7 +709,8 @@ if [ "$CustomBrain" = "NONE" ] ; then
 
   # ------------------------------------------------------------------------------
   #  Bias Field Correction: Calculate bias field using square root of the product
-  #  of T1w and T2w iamges.
+  #  of T1w and T2w images (if both available).
+  #  Otherwise (if only T1w available), calculate bias field using 'fsl_anat'
   # ------------------------------------------------------------------------------
 
   if [ ! "${T2wInputImages}" = "NONE" ] ; then

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -301,10 +301,11 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       When "MASK" or "CUSTOM" is specified, only the AtlasRegistration step is run.
                                       If the parameter is omitted or set to NONE (the default), 
                                       standard image processing will take place.
-  [--mpp-mode=(HCPStyleData|          Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" (the default) follows the processing steps
-               LegacyStyleData)]      described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. 
-                                      "LegacyStyleData" allows additional processing functionality and use of some acquisitions 
-                                      that do not conform to 'HCP-Style' expectations i.e., in this case:
+  [--mpp-mode=(HCPStyleData|          Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" 
+               LegacyStyleData)]      (the default) follows the processing stepsdescribed in Glasser et al. (2013) 
+                                      and requires 'HCP-Style' data acquistion. "LegacyStyleData" allows additional 
+                                      processing functionality and use of some acquisitions that do not conform to 
+                                      'HCP-Style' expectations i.e., in this case:
                                       - missing high-resolution T2w image, 
                                       - use of custom adjusted brain images or custom adjusted brain mask.
 EOF

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -203,7 +203,7 @@ fi
 
 source ${HCPPIPEDIR}/global/scripts/log.shlib  # Logging related functions
 source ${HCPPIPEDIR}/global/scripts/opts.shlib # Command line option functions
-source ${HCPPIPEDIR}/global/scripts/mppmodecheck.shlib  # Check MMP mode requirements
+source ${HCPPIPEDIR}/global/scripts/processingmodecheck.shlib  # Check processing mode requirements
 
 # ------------------------------------------------------------------------------
 #  Usage Description Function
@@ -226,7 +226,8 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       (T1w) structural images for the subject (required)
   --t2=<T2w images>                   An @ symbol separated list of full paths to T2-weighted
                                       (T2w) structural images for the subject (required for 
-                                      hcp-style data, can be NONE for legacy-style data, see --mpp-mode option)
+                                      hcp-style data, can be NONE for legacy-style data, 
+                                      see --processing-mode option)
   --t1template=<file path>            MNI T1w template
   --t1templatebrain=<file path>       Brain extracted MNI T1wTemplate
   --t1template2mm=<file path>         MNI 2mm T1wTemplate
@@ -307,11 +308,10 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       were not successfully processed and/or masked by the regular use of the pipelines.
                                       Before using this option, first ensure that the pipeline arguments used were 
                                       correct and that templates are a good match to the data.
-  [--processing-mode=(HCPStyleData|   Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" 
-               LegacyStyleData)]      (the default) follows the processing stepsdescribed in Glasser et al. (2013) 
-                                      and requires 'HCP-Style' data acquistion. "LegacyStyleData" allows additional 
-                                      processing functionality and use of some acquisitions that do not conform to 
-                                      'HCP-Style' expectations i.e., in this case:
+  [--processing-mode=(HCPStyleData|   Which processing mode to use. "HCPStyleData" (the default) follows the processing
+               LegacyStyleData)]      steps described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion.
+                                      "LegacyStyleData" allows additional processing functionality and use of some 
+                                      acquisitions that do not conform to 'HCP-Style' expectations i.e., in this case:                                      
                                       - missing high-resolution T2w image, 
                                       - use of custom adjusted brain images or custom adjusted brain mask.
 EOF
@@ -368,7 +368,7 @@ AvgrdcSTRING=`opts_GetOpt1 "--avgrdcmethod" $@`
 TopupConfig=`opts_GetOpt1 "--topupconfig" $@`
 BiasFieldSmoothingSigma=`opts_GetOpt1 "--bfsigma" $@`
 CustomBrain=`opts_GetOpt1 "--custombrain" $@`
-MPPMode=`opts_GetOpt1 "--processing-mode" $@`
+ProcessingMode=`opts_GetOpt1 "--processing-mode" $@`
 
 # NOTE: UseJacobian only affects whether the spin echo field maps 
 # get modulated by the gradient distortion correction warpfield 
@@ -384,7 +384,7 @@ RUN=`opts_GetOpt1 "--printcom" $@`
 # Defaults
 UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
 CustomBrain=`opts_DefaultOpt $CustomBrain "NONE"`
-MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+ProcessingMode=`opts_DefaultOpt $ProcessingMode "HCPStyleData"`
 
 # ------------------------------------------------------------------------------
 #  Compliance check
@@ -400,7 +400,7 @@ if [ "${T2wInputImages}" = "NONE" ]; then
   Compliance="LegacyStyleData"
 fi
 
-check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
+check_mode_compliance "${ProcessingMode}" "${Compliance}" "${ComplianceMsg}"
 
 
 # ------------------------------------------------------------------------------
@@ -440,7 +440,7 @@ log_Msg "BiasFieldSmoothingSigma: ${BiasFieldSmoothingSigma}"
 log_Msg "UseJacobian: ${UseJacobian}"
 log_Msg "T1wBiasCorrect: ${T1wBiasCorrect}"
 log_Msg "CustomBrain: ${CustomBrain}"
-log_Msg "MPPMode: ${MPPMode}"
+log_Msg "ProcessingMode: ${ProcessingMode}"
 
 # ------------------------------------------------------------------------------
 #  Show Environment Variables

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -385,21 +385,24 @@ UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
 
 MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
 MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+Compliance="HCPStyleData"
 ComplianceMsg=""
 
 # -- T2w image
 
 if [ "${T2wInputImages}" = "NONE" ]; then
   ComplianceMsg+=" --t2=NONE"
+  Compliance="LegacyStyleData"
 fi
 
 # -- Use of custom brain
 
 if [ ! "${CustomBrain}" = "NONE" ]; then
   ComplianceMsg+=" --custombrain=${CustomBrain}"
+  Compliance="LegacyStyleData"
 fi
 
-check_mpp_compliance "${MPPMode}" "${ComplianceMsg}"
+check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
 
 
 # ------------------------------------------------------------------------------

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -462,11 +462,7 @@ AtlasSpaceFolder="MNINonLinear"
 
 # Build Paths
 T1wFolder=${StudyFolder}/${Subject}/${T1wFolder}
-if [ "${T2wInputImages}" = "NONE" ] ; then
-  T2wFolder=NONE
-else
-  T2wFolder=${StudyFolder}/${Subject}/${T2wFolder}
-fi
+T2wFolder=${StudyFolder}/${Subject}/${T2wFolder}
 AtlasSpaceFolder=${StudyFolder}/${Subject}/${AtlasSpaceFolder}
 
 log_Msg "T1wFolder: $T1wFolder"
@@ -476,6 +472,15 @@ log_Msg "AtlasSpaceFolder: $AtlasSpaceFolder"
 # Unpack List of Images
 T1wInputImages=`echo ${T1wInputImages} | sed 's/@/ /g'`
 T2wInputImages=`echo ${T2wInputImages} | sed 's/@/ /g'`
+
+
+# -- Are T2w images available
+
+if [ ! "${T2wInputImages}" = "NONE" ] ; then
+  T2wAvailable="TRUE"
+else
+  T2wAvailable="FALSE"
+fi
 
 if [ ! -e ${T1wFolder}/xfms ] ; then
   log_Msg "mkdir -p ${T1wFolder}/xfms/"
@@ -666,7 +671,8 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --method=${AvgrdcSTRING} \
         --topupconfig=${TopupConfig} \
         --gdcoeffs=${GradientDistortionCoeffs} \
-        --usejacobian=${UseJacobian} 
+        --usejacobian=${UseJacobian} \
+        --t2avail=${T2wAvailable}
 
       ;;
 
@@ -694,7 +700,8 @@ if [ "$CustomBrain" = "NONE" ] ; then
         ${T1wFolder}/${T1wImage}_acpc_dc_brain \
         ${T1wFolder}/xfms/${T1wImage}_dc \
         ${T1wFolder}/${T2wImage}_acpc_dc \
-        ${T1wFolder}/xfms/${T2wImage}_reg_dc
+        ${T1wFolder}/xfms/${T2wImage}_reg_dc \
+        ${T2wAvailable}
 
   esac
 
@@ -822,12 +829,6 @@ fi  # --- skipped to here if we are using custom brain
 #  so, the primary purpose of the following is to generate the Atlas Registration itself).
 # ------------------------------------------------------------------------------
 
-if [ ! "${T2wInputImages}" = "NONE" ] ; then
-  t2avail="YES"
-else
-  t2avail="NO"
-fi
-
 log_Msg "Performing Atlas Registration to MNI152 (FLIRT and FNIRT)"
 
 ${RUN} ${HCPPIPEDIR_PreFS}/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh \
@@ -852,7 +853,7 @@ ${RUN} ${HCPPIPEDIR_PreFS}/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh \
   --ot2rest=${AtlasSpaceFolder}/${T2wImage}_restore \
   --ot2restbrain=${AtlasSpaceFolder}/${T2wImage}_restore_brain \
   --fnirtconfig=${FNIRTConfig} \
-  --t2avail=${t2avail}
+  --t2avail=${T2wAvailable}
 
 log_Msg "Completed"
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -446,7 +446,11 @@ AtlasSpaceFolder="MNINonLinear"
 
 # Build Paths
 T1wFolder=${StudyFolder}/${Subject}/${T1wFolder}
-T2wFolder=${StudyFolder}/${Subject}/${T2wFolder}
+if [ "${T2wInputImages}" = "NONE" ] ; then
+  T2wFolder=NONE
+else
+  T2wFolder=${StudyFolder}/${Subject}/${T2wFolder}
+fi
 AtlasSpaceFolder=${StudyFolder}/${Subject}/${AtlasSpaceFolder}
 
 log_Msg "T1wFolder: $T1wFolder"
@@ -462,7 +466,7 @@ if [ ! -e ${T1wFolder}/xfms ] ; then
   mkdir -p ${T1wFolder}/xfms/
 fi
 
-if [ ! -e ${T2wFolder}/xfms ] ; then
+if [ ! -e ${T2wFolder}/xfms ] && [ ${T2wFolder} != "NONE" ] ; then
   log_Msg "mkdir -p ${T2wFolder}/xfms/"
   mkdir -p ${T2wFolder}/xfms/
 fi

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -170,31 +170,31 @@ GENERAL_ELECTRIC_METHOD_OPT="GeneralElectricFieldMap"
 script_name=$(basename "${0}")
 
 if [ -z "${HCPPIPEDIR}" ]; then
-	echo "${script_name}: ABORTING: HCPPIPEDIR environment variable must be set"
-	exit 1
+  echo "${script_name}: ABORTING: HCPPIPEDIR environment variable must be set"
+  exit 1
 else
-	echo "${script_name}: HCPPIPEDIR: ${HCPPIPEDIR}"
+  echo "${script_name}: HCPPIPEDIR: ${HCPPIPEDIR}"
 fi
 
 if [ -z "${FSLDIR}" ]; then
-	echo "${script_name}: ABORTING: FSLDIR environment variable must be set"
-	exit 1
+  echo "${script_name}: ABORTING: FSLDIR environment variable must be set"
+  exit 1
 else
-	echo "${script_name}: FSLDIR: ${FSLDIR}"
+  echo "${script_name}: FSLDIR: ${FSLDIR}"
 fi
 
 if [ -z "${HCPPIPEDIR_Global}" ]; then
-	echo "${script_name}: ABORTING: HCPPIPEDIR_Global environment variable must be set"
-	exit 1
+  echo "${script_name}: ABORTING: HCPPIPEDIR_Global environment variable must be set"
+  exit 1
 else
-	echo "${script_name}: HCPPIPEDIR_Global: ${HCPPIPEDIR_Global}"
+  echo "${script_name}: HCPPIPEDIR_Global: ${HCPPIPEDIR_Global}"
 fi
 
 if [ -z "${HCPPIPEDIR_PreFS}" ]; then
-	echo "${script_name}: ABORTING: HCPPIPEDIR_PreFS environment variable must be set"
-	exit 1
+  echo "${script_name}: ABORTING: HCPPIPEDIR_PreFS environment variable must be set"
+  exit 1
 else
-	echo "${script_name}: HCPPIPEDIR_PreFS: ${HCPPIPEDIR_PreFS}"
+  echo "${script_name}: HCPPIPEDIR_PreFS: ${HCPPIPEDIR_PreFS}"
 fi
 
 # ------------------------------------------------------------------------------
@@ -209,22 +209,22 @@ source ${HCPPIPEDIR}/global/scripts/opts.shlib # Command line option functions
 # ------------------------------------------------------------------------------
 
 show_usage() {
-	cat <<EOF
+  cat <<EOF
 
 PreFreeSurferPipeline.sh
 
 Usage: PreeFreeSurferPipeline.sh [options]
 
-  --path=<path>        Path to study data folder (required)
-					   Used with --subject input to create full path to root
-					   directory for all outputs generated as path/subject
-  --subject=<subject>  Subject ID (required)
-					   Used with --path input to create full path to root
-					   directory for all outputs generated as path/subject
-  --t1=<T1w images>    An @ symbol separated list of full paths to T1-weighted
-					   (T1w) structural images for the subject (required)
-  --t2=<T2w images>    An @ symbol separated list of full paths to T2-weighted
-					   (T2w) structural images for the subject (required)
+  --path=<path>                     Path to study data folder (required)
+                                    Used with --subject input to create full path to root
+                                    directory for all outputs generated as path/subject
+  --subject=<subject>               Subject ID (required)
+                                    Used with --path input to create full path to root
+                                    directory for all outputs generated as path/subject
+  --t1=<T1w images>                 An @ symbol separated list of full paths to T1-weighted
+                                    (T1w) structural images for the subject (required)
+  --t2=<T2w images>                 An @ symbol separated list of full paths to T2-weighted
+                                    (T2w) structural images for the subject (required)
   --t1template=<file path>          MNI T1w template
   --t1templatebrain=<file path>     Brain extracted MNI T1wTemplate
   --t1template2mm=<file path>       MNI 2mm T1wTemplate
@@ -238,21 +238,21 @@ Usage: PreeFreeSurferPipeline.sh [options]
   --fmapmag=<file path>             Siemens Gradient Echo Fieldmap magnitude file
   --fmapphase=<file path>           Siemens Gradient Echo Fieldmap phase file
   --fmapgeneralelectric=<file path> General Electric Gradient Echo Field Map file
-									Two volumes in one file
-									1. field map in deg
-									2. magnitude
+                                    Two volumes in one file
+                                    1. field map in deg
+                                    2. magnitude
   --echodiff=<delta TE>             Delta TE in ms for field map or "NONE" if
-									not used
+                                    not used
   --SEPhaseNeg={<file path>, NONE}  For spin echo field map, path to volume with
-									a negative phase encoding direction (LR in
-									HCP data), set to "NONE" if not using Spin
-									Echo Field Maps
+                                    a negative phase encoding direction (LR in
+                                    HCP data), set to "NONE" if not using Spin
+                                    Echo Field Maps
   --SEPhasePos={<file path>, NONE}  For spin echo field map, path to volume with
-									a positive phase encoding direction (RL in
-									HCP data), set to "NONE" if not using Spin
-									Echo Field Maps
+                                    a positive phase encoding direction (RL in
+                                    HCP data), set to "NONE" if not using Spin
+                                    Echo Field Maps
   --seechospacing=<seconds>         Effective Echo Spacing of Spin Echo Field Map,
-									(in seconds) or "NONE" if not used
+                                    (in seconds) or "NONE" if not used
   --seunwarpdir={x,y,NONE}          Phase encoding direction (according to the *voxel* axes)
              or={i,j,NONE}          of the spin echo field map. 
                                     (Only applies when using a spin echo field map.)
@@ -260,37 +260,42 @@ Usage: PreeFreeSurferPipeline.sh [options]
   --t2samplespacing=<seconds>       T2 image sample spacing, "NONE" if not used
   --unwarpdir={x,y,z,x-,y-,z-}      Readout direction of the T1w and T2w images (according to the *voxel axes)
            or={i,j,k,i-,j-,k-}      (Used with either a gradient echo field map 
-									or a spin echo field map)
+                                    or a spin echo field map)
   --gdcoeffs=<file path>            File containing gradient distortion
-									coefficients, Set to "NONE" to turn off
+                                    coefficients, Set to "NONE" to turn off
   --avgrdcmethod=<avgrdcmethod>     Averaging and readout distortion correction
-									method. See below for supported values.
+                                    method. See below for supported values.
+  --custombrain=(NONE|MASK|CUSTOM)  Whether to use a custom brain mask (MASK) the 
+                                    pre-existing custom brain images (CUSTOM)
+                                    or not (NONE)
 
-	  "${NONE_METHOD_OPT}"
-		 average any repeats with no readout distortion correction
+    "${NONE_METHOD_OPT}"
+     average any repeats with no readout distortion correction
 
-	  "${FIELDMAP_METHOD_OPT}"
-		 equivalent to "${SIEMENS_METHOD_OPT}" (see below)
-		 SiemensFieldMap is preferred. This option value is maintained for
-		 backward compatibility.
+    "${FIELDMAP_METHOD_OPT}"
+       equivalent to "${SIEMENS_METHOD_OPT}" (see below)
+       SiemensFieldMap is preferred. This option value is maintained for
+       backward compatibility.
 
-	  "${SPIN_ECHO_METHOD_OPT}"
-		 average any repeats and use Spin Echo Field Maps for readout
-		 distortion correction
+    "${SPIN_ECHO_METHOD_OPT}"
+       average any repeats and use Spin Echo Field Maps for readout
+       distortion correction
 
-	  "${GENERAL_ELECTRIC_METHOD_OPT}"
-		 average any repeats and use General Electric specific Gradient
-		 Echo Field Maps for readout distortion correction
+    "${GENERAL_ELECTRIC_METHOD_OPT}"
+       average any repeats and use General Electric specific Gradient
+       Echo Field Maps for readout distortion correction
 
-	  "${SIEMENS_METHOD_OPT}"
-		 average any repeats and use Siemens specific Gradient Echo
-		 Field Maps for readout distortion correction
+    "${SIEMENS_METHOD_OPT}"
+       average any repeats and use Siemens specific Gradient Echo
+       Field Maps for readout distortion correction
 
   --topupconfig=<file path>      Configuration file for topup or "NONE" if not
-								 used
+                 used
   --bfsigma=<value>              Bias Field Smoothing Sigma (optional)
+  --t1biascorrect=(YES|NONE)     Bias Field Correction for T1w image only (YES or NONE if not, YES default; optional)
+  --mppversion=(hcp|legacy)      Which version of MPP to use. ("hcp" is default, "legacy"; optional).
 EOF
-	exit 1
+  exit 1
 }
 
 # ------------------------------------------------------------------------------
@@ -305,7 +310,7 @@ log_SetToolName "PreFreeSurferPipeline.sh"
 opts_ShowVersionIfRequested $@
 
 if opts_CheckForHelpRequest $@; then
-	show_usage
+  show_usage
 fi
 
 log_Msg "Platform Information Follows: "
@@ -342,6 +347,12 @@ GradientDistortionCoeffs=`opts_GetOpt1 "--gdcoeffs" $@`
 AvgrdcSTRING=`opts_GetOpt1 "--avgrdcmethod" $@`
 TopupConfig=`opts_GetOpt1 "--topupconfig" $@`
 BiasFieldSmoothingSigma=`opts_GetOpt1 "--bfsigma" $@`
+T1wBiasCorrect=`opts_GetOpt1 "--t1biascorrect" $@`
+CustomBrain=`opts_GetOpt1 "--custombrain" $@`
+
+# Defaults
+CustomBrain=`opts_DefaultOpt $CustomBrain NONE`
+T1wBiasCorrect=`opts_DefaultOpt $T1wBiasCorrect YES`
 
 #NOTE: currently is only used in gradient distortion correction of spin echo fieldmaps to topup
 #not currently in usage, either, because of this very limited use
@@ -354,6 +365,72 @@ RUN=`opts_GetOpt1 "--printcom" $@`
 # Convert UseJacobian value to all lowercase (to allow the user the flexibility to use True, true, TRUE, False, False, false, etc.)
 UseJacobian="$(echo ${UseJacobian} | tr '[:upper:]' '[:lower:]')"
 UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
+
+
+# ------------------------------------------------------------------------------
+#  Check MMP Version
+# ------------------------------------------------------------------------------
+
+Compliance="hcp"
+MPPVersion=`opts_GetOpt1 "--mppversion" $@`
+MPPVersion=`opts_DefaultOpt $MPPVersion "hcp"`
+
+if [ "${MPPVersion}" = "legacy" ] ; then
+  log_Msg "Legacy Minimal Preprocessing Pipelines: PreFreeSurferPipeline v.XX"
+  log_Msg "NOTICE: You are using MPP version that enables processing of images that do not"
+  log_Msg "        conform to the HCP specification as described in Glasser et al. (2013)!"
+  log_Msg "        Be aware that if the HCP requirements are not met, the level of data quality"
+  log_Msg "        can not be guaranteed and the Glasser et al. (2013) paper should not be used"
+  log_Msg "        in support of this workflow. A mnauscript with comprehensive evaluation for"
+  log_Msg "        the Legacy MPP workflow is in active preparation and should be appropriately"
+  log_Msg "        cited when published."
+  log_Msg "        "
+  log_Msg "Checking available data and processing options"
+else
+  log_Msg "HCP Minimal Preprocessing Pipelines: PreFreeSurferPipeline v.XX"
+  log_Msg "Checking data compliance with HCP MPP"
+fi
+
+# -- T2w image
+
+if [ "${T2wInputImages}" = "NONE" ] ; then
+  log_Msg "-> T2w image not present (legacy)"
+  SkipT2wImage="YES"
+  Compliance="legacy"
+else
+  SkipT2wImage="NO"
+  log_Msg "-> T2w image present (HCP)"
+fi
+
+# -- Use of custom brain
+
+if [ ! "${CustomBrain}" = "NONE" ] ; then
+  log_Msg "-> Custom brain used: ${CustomBrain} (legacy)"
+  Compliance="legacy"
+else
+  log_Msg "-> No custom brain used (HCP)"
+fi
+
+# -- Final evaluation
+
+if [ "${MPPVersion}" = "legacy" ] ; then
+  if [ "${Compliance}" = "legacy" ] ; then
+    log_Msg "Processing will continue using Legacy MPP."
+  else
+    log_Msg "All conditions for the use of HCP MPP are met. Consider using HCP MPP instead of Legacy MPP."
+    log_Msg "Processing will continue using Legacy MPP."
+  fi
+else
+  if [ "${Compliance}" = "legacy" ] ; then
+    log_Msg "User requested HCP MPP. However, compliance check for use of HCP MPP failed."
+    log_Msg "Aborting execution."
+    exit 1
+  else
+    log_Msg "Conditions for the use of HCP MPP are met."
+    log_Msg "Processing will continue using HCP MPP."
+  fi
+fi
+
 
 # ------------------------------------------------------------------------------
 #  Show Command Line Options
@@ -390,6 +467,8 @@ log_Msg "AvgrdcSTRING: ${AvgrdcSTRING}"
 log_Msg "TopupConfig: ${TopupConfig}"
 log_Msg "BiasFieldSmoothingSigma: ${BiasFieldSmoothingSigma}"
 log_Msg "UseJacobian: ${UseJacobian}"
+log_Msg "T1wBiasCorrect: ${T1wBiasCorrect}"
+log_Msg "CustomBrain: ${CustomBrain}"
 
 # ------------------------------------------------------------------------------
 #  Show Environment Variables
@@ -422,18 +501,18 @@ T1wInputImages=`echo ${T1wInputImages} | sed 's/@/ /g'`
 T2wInputImages=`echo ${T2wInputImages} | sed 's/@/ /g'`
 
 if [ ! -e ${T1wFolder}/xfms ] ; then
-	log_Msg "mkdir -p ${T1wFolder}/xfms/"
-	mkdir -p ${T1wFolder}/xfms/
+  log_Msg "mkdir -p ${T1wFolder}/xfms/"
+  mkdir -p ${T1wFolder}/xfms/
 fi
 
 if [ ! -e ${T2wFolder}/xfms ] ; then
-	log_Msg "mkdir -p ${T2wFolder}/xfms/"
-	mkdir -p ${T2wFolder}/xfms/
+  log_Msg "mkdir -p ${T2wFolder}/xfms/"
+  mkdir -p ${T2wFolder}/xfms/
 fi
 
 if [ ! -e ${AtlasSpaceFolder}/xfms ] ; then
-	log_Msg "mkdir -p ${AtlasSpaceFolder}/xfms/"
-	mkdir -p ${AtlasSpaceFolder}/xfms/
+  log_Msg "mkdir -p ${AtlasSpaceFolder}/xfms/"
+  mkdir -p ${AtlasSpaceFolder}/xfms/
 fi
 
 log_Msg "POSIXLY_CORRECT="${POSIXLY_CORRECT}
@@ -452,253 +531,327 @@ log_Msg "POSIXLY_CORRECT="${POSIXLY_CORRECT}
 #  - Perform Brain Extraction(FNIRT-based Masking)
 # ------------------------------------------------------------------------------
 
-Modalities="T1w T2w"
+# --- skip if we have a custom brain
 
-for TXw in ${Modalities} ; do
-	log_Msg "Processing Modality: " $TXw
+if [ "$CustomBrain" = "NONE" ] ; then
 
-	# set up appropriate input variables
-	if [ $TXw = T1w ] ; then
-		TXwInputImages="${T1wInputImages}"
-		TXwFolder=${T1wFolder}
-		TXwImage=${T1wImage}
-		TXwTemplate=${T1wTemplate}
-		TXwTemplate2mm=${T1wTemplate2mm}
-	else
-		TXwInputImages="${T2wInputImages}"
-		TXwFolder=${T2wFolder}
-		TXwImage=${T2wImage}
-		TXwTemplate=${T2wTemplate}
-		TXwTemplate2mm=${T2wTemplate2mm}
-	fi
-	OutputTXwImageSTRING=""
+  Modalities="T1w T2w"
 
-	# Perform Gradient Nonlinearity Correction
+  for TXw in ${Modalities} ; do
+      log_Msg "Processing Modality: " $TXw
 
-	if [ ! $GradientDistortionCoeffs = "NONE" ] ; then
-		log_Msg "Performing Gradient Nonlinearity Correction"
+      # set up appropriate input variables
+      if [ $TXw = T1w ] ; then
+          TXwInputImages="${T1wInputImages}"
+          TXwFolder=${T1wFolder}
+          TXwImage=${T1wImage}
+          TXwTemplate=${T1wTemplate}
+          TXwTemplate2mm=${T1wTemplate2mm}
+      else
+          TXwInputImages="${T2wInputImages}"
+          TXwFolder=${T2wFolder}
+          TXwImage=${T2wImage}
+          TXwTemplate=${T2wTemplate}
+          TXwTemplate2mm=${T2wTemplate2mm}
+      fi
+      OutputTXwImageSTRING=""
 
-		i=1
-		for Image in $TXwInputImages ; do
-			wdir=${TXwFolder}/${TXwImage}${i}_GradientDistortionUnwarp
-			log_Msg "mkdir -p $wdir"
-			mkdir -p $wdir
-			# Make sure input axes are oriented the same as the templates
-			${RUN} ${FSLDIR}/bin/fslreorient2std $Image ${wdir}/${TXwImage}${i}
+      # skip modality if no image
 
-			${RUN} ${HCPPIPEDIR_Global}/GradientDistortionUnwarp.sh \
-				--workingdir=${wdir} \
-				--coeffs=$GradientDistortionCoeffs \
-				--in=${wdir}/${TXwImage}${i} \
-				--out=${TXwFolder}/${TXwImage}${i}_gdc \
-				--owarp=${TXwFolder}/xfms/${TXwImage}${i}_gdc_warp
-			OutputTXwImageSTRING="${OutputTXwImageSTRING}${TXwFolder}/${TXwImage}${i}_gdc "
-			i=$(($i+1))
-		done
+      if [ "${TXwInputImages}" = "NONE" ] ; then
+        continue
+      fi
 
-	else
-		log_Msg "NOT PERFORMING GRADIENT DISTORTION CORRECTION"
+      # Perform Gradient Nonlinearity Correction
 
-		i=1
-		for Image in $TXwInputImages ; do
-			${RUN} ${FSLDIR}/bin/fslreorient2std $Image ${TXwFolder}/${TXwImage}${i}_gdc
-			OutputTXwImageSTRING="${OutputTXwImageSTRING}${TXwFolder}/${TXwImage}${i}_gdc "
-			i=$(($i+1))
-		done
+      if [ ! $GradientDistortionCoeffs = "NONE" ] ; then
+        log_Msg "Performing Gradient Nonlinearity Correction"
 
-	fi
+        i=1
+        for Image in $TXwInputImages ; do
+          wdir=${TXwFolder}/${TXwImage}${i}_GradientDistortionUnwarp
+          log_Msg "mkdir -p $wdir"
+          mkdir -p $wdir
+          # Make sure input axes are oriented the same as the templates
+          ${RUN} ${FSLDIR}/bin/fslreorient2std $Image ${wdir}/${TXwImage}${i}
 
-	# Average Like (Same Modality) Scans
+          ${RUN} ${HCPPIPEDIR_Global}/GradientDistortionUnwarp.sh \
+            --workingdir=${wdir} \
+            --coeffs=$GradientDistortionCoeffs \
+            --in=${wdir}/${TXwImage}${i} \
+            --out=${TXwFolder}/${TXwImage}${i}_gdc \
+            --owarp=${TXwFolder}/xfms/${TXwImage}${i}_gdc_warp
+          OutputTXwImageSTRING="${OutputTXwImageSTRING}${TXwFolder}/${TXwImage}${i}_gdc "
+          i=$(($i+1))
+        done
 
-	if [ `echo $TXwInputImages | wc -w` -gt 1 ] ; then
-		log_Msg "Averaging ${TXw} Images"
-		log_Msg "mkdir -p ${TXwFolder}/Average${TXw}Images"
-		mkdir -p ${TXwFolder}/Average${TXw}Images
-		log_Msg "PERFORMING SIMPLE AVERAGING"
-		${RUN} ${HCPPIPEDIR_PreFS}/AnatomicalAverage.sh -o ${TXwFolder}/${TXwImage} -s ${TXwTemplate} -m ${TemplateMask} -n -w ${TXwFolder}/Average${TXw}Images --noclean -v -b $BrainSize $OutputTXwImageSTRING
-	else
-		log_Msg "Not Averaging ${TXw} Images"
-		log_Msg "ONLY ONE AVERAGE FOUND: COPYING"
-		${RUN} ${FSLDIR}/bin/imcp ${TXwFolder}/${TXwImage}1_gdc ${TXwFolder}/${TXwImage}
-	fi
+      else
+        log_Msg "NOT PERFORMING GRADIENT DISTORTION CORRECTION"
 
-	# ACPC align T1w or T2w image to specified MNI Template to create native volume space
-	log_Msg "Aligning ${TXw} image to ${TXwTemplate} to create native volume space"
-	log_Msg "mkdir -p ${TXwFolder}/ACPCAlignment"
-	mkdir -p ${TXwFolder}/ACPCAlignment
-	${RUN} ${HCPPIPEDIR_PreFS}/ACPCAlignment.sh \
-		--workingdir=${TXwFolder}/ACPCAlignment \
-		--in=${TXwFolder}/${TXwImage} \
-		--ref=${TXwTemplate} \
-		--out=${TXwFolder}/${TXwImage}_acpc \
-		--omat=${TXwFolder}/xfms/acpc.mat \
-		--brainsize=${BrainSize}
+        i=1
+        for Image in $TXwInputImages ; do
+          ${RUN} ${FSLDIR}/bin/fslreorient2std $Image ${TXwFolder}/${TXwImage}${i}_gdc
+          OutputTXwImageSTRING="${OutputTXwImageSTRING}${TXwFolder}/${TXwImage}${i}_gdc "
+          i=$(($i+1))
+        done
 
-	# Brain Extraction(FNIRT-based Masking)
-	log_Msg "Performing Brain Extraction using FNIRT-based Masking"
-	log_Msg "mkdir -p ${TXwFolder}/BrainExtraction_FNIRTbased"
-	mkdir -p ${TXwFolder}/BrainExtraction_FNIRTbased
-	${RUN} ${HCPPIPEDIR_PreFS}/BrainExtraction_FNIRTbased.sh \
-		--workingdir=${TXwFolder}/BrainExtraction_FNIRTbased \
-		--in=${TXwFolder}/${TXwImage}_acpc \
-		--ref=${TXwTemplate} \
-		--refmask=${TemplateMask} \
-		--ref2mm=${TXwTemplate2mm} \
-		--ref2mmmask=${Template2mmMask} \
-		--outbrain=${TXwFolder}/${TXwImage}_acpc_brain \
-		--outbrainmask=${TXwFolder}/${TXwImage}_acpc_brain_mask \
-		--fnirtconfig=${FNIRTConfig}
+      fi
 
-done
+      # Average Like (Same Modality) Scans
 
-# End of looping over modalities (T1w and T2w)
+      if [ `echo $TXwInputImages | wc -w` -gt 1 ] ; then
+        log_Msg "Averaging ${TXw} Images"
+        log_Msg "mkdir -p ${TXwFolder}/Average${TXw}Images"
+        mkdir -p ${TXwFolder}/Average${TXw}Images
+        log_Msg "PERFORMING SIMPLE AVERAGING"
+        ${RUN} ${HCPPIPEDIR_PreFS}/AnatomicalAverage.sh -o ${TXwFolder}/${TXwImage} -s ${TXwTemplate} -m ${TemplateMask} -n -w ${TXwFolder}/Average${TXw}Images --noclean -v -b $BrainSize $OutputTXwImageSTRING
+      else
+        log_Msg "Not Averaging ${TXw} Images"
+        log_Msg "ONLY ONE AVERAGE FOUND: COPYING"
+        ${RUN} ${FSLDIR}/bin/imcp ${TXwFolder}/${TXwImage}1_gdc ${TXwFolder}/${TXwImage}
+      fi
 
-# ------------------------------------------------------------------------------
-#  T2w to T1w Registration and Optional Readout Distortion Correction
-# ------------------------------------------------------------------------------
+      # ACPC align T1w or T2w image to specified MNI Template to create native volume space
+      log_Msg "Aligning ${TXw} image to ${TXwTemplate} to create native volume space"
+      log_Msg "mkdir -p ${TXwFolder}/ACPCAlignment"
+      mkdir -p ${TXwFolder}/ACPCAlignment
+      ${RUN} ${HCPPIPEDIR_PreFS}/ACPCAlignment.sh \
+        --workingdir=${TXwFolder}/ACPCAlignment \
+        --in=${TXwFolder}/${TXwImage} \
+        --ref=${TXwTemplate} \
+        --out=${TXwFolder}/${TXwImage}_acpc \
+        --omat=${TXwFolder}/xfms/acpc.mat \
+        --brainsize=${BrainSize}
 
-case $AvgrdcSTRING in
+      # Brain Extraction(FNIRT-based Masking)
+      log_Msg "Performing Brain Extraction using FNIRT-based Masking"
+      log_Msg "mkdir -p ${TXwFolder}/BrainExtraction_FNIRTbased"
+      mkdir -p ${TXwFolder}/BrainExtraction_FNIRTbased
+      ${RUN} ${HCPPIPEDIR_PreFS}/BrainExtraction_FNIRTbased.sh \
+        --workingdir=${TXwFolder}/BrainExtraction_FNIRTbased \
+        --in=${TXwFolder}/${TXwImage}_acpc \
+        --ref=${TXwTemplate} \
+        --refmask=${TemplateMask} \
+        --ref2mm=${TXwTemplate2mm} \
+        --ref2mmmask=${Template2mmMask} \
+        --outbrain=${TXwFolder}/${TXwImage}_acpc_brain \
+        --outbrainmask=${TXwFolder}/${TXwImage}_acpc_brain_mask \
+      --fnirtconfig=${FNIRTConfig}
 
-	${FIELDMAP_METHOD_OPT} | ${SPIN_ECHO_METHOD_OPT} | ${GENERAL_ELECTRIC_METHOD_OPT} | ${SIEMENS_METHOD_OPT})
+  done
 
-		log_Msg "Performing ${AvgrdcSTRING} Readout Distortion Correction"
-		wdir=${T2wFolder}/T2wToT1wDistortionCorrectAndReg
-		if [ -d ${wdir} ] ; then
-			# DO NOT change the following line to "rm -r ${wdir}" because the
-			# chances of something going wrong with that are much higher, and
-			# rm -r always needs to be treated with the utmost caution
-			rm -r ${T2wFolder}/T2wToT1wDistortionCorrectAndReg
-		fi
+  # End of looping over modalities (T1w and T2w)
 
-		log_Msg "mkdir -p ${wdir}"
-		mkdir -p ${wdir}
+  # ------------------------------------------------------------------------------
+  #  T2w to T1w Registration and Optional Readout Distortion Correction
+  # ------------------------------------------------------------------------------
 
-		${RUN} ${HCPPIPEDIR_PreFS}/T2wToT1wDistortionCorrectAndReg.sh \
-			--workingdir=${wdir} \
-			--t1=${T1wFolder}/${T1wImage}_acpc \
-			--t1brain=${T1wFolder}/${T1wImage}_acpc_brain \
-			--t2=${T2wFolder}/${T2wImage}_acpc \
-			--t2brain=${T2wFolder}/${T2wImage}_acpc_brain \
-			--fmapmag=${MagnitudeInputName} \
-			--fmapphase=${PhaseInputName} \
-			--fmapgeneralelectric=${GEB0InputName} \
-			--echodiff=${TE} \
-			--SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
-			--SEPhasePos=${SpinEchoPhaseEncodePositive} \
-			--seechospacing=${SEEchoSpacing} \
-			--seunwarpdir=${SEUnwarpDir} \
-			--t1sampspacing=${T1wSampleSpacing} \
-			--t2sampspacing=${T2wSampleSpacing} \
-			--unwarpdir=${UnwarpDir} \
-			--ot1=${T1wFolder}/${T1wImage}_acpc_dc \
-			--ot1brain=${T1wFolder}/${T1wImage}_acpc_dc_brain \
-			--ot1warp=${T1wFolder}/xfms/${T1wImage}_dc \
-			--ot2=${T1wFolder}/${T2wImage}_acpc_dc \
-			--ot2warp=${T1wFolder}/xfms/${T2wImage}_reg_dc \
-			--method=${AvgrdcSTRING} \
-			--topupconfig=${TopupConfig} \
-			--gdcoeffs=${GradientDistortionCoeffs} \
-			--usejacobian=${UseJacobian}
+  if [ "${T2wInputImages}" = "NONE" ] ; then
+    T2wImagePath="NONE"
+  else
+    T2wImagePath="${T2wFolder}/${T2wImage}_acpc"
+  fi
 
-		;;
+  case $AvgrdcSTRING in
 
-	*)
+    ${FIELDMAP_METHOD_OPT} | ${SPIN_ECHO_METHOD_OPT} | ${GENERAL_ELECTRIC_METHOD_OPT} | ${SIEMENS_METHOD_OPT})
 
-		log_Msg "NOT PERFORMING READOUT DISTORTION CORRECTION"
-		wdir=${T2wFolder}/T2wToT1wReg
-		if [ -e ${wdir} ] ; then
-			# DO NOT change the following line to "rm -r ${wdir}" because the
-			# chances of something going wrong with that are much higher, and
-			# rm -r always needs to be treated with the utmost caution
-			rm -r ${T2wFolder}/T2wToT1wReg
-		fi
+      log_Msg "Performing ${AvgrdcSTRING} Readout Distortion Correction"
+      wdir=${T2wFolder}/T2wToT1wDistortionCorrectAndReg
+      if [ -d ${wdir} ] ; then
+        # DO NOT change the following line to "rm -r ${wdir}" because the
+        # chances of something going wrong with that are much higher, and
+        # rm -r always needs to be treated with the utmost caution
+        rm -r ${T2wFolder}/T2wToT1wDistortionCorrectAndReg
+      fi
 
-		log_Msg "mkdir -p ${wdir}"
-		mkdir -p ${wdir}
+      log_Msg "mkdir -p ${wdir}"
+      mkdir -p ${wdir}
 
-		${RUN} ${HCPPIPEDIR_PreFS}/T2wToT1wReg.sh \
-			${wdir} \
-			${T1wFolder}/${T1wImage}_acpc \
-			${T1wFolder}/${T1wImage}_acpc_brain \
-			${T2wFolder}/${T2wImage}_acpc \
-			${T2wFolder}/${T2wImage}_acpc_brain \
-			${T1wFolder}/${T1wImage}_acpc_dc \
-			${T1wFolder}/${T1wImage}_acpc_dc_brain \
-			${T1wFolder}/xfms/${T1wImage}_dc \
-			${T1wFolder}/${T2wImage}_acpc_dc \
-			${T1wFolder}/xfms/${T2wImage}_reg_dc
+      ${RUN} ${HCPPIPEDIR_PreFS}/T2wToT1wDistortionCorrectAndReg.sh \
+        --workingdir=${wdir} \
+        --t1=${T1wFolder}/${T1wImage}_acpc \
+        --t1brain=${T1wFolder}/${T1wImage}_acpc_brain \
+        --t2=${T2wImagePath} \
+        --t2brain=${T2wFolder}/${T2wImage}_acpc_brain \
+        --fmapmag=${MagnitudeInputName} \
+        --fmapphase=${PhaseInputName} \
+        --fmapgeneralelectric=${GEB0InputName} \
+        --echodiff=${TE} \
+        --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
+        --SEPhasePos=${SpinEchoPhaseEncodePositive} \
+        --seechospacing=${SEEchoSpacing} \
+        --seunwarpdir=${SEUnwarpDir} \
+        --t1sampspacing=${T1wSampleSpacing} \
+        --t2sampspacing=${T2wSampleSpacing} \
+        --unwarpdir=${UnwarpDir} \
+        --ot1=${T1wFolder}/${T1wImage}_acpc_dc \
+        --ot1brain=${T1wFolder}/${T1wImage}_acpc_dc_brain \
+        --ot1warp=${T1wFolder}/xfms/${T1wImage}_dc \
+        --ot2=${T1wFolder}/${T2wImage}_acpc_dc \
+        --ot2warp=${T1wFolder}/xfms/${T2wImage}_reg_dc \
+        --method=${AvgrdcSTRING} \
+        --topupconfig=${TopupConfig} \
+        --gdcoeffs=${GradientDistortionCoeffs} \
+        --usejacobian=${UseJacobian} 
 
-esac
+      ;;
 
-# ------------------------------------------------------------------------------
-#  Bias Field Correction: Calculate bias field using square root of the product
-#  of T1w and T2w iamges.
-# ------------------------------------------------------------------------------
+    *)
 
-log_Msg "Performing Bias Field Correction"
-if [ ! -z ${BiasFieldSmoothingSigma} ] ; then
-	BiasFieldSmoothingSigma="--bfsigma=${BiasFieldSmoothingSigma}"
-fi
+      log_Msg "NOT PERFORMING READOUT DISTORTION CORRECTION"
+      wdir=${T2wFolder}/T2wToT1wReg
+      if [ -e ${wdir} ] ; then
+        # DO NOT change the following line to "rm -r ${wdir}" because the
+        # chances of something going wrong with that are much higher, and
+        # rm -r always needs to be treated with the utmost caution
+        rm -r ${T2wFolder}/T2wToT1wReg
+      fi
 
-log_Msg "mkdir -p ${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w"
-mkdir -p ${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w
+      log_Msg "mkdir -p ${wdir}"
+      mkdir -p ${wdir}
 
-${RUN} ${HCPPIPEDIR_PreFS}/BiasFieldCorrection_sqrtT1wXT1w.sh \
-	--workingdir=${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w \
-	--T1im=${T1wFolder}/${T1wImage}_acpc_dc \
-	--T1brain=${T1wFolder}/${T1wImage}_acpc_dc_brain \
-	--T2im=${T1wFolder}/${T2wImage}_acpc_dc \
-	--obias=${T1wFolder}/BiasField_acpc_dc \
-	--oT1im=${T1wFolder}/${T1wImage}_acpc_dc_restore \
-	--oT1brain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
-	--oT2im=${T1wFolder}/${T2wImage}_acpc_dc_restore \
-	--oT2brain=${T1wFolder}/${T2wImage}_acpc_dc_restore_brain \
-	${BiasFieldSmoothingSigma}
+      ${RUN} ${HCPPIPEDIR_PreFS}/T2wToT1wReg.sh \
+        ${wdir} \
+        ${T1wFolder}/${T1wImage}_acpc \
+        ${T1wFolder}/${T1wImage}_acpc_brain \
+        ${T2wImagePath} \
+        ${T2wFolder}/${T2wImage}_acpc_brain \
+        ${T1wFolder}/${T1wImage}_acpc_dc \
+        ${T1wFolder}/${T1wImage}_acpc_dc_brain \
+        ${T1wFolder}/xfms/${T1wImage}_dc \
+        ${T1wFolder}/${T2wImage}_acpc_dc \
+        ${T1wFolder}/xfms/${T2wImage}_reg_dc
 
-# ------------------------------------------------------------------------------
-# Create a one-step resampled version of the {T1w,T2w}_acpc_dc outputs
-# (applied after GDC, which we don't bundle in, because of the possible need
-# to average multiple T1/T2 inputs).
+  esac
 
-# This overwrites the {T1w,T2w}_acpc_dc outputs created above, and mimics what
-# occurs at the beginning of PostFreeSurfer/CreateMyelinMaps.sh.
-# Note that the CreateMyelinMaps equivalent is still needed though because
-# (1) T1w_acpc_dc_restore_brain is (re)generated with a better estimate of
-#     the brain mask, provided by FreeSurfer
-# (2) the entire set of T2w_acpc_dc outputs needs to be regenerated, using the
-#     refinement to the "T2wtoT1w" registration that FreeSurfer provides.
+  # ------------------------------------------------------------------------------
+  #  Bias Field Correction: Calculate bias field using square root of the product
+  #  of T1w and T2w iamges.
+  # ------------------------------------------------------------------------------
 
-# Just implement inline, rather than writing a separate script
-# Added 2/19/2019
-# ------------------------------------------------------------------------------
+  if [ ! "${T2wInputImages}" = "NONE" ] ; then
 
-log_Msg "Creating one-step resampled version of {T1w,T2w}_acpc_dc outputs"
+    log_Msg "Performing Bias Field Correction"
+    if [ ! -z ${BiasFieldSmoothingSigma} ] ; then
+      BiasFieldSmoothingSigma="--bfsigma=${BiasFieldSmoothingSigma}"
+    fi
 
-# T1w
-OutputOrigT1wToT1w=OrigT1w2T1w_PreFS  # Name for one-step resample warpfield
-convertwarp --relout --rel --ref=${T1wTemplate} --premat=${T1wFolder}/xfms/acpc.mat --warp1=${T1wFolder}/xfms/${T1wImage}_dc --out=${T1wFolder}/xfms/${OutputOrigT1wToT1w}
+    log_Msg "mkdir -p ${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w"
+    mkdir -p ${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w
 
-OutputT1wImage=${T1wFolder}/${T1wImage}_acpc_dc
-applywarp --rel --interp=spline -i ${T1wFolder}/${T1wImage} -r ${T1wTemplate} -w ${T1wFolder}/xfms/${OutputOrigT1wToT1w} -o ${OutputT1wImage}
-fslmaths ${OutputT1wImage} -abs ${OutputT1wImage} -odt float  # Use -abs (rather than '-thr 0') to avoid introducing zeros
-fslmaths ${OutputT1wImage} -div ${T1wFolder}/BiasField_acpc_dc ${OutputT1wImage}_restore
-fslmaths ${OutputT1wImage}_restore -mas ${T1wFolder}/${T1wImage}_acpc_dc_brain ${OutputT1wImage}_restore_brain
+    ${RUN} ${HCPPIPEDIR_PreFS}/BiasFieldCorrection_sqrtT1wXT1w.sh \
+      --workingdir=${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w \
+      --T1im=${T1wFolder}/${T1wImage}_acpc_dc \
+      --T1brain=${T1wFolder}/${T1wImage}_acpc_dc_brain \
+      --T2im=${T1wFolder}/${T2wImage}_acpc_dc \
+      --obias=${T1wFolder}/BiasField_acpc_dc \
+      --oT1im=${T1wFolder}/${T1wImage}_acpc_dc_restore \
+      --oT1brain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
+      --oT2im=${T1wFolder}/${T2wImage}_acpc_dc_restore \
+      --oT2brain=${T1wFolder}/${T2wImage}_acpc_dc_restore_brain \
+      ${BiasFieldSmoothingSigma}
 
-#T2w
-OutputOrigT2wToT1w=OrigT2w2T1w_PreFS  # Name for one-step resample warpfield
-convertwarp --relout --rel --ref=${T1wTemplate} --premat=${T2wFolder}/xfms/acpc.mat --warp1=${T1wFolder}/xfms/${T2wImage}_reg_dc --out=${T1wFolder}/xfms/${OutputOrigT2wToT1w}
+  else  # -- No T2w image
 
-OutputT2wImage=${T1wFolder}/${T2wImage}_acpc_dc
-applywarp --rel --interp=spline -i ${T2wFolder}/${T2wImage} -r ${T1wTemplate} -w ${T1wFolder}/xfms/${OutputOrigT2wToT1w} -o ${OutputT2wImage}
-fslmaths ${OutputT2wImage} -abs ${OutputT2wImage} -odt float  # Use -abs (rather than '-thr 0') to avoid introducing zeros
-fslmaths ${OutputT2wImage} -div ${T1wFolder}/BiasField_acpc_dc ${OutputT2wImage}_restore
-fslmaths ${OutputT2wImage}_restore -mas ${T1wFolder}/${T1wImage}_acpc_dc_brain ${OutputT2wImage}_restore_brain
+    if [ ! "${T1wBiasCorrect}" = "NONE" ] ; then
 
-# Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
-# i.e., whether the T1w/T2w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
-# or the PostFreeSurferPipeline versions
-OutputOrigT2wToT1wPostFS=OrigT2w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
-imrm ${OutputOrigT2wToT1wPostFS}
+      log_Msg "Performing Bias Field Correction on T1w image only"
+
+      if [ ! -z ${BiasFieldSmoothingSigma} ] ; then
+        BiasFieldSmoothingSigma="--bfsigma=${BiasFieldSmoothingSigma}"
+      fi
+
+      ${RUN} ${HCPPIPEDIR_PreFS}/BiasFieldCorrection_T1wOnly.sh \
+        --workingdir=${T1wFolder}/BiasFieldCorrection_T1wOnly \
+        --T1im=${T1wFolder}/${T1wImage}_acpc_dc \
+        --T1brain=${T1wFolder}/${T1wImage}_acpc_dc_brain \
+        --obias=${T1wFolder}/BiasField_acpc_dc \
+        --oT1im=${T1wFolder}/${T1wImage}_acpc_dc_restore \
+        --oT1brain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
+        ${BiasFieldSmoothingSigma}
+
+    else
+
+      log_Msg "Skipping Bias Field Correction of T1w image"
+
+      cp ${T1wFolder}/${T1wImage}_acpc_dc.nii.gz ${T1wFolder}/${T1wImage}_acpc_dc_restore.nii.gz
+      cp ${T1wFolder}/${T1wImage}_acpc_dc_brain.nii.gz ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain.nii.gz
+      fslmaths ${T1wFolder}/${T1wImage}_acpc_dc -div ${T1wFolder}/${T1wImage}_acpc_dc ${T1wFolder}/BiasField_acpc_dc
+
+    fi
+
+  fi
+
+
+  # ------------------------------------------------------------------------------
+  # Create a one-step resampled version of the {T1w,T2w}_acpc_dc outputs
+  # (applied after GDC, which we don't bundle in, because of the possible need
+  # to average multiple T1/T2 inputs).
+
+  # This overwrites the {T1w,T2w}_acpc_dc outputs created above, and mimics what
+  # occurs at the beginning of PostFreeSurfer/CreateMyelinMaps.sh.
+  # Note that the CreateMyelinMaps equivalent is still needed though because
+  # (1) T1w_acpc_dc_restore_brain is (re)generated with a better estimate of
+  #     the brain mask, provided by FreeSurfer
+  # (2) the entire set of T2w_acpc_dc outputs needs to be regenerated, using the
+  #     refinement to the "T2wtoT1w" registration that FreeSurfer provides.
+
+  # Just implement inline, rather than writing a separate script
+  # Added 2/19/2019
+  # ------------------------------------------------------------------------------
+
+  log_Msg "Creating one-step resampled version of {T1w,T2w}_acpc_dc outputs"
+
+  # T1w
+  OutputOrigT1wToT1w=OrigT1w2T1w_PreFS  # Name for one-step resample warpfield
+  convertwarp --relout --rel --ref=${T1wTemplate} --premat=${T1wFolder}/xfms/acpc.mat --warp1=${T1wFolder}/xfms/${T1wImage}_dc --out=${T1wFolder}/xfms/${OutputOrigT1wToT1w}
+
+  OutputT1wImage=${T1wFolder}/${T1wImage}_acpc_dc
+  applywarp --rel --interp=spline -i ${T1wFolder}/${T1wImage} -r ${T1wTemplate} -w ${T1wFolder}/xfms/${OutputOrigT1wToT1w} -o ${OutputT1wImage}
+  fslmaths ${OutputT1wImage} -abs ${OutputT1wImage} -odt float  # Use -abs (rather than '-thr 0') to avoid introducing zeros
+  fslmaths ${OutputT1wImage} -div ${T1wFolder}/BiasField_acpc_dc ${OutputT1wImage}_restore
+  fslmaths ${OutputT1wImage}_restore -mas ${T1wFolder}/${T1wImage}_acpc_dc_brain ${OutputT1wImage}_restore_brain
+
+  if [ ! "${T2wInputImages}" = "NONE" ] ; then
+    OutputOrigT2wToT1w=OrigT2w2T1w_PreFS  # Name for one-step resample warpfield
+    convertwarp --relout --rel --ref=${T1wTemplate} --premat=${T2wFolder}/xfms/acpc.mat --warp1=${T1wFolder}/xfms/${T2wImage}_reg_dc --out=${T1wFolder}/xfms/${OutputOrigT2wToT1w}
+
+    OutputT2wImage=${T1wFolder}/${T2wImage}_acpc_dc
+    applywarp --rel --interp=spline -i ${T2wFolder}/${T2wImage} -r ${T1wTemplate} -w ${T1wFolder}/xfms/${OutputOrigT2wToT1w} -o ${OutputT2wImage}
+    fslmaths ${OutputT2wImage} -abs ${OutputT2wImage} -odt float  # Use -abs (rather than '-thr 0') to avoid introducing zeros
+    fslmaths ${OutputT2wImage} -div ${T1wFolder}/BiasField_acpc_dc ${OutputT2wImage}_restore
+    fslmaths ${OutputT2wImage}_restore -mas ${T1wFolder}/${T1wImage}_acpc_dc_brain ${OutputT2wImage}_restore_brain
+
+    # Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
+    # i.e., whether the T1w/T2w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
+    # or the PostFreeSurferPipeline versions
+    OutputOrigT2wToT1wPostFS=OrigT2w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
+    imrm ${OutputOrigT2wToT1wPostFS}
+  fi
+
+
+# -- Are we using a custom mask?
+
+elif [ "$CustomBrain" = "MASK" ] ; then
+
+  log_Msg "Skipping all the steps to Atlas registration, applying custom mask."
+  ceho "---> Applying custom mask"
+
+  ${FSLDIR}/bin/fslmaths ${T1wFolder}/${T1wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain
+
+  if [ ! "${T2wInputImages}" = "NONE" ] ; then
+    ${FSLDIR}/bin/fslmaths ${T1wFolder}/${T2wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T2wImage}_acpc_dc_restore_brain
+  fi
+
+# -- Then we are using existing images
+
+else
+
+  log_Msg "Skipping all the steps to Atlas registration, using existing images."
+  ceho "---> Using existing images"
+
+fi  # --- skipped to here if we are using custom brain
 
 # ------------------------------------------------------------------------------
 #  Atlas Registration to MNI152: FLIRT + FNIRT
@@ -708,30 +861,37 @@ imrm ${OutputOrigT2wToT1wPostFS}
 #  so, the primary purpose of the following is to generate the Atlas Registration itself).
 # ------------------------------------------------------------------------------
 
+if [ ! "${T2wInputImages}" = "NONE" ] ; then
+  t2status="RUN"
+else
+  t2status="SKIP"
+fi
+
 log_Msg "Performing Atlas Registration to MNI152 (FLIRT and FNIRT)"
 
 ${RUN} ${HCPPIPEDIR_PreFS}/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh \
-	--workingdir=${AtlasSpaceFolder} \
-	--t1=${T1wFolder}/${T1wImage}_acpc_dc \
-	--t1rest=${T1wFolder}/${T1wImage}_acpc_dc_restore \
-	--t1restbrain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
-	--t2=${T1wFolder}/${T2wImage}_acpc_dc \
-	--t2rest=${T1wFolder}/${T2wImage}_acpc_dc_restore \
-	--t2restbrain=${T1wFolder}/${T2wImage}_acpc_dc_restore_brain \
-	--ref=${T1wTemplate} \
-	--refbrain=${T1wTemplateBrain} \
-	--refmask=${TemplateMask} \
-	--ref2mm=${T1wTemplate2mm} \
-	--ref2mmmask=${Template2mmMask} \
-	--owarp=${AtlasSpaceFolder}/xfms/acpc_dc2standard.nii.gz \
-	--oinvwarp=${AtlasSpaceFolder}/xfms/standard2acpc_dc.nii.gz \
-	--ot1=${AtlasSpaceFolder}/${T1wImage} \
-	--ot1rest=${AtlasSpaceFolder}/${T1wImage}_restore \
-	--ot1restbrain=${AtlasSpaceFolder}/${T1wImage}_restore_brain \
-	--ot2=${AtlasSpaceFolder}/${T2wImage} \
-	--ot2rest=${AtlasSpaceFolder}/${T2wImage}_restore \
-	--ot2restbrain=${AtlasSpaceFolder}/${T2wImage}_restore_brain \
-	--fnirtconfig=${FNIRTConfig}
+  --workingdir=${AtlasSpaceFolder} \
+  --t1=${T1wFolder}/${T1wImage}_acpc_dc \
+  --t1rest=${T1wFolder}/${T1wImage}_acpc_dc_restore \
+  --t1restbrain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
+  --t2=${T1wFolder}/${T2wImage}_acpc_dc \
+  --t2rest=${T1wFolder}/${T2wImage}_acpc_dc_restore \
+  --t2restbrain=${T1wFolder}/${T2wImage}_acpc_dc_restore_brain \
+  --ref=${T1wTemplate} \
+  --refbrain=${T1wTemplateBrain} \
+  --refmask=${TemplateMask} \
+  --ref2mm=${T1wTemplate2mm} \
+  --ref2mmmask=${Template2mmMask} \
+  --owarp=${AtlasSpaceFolder}/xfms/acpc_dc2standard.nii.gz \
+  --oinvwarp=${AtlasSpaceFolder}/xfms/standard2acpc_dc.nii.gz \
+  --ot1=${AtlasSpaceFolder}/${T1wImage} \
+  --ot1rest=${AtlasSpaceFolder}/${T1wImage}_restore \
+  --ot1restbrain=${AtlasSpaceFolder}/${T1wImage}_restore_brain \
+  --ot2=${AtlasSpaceFolder}/${T2wImage} \
+  --ot2rest=${AtlasSpaceFolder}/${T2wImage}_restore \
+  --ot2restbrain=${AtlasSpaceFolder}/${T2wImage}_restore_brain \
+  --fnirtconfig=${FNIRTConfig} \
+  --t2status=${t2status}
 
 log_Msg "Completed"
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -476,10 +476,14 @@ T2wInputImages=`echo ${T2wInputImages} | sed 's/@/ /g'`
 
 # -- Are T2w images available
 
-if [ ! "${T2wInputImages}" = "NONE" ] ; then
-  T2wAvailable="TRUE"
+if [ "${T2wInputImages}" = "NONE" ] ; then
+  T2wFolder_T2wImageWithPath_acpc="NONE"
+  T2wFolder_T2wImageWithPath_acpc_brain="NONE"
+  T1wFolder_T2wImageWithPath_acpc_dc="NONE"
 else
-  T2wAvailable="FALSE"
+  T2wFolder_T2wImageWithPath_acpc="${T2wFolder}/${T2wImage}_acpc"
+  T2wFolder_T2wImageWithPath_acpc_brain="${T2wFolder}/${T2wImage}_acpc_brain"
+  T1wFolder_T2wImageWithPath_acpc_dc=${T1wFolder}/${T2wImage}_acpc_dc
 fi
 
 if [ ! -e ${T1wFolder}/xfms ] ; then
@@ -650,8 +654,8 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --workingdir=${wdir} \
         --t1=${T1wFolder}/${T1wImage}_acpc \
         --t1brain=${T1wFolder}/${T1wImage}_acpc_brain \
-        --t2=${T2wFolder}/${T2wImage}_acpc \
-        --t2brain=${T2wFolder}/${T2wImage}_acpc_brain \
+        --t2=${T2wFolder_T2wImageWithPath_acpc} \
+        --t2brain=${T2wFolder_T2wImageWithPath_acpc_brain} \
         --fmapmag=${MagnitudeInputName} \
         --fmapphase=${PhaseInputName} \
         --fmapgeneralelectric=${GEB0InputName} \
@@ -671,8 +675,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --method=${AvgrdcSTRING} \
         --topupconfig=${TopupConfig} \
         --gdcoeffs=${GradientDistortionCoeffs} \
-        --usejacobian=${UseJacobian} \
-        --t2avail=${T2wAvailable}
+        --usejacobian=${UseJacobian} 
 
       ;;
 
@@ -694,14 +697,13 @@ if [ "$CustomBrain" = "NONE" ] ; then
         ${wdir} \
         ${T1wFolder}/${T1wImage}_acpc \
         ${T1wFolder}/${T1wImage}_acpc_brain \
-        ${T2wFolder}/${T2wImage}_acpc \
-        ${T2wFolder}/${T2wImage}_acpc_brain \
+        ${T2wFolder_T2wImageWithPath_acpc} \
+        ${T2wFolder_T2wImageWithPath_acpc_brain} \
         ${T1wFolder}/${T1wImage}_acpc_dc \
         ${T1wFolder}/${T1wImage}_acpc_dc_brain \
         ${T1wFolder}/xfms/${T1wImage}_dc \
         ${T1wFolder}/${T2wImage}_acpc_dc \
-        ${T1wFolder}/xfms/${T2wImage}_reg_dc \
-        ${T2wAvailable}
+        ${T1wFolder}/xfms/${T2wImage}_reg_dc 
 
   esac
 
@@ -724,7 +726,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
       --workingdir=${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w \
       --T1im=${T1wFolder}/${T1wImage}_acpc_dc \
       --T1brain=${T1wFolder}/${T1wImage}_acpc_dc_brain \
-      --T2im=${T1wFolder}/${T2wImage}_acpc_dc \
+      --T2im=${T1wFolder_T2wImageWithPath_acpc_dc} \
       --obias=${T1wFolder}/BiasField_acpc_dc \
       --oT1im=${T1wFolder}/${T1wImage}_acpc_dc_restore \
       --oT1brain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
@@ -836,7 +838,7 @@ ${RUN} ${HCPPIPEDIR_PreFS}/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh \
   --t1=${T1wFolder}/${T1wImage}_acpc_dc \
   --t1rest=${T1wFolder}/${T1wImage}_acpc_dc_restore \
   --t1restbrain=${T1wFolder}/${T1wImage}_acpc_dc_restore_brain \
-  --t2=${T1wFolder}/${T2wImage}_acpc_dc \
+  --t2=${T1wFolder_T2wImageWithPath_acpc_dc} \
   --t2rest=${T1wFolder}/${T2wImage}_acpc_dc_restore \
   --t2restbrain=${T1wFolder}/${T2wImage}_acpc_dc_restore_brain \
   --ref=${T1wTemplate} \
@@ -852,8 +854,7 @@ ${RUN} ${HCPPIPEDIR_PreFS}/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh \
   --ot2=${AtlasSpaceFolder}/${T2wImage} \
   --ot2rest=${AtlasSpaceFolder}/${T2wImage}_restore \
   --ot2restbrain=${AtlasSpaceFolder}/${T2wImage}_restore_brain \
-  --fnirtconfig=${FNIRTConfig} \
-  --t2avail=${T2wAvailable}
+  --fnirtconfig=${FNIRTConfig} 
 
 log_Msg "Completed"
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -268,8 +268,12 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       method. See below for supported values.
   [--custombrain=(NONE|MASK|CUSTOM)]  If PreFreeSurfer has been run before and you have created a custom
                                       brain mask saved as "<path>/T1w/custom_acpc_dc_restore_mask.nii.gz", specify "MASK". 
-                                      If PreFreeSurfer has been run before and you have created custom T1w images to
-                                      be used when peforming Atlas registration, specify "CUSTOM".
+                                      If PreFreeSurfer has been run before and you have created custom structural images, e.g.: 
+                                      - "<path>/T1w/T1w_acpc_dc_restore_brain.nii.gz"
+                                      - "<path>/T1w/T1w_acpc_dc_restore.nii.gz"
+                                      - "<path>/T1w/T2w_acpc_dc_restore_brain.nii.gz"
+                                      - "<path>/T1w/T2w_acpc_dc_restore.nii.gz"
+                                      to be used when peforming Atlas registration, specify "CUSTOM".
                                       When "MASK" or "CUSTOM" is specified, all the steps until Atlas registration 
                                       are skipped.
                                       If the parameter is ommited or set to NONE (the default), 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -790,13 +790,13 @@ if [ "$CustomBrain" = "NONE" ] ; then
     fslmaths ${OutputT2wImage} -abs ${OutputT2wImage} -odt float  # Use -abs (rather than '-thr 0') to avoid introducing zeros
     fslmaths ${OutputT2wImage} -div ${T1wFolder}/BiasField_acpc_dc ${OutputT2wImage}_restore
     fslmaths ${OutputT2wImage}_restore -mas ${T1wFolder}/${T1wImage}_acpc_dc_brain ${OutputT2wImage}_restore_brain
-
-    # Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
-    # i.e., whether the T1w/T2w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
-    # or the PostFreeSurferPipeline versions
-    OutputOrigT2wToT1wPostFS=OrigT2w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
-    imrm ${OutputOrigT2wToT1wPostFS}
   fi
+
+  # Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
+  # i.e., whether the T1w/T1w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
+  # or the PostFreeSurferPipeline versions
+  OutputOrigT1wToT1wPostFS=OrigT1w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
+  imrm ${OutputOrigT1wToT1wPostFS}
 
 
 # -- Are we using a custom mask?

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -302,11 +302,12 @@ Usage: PreeFreeSurferPipeline.sh [options]
 
   --topupconfig=<file path>           Configuration file for topup or "NONE" if not used
   [--bfsigma=<value>]                 Bias Field Smoothing Sigma (optional)
-  [--mpp-mode=(HCPStyleData|          Which version of MPP to use. "HCPStyleData" (the default) requires the data and follows
-               LegacyStyleData)]      the steps described in Glasser et al. (2013). "LegacyStyleData" allows additional 
-                                      functionality and working with data that does not conform to standards described in
-                                      Glasser et al. (2013), e.g. missing high-resolution T2w image, missing field maps
-                                      for distortion correction, etc.
+  [--mpp-mode=(HCPStyleData|          Which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps
+               LegacyStyleData)]      described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. 
+                                      "LegacyStyleData" allows additional processing functionality and use of some acquisitions 
+                                      that do not conform to 'HCP-Style' expectations:
+                                      - missing high-resolution T2w image, 
+                                      - use of custom adjusted brain images or custom adjusted brain mask.
 EOF
   exit 1
 }

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -313,7 +313,7 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                          and requires 'HCP-Style' data acquistion. 
                                       "LegacyStyleData" allows additional processing functionality and use of some acquisitions
                                          that do not conform to 'HCP-Style' expectations.
-                                         i.e., in this case no high-resolution T2w image acquisition
+                                         In this script, it allows not having a high-resolution T2w image.
 EOF
   exit 1
 }

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -363,20 +363,19 @@ TopupConfig=`opts_GetOpt1 "--topupconfig" $@`
 BiasFieldSmoothingSigma=`opts_GetOpt1 "--bfsigma" $@`
 CustomBrain=`opts_GetOpt1 "--custombrain" $@`
 
-# Defaults
-CustomBrain=`opts_DefaultOpt $CustomBrain NONE`
-
 #NOTE: currently is only used in gradient distortion correction of spin echo fieldmaps to topup
 #not currently in usage, either, because of this very limited use
 UseJacobian=`opts_GetOpt1 "--usejacobian" $@`
+# Convert UseJacobian value to all lowercase (to allow the user the flexibility to use True, true, TRUE, False, False, false, etc.)
+UseJacobian="$(echo ${UseJacobian} | tr '[:upper:]' '[:lower:]')"
 
 # Use --printcom=echo for just printing everything and not actually
 # running the commands (the default is to actually run the commands)
 RUN=`opts_GetOpt1 "--printcom" $@`
 
-# Convert UseJacobian value to all lowercase (to allow the user the flexibility to use True, true, TRUE, False, False, false, etc.)
-UseJacobian="$(echo ${UseJacobian} | tr '[:upper:]' '[:lower:]')"
+# Defaults
 UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
+CustomBrain=`opts_DefaultOpt $CustomBrain NONE`
 
 
 # ------------------------------------------------------------------------------
@@ -442,6 +441,7 @@ log_Msg "BiasFieldSmoothingSigma: ${BiasFieldSmoothingSigma}"
 log_Msg "UseJacobian: ${UseJacobian}"
 log_Msg "T1wBiasCorrect: ${T1wBiasCorrect}"
 log_Msg "CustomBrain: ${CustomBrain}"
+log_Msg "MPPMode: ${MPPMode}"
 
 # ------------------------------------------------------------------------------
 #  Show Environment Variables
@@ -517,7 +517,8 @@ log_Msg "POSIXLY_CORRECT="${POSIXLY_CORRECT}
 #  - Perform Brain Extraction(FNIRT-based Masking)
 # ------------------------------------------------------------------------------
 
-# --- skip if we have a custom brain
+# NOTE: We skip all the way to AtlasRegistration (last step) if using a custom 
+# brain mask or custom structural images ($CustomBrain={MASK|CUSTOM})
 
 if [ "$CustomBrain" = "NONE" ] ; then
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -806,20 +806,20 @@ elif [ "$CustomBrain" = "MASK" ] ; then
   log_Msg "Skipping all the steps to Atlas registration, applying custom mask."
   verbose_red_echo "---> Applying custom mask"
 
-  ${FSLDIR}/bin/fslmaths ${T1wFolder}/${T1wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain
+  fslmaths ${T1wFolder}/${T1wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain
 
   if [ ! "${T2wInputImages}" = "NONE" ] ; then
-    ${FSLDIR}/bin/fslmaths ${T1wFolder}/${T2wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T2wImage}_acpc_dc_restore_brain
+    fslmaths ${T1wFolder}/${T2wImage}_acpc_dc_restore -mas ${T1wFolder}/custom_acpc_dc_restore_mask ${T1wFolder}/${T2wImage}_acpc_dc_restore_brain
   fi
 
 # -- Then we are using existing images
 
 else
 
-  log_Msg "Skipping all the steps to Atlas registration, using existing images."
+  log_Msg "Skipping all the steps preceding AtlasRegistration, using existing images instead."
   verbose_red_echo "---> Using existing images"
 
-fi  # --- skipped to here if we are using custom brain
+fi  # --- skipped all the way to here if using customized structural images (--custombrain=CUSTOM)
 
 # ------------------------------------------------------------------------------
 #  Atlas Registration to MNI152: FLIRT + FNIRT

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -713,14 +713,15 @@ if [ "$CustomBrain" = "NONE" ] ; then
   #  Otherwise (if only T1w available), calculate bias field using 'fsl_anat'
   # ------------------------------------------------------------------------------
 
+  if [ ! -z ${BiasFieldSmoothingSigma} ] ; then
+    BiasFieldSmoothingSigma="--bfsigma=${BiasFieldSmoothingSigma}"
+  fi
+
   if [ ! "${T2wInputImages}" = "NONE" ] ; then
 
-    log_Msg "Performing Bias Field Correction"
-    if [ ! -z ${BiasFieldSmoothingSigma} ] ; then
-      BiasFieldSmoothingSigma="--bfsigma=${BiasFieldSmoothingSigma}"
-    fi
-
+    log_Msg "Performing Bias Field Correction using sqrt(T1w x T2w)"    
     log_Msg "mkdir -p ${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w"
+
     mkdir -p ${T1wFolder}/BiasFieldCorrection_sqrtT1wXT1w
 
     ${RUN} ${HCPPIPEDIR_PreFS}/BiasFieldCorrection_sqrtT1wXT1w.sh \
@@ -737,11 +738,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
 
   else  # -- No T2w image
 
-    log_Msg "Performing Bias Field Correction on T1w image only"
-
-    if [ ! -z ${BiasFieldSmoothingSigma} ] ; then
-      BiasFieldSmoothingSigma="--bfsigma=${BiasFieldSmoothingSigma}"
-    fi
+    log_Msg "Performing Bias Field Correction using T1w image only"
 
     ${RUN} ${HCPPIPEDIR_PreFS}/BiasFieldCorrection_T1wOnly.sh \
       --workingdir=${T1wFolder}/BiasFieldCorrection_T1wOnly \

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -301,7 +301,7 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       When "MASK" or "CUSTOM" is specified, only the AtlasRegistration step is run.
                                       If the parameter is omitted or set to NONE (the default), 
                                       standard image processing will take place.
-  [--mpp-mode=(HCPStyleData|          Which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps
+  [--mpp-mode=(HCPStyleData|          Which variant of Minimal Preprocessing Pipelines (MPP) to use. "HCPStyleData" (the default) follows the processing steps
                LegacyStyleData)]      described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. 
                                       "LegacyStyleData" allows additional processing functionality and use of some acquisitions 
                                       that do not conform to 'HCP-Style' expectations i.e., in this case:

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -215,59 +215,65 @@ PreFreeSurferPipeline.sh
 
 Usage: PreeFreeSurferPipeline.sh [options]
 
-  --path=<path>                     Path to study data folder (required)
-                                    Used with --subject input to create full path to root
-                                    directory for all outputs generated as path/subject
-  --subject=<subject>               Subject ID (required)
-                                    Used with --path input to create full path to root
-                                    directory for all outputs generated as path/subject
-  --t1=<T1w images>                 An @ symbol separated list of full paths to T1-weighted
-                                    (T1w) structural images for the subject (required)
-  --t2=<T2w images>                 An @ symbol separated list of full paths to T2-weighted
-                                    (T2w) structural images for the subject (required)
-  --t1template=<file path>          MNI T1w template
-  --t1templatebrain=<file path>     Brain extracted MNI T1wTemplate
-  --t1template2mm=<file path>       MNI 2mm T1wTemplate
-  --t2template=<file path>          MNI T2w template
-  --t2templatebrain=<file path>     Brain extracted MNI T2wTemplate
-  --t2template2mm=<file path>       MNI 2mm T2wTemplate
-  --templatemask=<file path>        Brain mask MNI Template
-  --template2mmmask=<file path>     Brain mask MNI 2mm Template
-  --brainsize=<size value>          Brain size estimate in mm, 150 for humans
-  --fnirtconfig=<file path>         FNIRT 2mm T1w Configuration file
-  --fmapmag=<file path>             Siemens Gradient Echo Fieldmap magnitude file
-  --fmapphase=<file path>           Siemens Gradient Echo Fieldmap phase file
-  --fmapgeneralelectric=<file path> General Electric Gradient Echo Field Map file
-                                    Two volumes in one file
-                                    1. field map in deg
-                                    2. magnitude
-  --echodiff=<delta TE>             Delta TE in ms for field map or "NONE" if
-                                    not used
-  --SEPhaseNeg={<file path>, NONE}  For spin echo field map, path to volume with
-                                    a negative phase encoding direction (LR in
-                                    HCP data), set to "NONE" if not using Spin
-                                    Echo Field Maps
-  --SEPhasePos={<file path>, NONE}  For spin echo field map, path to volume with
-                                    a positive phase encoding direction (RL in
-                                    HCP data), set to "NONE" if not using Spin
-                                    Echo Field Maps
-  --seechospacing=<seconds>         Effective Echo Spacing of Spin Echo Field Map,
-                                    (in seconds) or "NONE" if not used
-  --seunwarpdir={x,y,NONE}          Phase encoding direction (according to the *voxel* axes)
-             or={i,j,NONE}          of the spin echo field map. 
-                                    (Only applies when using a spin echo field map.)
-  --t1samplespacing=<seconds>       T1 image sample spacing, "NONE" if not used
-  --t2samplespacing=<seconds>       T2 image sample spacing, "NONE" if not used
-  --unwarpdir={x,y,z,x-,y-,z-}      Readout direction of the T1w and T2w images (according to the *voxel axes)
-           or={i,j,k,i-,j-,k-}      (Used with either a gradient echo field map 
-                                    or a spin echo field map)
-  --gdcoeffs=<file path>            File containing gradient distortion
-                                    coefficients, Set to "NONE" to turn off
-  --avgrdcmethod=<avgrdcmethod>     Averaging and readout distortion correction
-                                    method. See below for supported values.
-  --custombrain=(NONE|MASK|CUSTOM)  Whether to use a custom brain mask (MASK) the 
-                                    pre-existing custom brain images (CUSTOM)
-                                    or not (NONE)
+  --path=<path>                       Path to study data folder (required)
+                                      Used with --subject input to create full path to root
+                                      directory for all outputs generated as path/subject
+  --subject=<subject>                 Subject ID (required)
+                                      Used with --path input to create full path to root
+                                      directory for all outputs generated as path/subject
+  --t1=<T1w images>                   An @ symbol separated list of full paths to T1-weighted
+                                      (T1w) structural images for the subject (required)
+  --t2=<T2w images>                   An @ symbol separated list of full paths to T2-weighted
+                                      (T2w) structural images for the subject (required)
+  --t1template=<file path>            MNI T1w template
+  --t1templatebrain=<file path>       Brain extracted MNI T1wTemplate
+  --t1template2mm=<file path>         MNI 2mm T1wTemplate
+  --t2template=<file path>            MNI T2w template
+  --t2templatebrain=<file path>       Brain extracted MNI T2wTemplate
+  --t2template2mm=<file path>         MNI 2mm T2wTemplate
+  --templatemask=<file path>          Brain mask MNI Template
+  --template2mmmask=<file path>       Brain mask MNI 2mm Template
+  --brainsize=<size value>            Brain size estimate in mm, 150 for humans
+  --fnirtconfig=<file path>           FNIRT 2mm T1w Configuration file
+  --fmapmag=<file path>               Siemens Gradient Echo Fieldmap magnitude file
+  --fmapphase=<file path>             Siemens Gradient Echo Fieldmap phase file
+  --fmapgeneralelectric=<file path>   General Electric Gradient Echo Field Map file
+                                      Two volumes in one file
+                                      1. field map in deg
+                                      2. magnitude
+  --echodiff=<delta TE>               Delta TE in ms for field map or "NONE" if
+                                      not used
+  --SEPhaseNeg={<file path>, NONE}    For spin echo field map, path to volume with
+                                      a negative phase encoding direction (LR in
+                                      HCP data), set to "NONE" if not using Spin
+                                      Echo Field Maps
+  --SEPhasePos={<file path>, NONE}    For spin echo field map, path to volume with
+                                      a positive phase encoding direction (RL in
+                                      HCP data), set to "NONE" if not using Spin
+                                      Echo Field Maps
+  --seechospacing=<seconds>           Effective Echo Spacing of Spin Echo Field Map,
+                                      (in seconds) or "NONE" if not used
+  --seunwarpdir={x,y,NONE}            Phase encoding direction (according to the *voxel* axes)
+             or={i,j,NONE}            of the spin echo field map. 
+                                      (Only applies when using a spin echo field map.)
+  --t1samplespacing=<seconds>         T1 image sample spacing, "NONE" if not used
+  --t2samplespacing=<seconds>         T2 image sample spacing, "NONE" if not used
+  --unwarpdir={x,y,z,x-,y-,z-}        Readout direction of the T1w and T2w images (according to the *voxel axes)
+           or={i,j,k,i-,j-,k-}        (Used with either a gradient echo field map 
+                                      or a spin echo field map)
+  --gdcoeffs=<file path>              File containing gradient distortion
+                                      coefficients, Set to "NONE" to turn off
+  --avgrdcmethod=<avgrdcmethod>       Averaging and readout distortion correction
+                                      method. See below for supported values.
+  [--custombrain=(NONE|MASK|CUSTOM)]  If PreFreeSurfer has been run before and you have created a custom
+                                      brain mask saved as "<path>/T1w/custom_acpc_dc_restore_mask.nii.gz", specify "MASK". 
+                                      If PreFreeSurfer has been run before and you have created custom T1w images to
+                                      be used when peforming Atlas registration, specify "CUSTOM".
+                                      When "MASK" or "CUSTOM" is specified, all the steps until Atlas registration 
+                                      are skipped.
+                                      If the parameter is ommited or set to NONE (the default), 
+                                      standard image processing will take place.
+
 
     "${NONE_METHOD_OPT}"
      average any repeats with no readout distortion correction
@@ -289,11 +295,18 @@ Usage: PreeFreeSurferPipeline.sh [options]
        average any repeats and use Siemens specific Gradient Echo
        Field Maps for readout distortion correction
 
-  --topupconfig=<file path>      Configuration file for topup or "NONE" if not
-                 used
-  --bfsigma=<value>              Bias Field Smoothing Sigma (optional)
-  --t1biascorrect=(YES|NONE)     Bias Field Correction for T1w image only (YES or NONE if not, YES default; optional)
-  --mppversion=(hcp|legacy)      Which version of MPP to use. ("hcp" is default, "legacy"; optional).
+  --topupconfig=<file path>           Configuration file for topup or "NONE" if not used
+  [--bfsigma=<value>]                 Bias Field Smoothing Sigma (optional)
+  [--t1biascorrect=(YES|NO|NONE)]     Whether to run Bias Field Correction even when only T1w image 
+                                      is present (YES default; optional). NOTE that if set to NO or NONE, 
+                                      T1w_*_restore* images should be considered misnamed and 
+                                      ARE NOT bias field corrected. 
+                                      Also BiasField_acpc_dc.nii.gz IS NOT an estimate of the bias field.
+  [--mpp-mode=(standard|extended)]    Which version of MPP to use. "standard" (the default) requires the data and follows
+                                      the steps described in Glasser et al. (2013). "extended" allows additional 
+                                      functionality and working with data that does not conform to standards described in
+                                      Glasser et al. (2013), e.g. missing high-resolution T2w image, missing field maps
+                                      for distortion correction, etc.
 EOF
   exit 1
 }
@@ -371,63 +384,61 @@ UseJacobian=`opts_DefaultOpt $UseJacobian "true"`
 #  Check MMP Version
 # ------------------------------------------------------------------------------
 
-Compliance="hcp"
-MPPVersion=`opts_GetOpt1 "--mppversion" $@`
-MPPVersion=`opts_DefaultOpt $MPPVersion "hcp"`
+Compliance="standard"
+MPPVersion=`opts_GetOpt1 "--mpp-mode" $@`
+MPPVersion=`opts_DefaultOpt $MPPVersion "standard"`
 
-if [ "${MPPVersion}" = "legacy" ] ; then
-  log_Msg "Legacy Minimal Preprocessing Pipelines: PreFreeSurferPipeline v.XX"
+if [ "${MPPVersion}" = "extended" ] ; then
+  log_Msg "Extended Minimal Preprocessing Pipelines: PreFreeSurferPipeline"
   log_Msg "NOTICE: You are using MPP version that enables processing of images that do not"
   log_Msg "        conform to the HCP specification as described in Glasser et al. (2013)!"
   log_Msg "        Be aware that if the HCP requirements are not met, the level of data quality"
   log_Msg "        can not be guaranteed and the Glasser et al. (2013) paper should not be used"
-  log_Msg "        in support of this workflow. A mnauscript with comprehensive evaluation for"
-  log_Msg "        the Legacy MPP workflow is in active preparation and should be appropriately"
+  log_Msg "        in support of this workflow. A manuscript with comprehensive evaluation for"
+  log_Msg "        the Extended MPP workflow is in active preparation and should be appropriately"
   log_Msg "        cited when published."
   log_Msg "        "
   log_Msg "Checking available data and processing options"
 else
-  log_Msg "HCP Minimal Preprocessing Pipelines: PreFreeSurferPipeline v.XX"
+  log_Msg "HCP Minimal Preprocessing Pipelines: PreFreeSurferPipeline"
   log_Msg "Checking data compliance with HCP MPP"
 fi
 
 # -- T2w image
 
 if [ "${T2wInputImages}" = "NONE" ] ; then
-  log_Msg "-> T2w image not present (legacy)"
+  log_Msg "-> T2w image not present (extended)"
   SkipT2wImage="YES"
-  Compliance="legacy"
+  Compliance="extended"
 else
   SkipT2wImage="NO"
-  log_Msg "-> T2w image present (HCP)"
+  log_Msg "-> T2w image present (standard)"
 fi
 
 # -- Use of custom brain
 
 if [ ! "${CustomBrain}" = "NONE" ] ; then
-  log_Msg "-> Custom brain used: ${CustomBrain} (legacy)"
-  Compliance="legacy"
+  log_Msg "-> Custom brain used: ${CustomBrain} (extended)"
+  Compliance="extended"
 else
-  log_Msg "-> No custom brain used (HCP)"
+  log_Msg "-> No custom brain used (standard)"
 fi
 
 # -- Final evaluation
 
-if [ "${MPPVersion}" = "legacy" ] ; then
-  if [ "${Compliance}" = "legacy" ] ; then
-    log_Msg "Processing will continue using Legacy MPP."
+if [ "${MPPVersion}" = "extended" ] ; then
+  if [ "${Compliance}" = "extended" ] ; then
+    log_Msg "Processing will continue using Extended MPP mode."
   else
-    log_Msg "All conditions for the use of HCP MPP are met. Consider using HCP MPP instead of Legacy MPP."
-    log_Msg "Processing will continue using Legacy MPP."
+    log_Warn "All conditions for the use of Standard HCP MPP are met. Consider using Standard HCP MPP mode instead of Extended MPP mode."
+    log_Msg "Processing will continue using Exteneded MPP mode."
   fi
 else
-  if [ "${Compliance}" = "legacy" ] ; then
-    log_Msg "User requested HCP MPP. However, compliance check for use of HCP MPP failed."
-    log_Msg "Aborting execution."
-    exit 1
+  if [ "${Compliance}" = "extended" ] ; then
+    log_Err_Abort "User requested Standard HCP MPP mode. However, compliance check for use of Standard HCP MPP mode failed."
   else
-    log_Msg "Conditions for the use of HCP MPP are met."
-    log_Msg "Processing will continue using HCP MPP."
+    log_Msg "Conditions for the use of Standard HCP MPP mode are met."
+    log_Msg "Processing will continue using Standard HCP MPP."
   fi
 fi
 
@@ -538,7 +549,15 @@ if [ "$CustomBrain" = "NONE" ] ; then
   Modalities="T1w T2w"
 
   for TXw in ${Modalities} ; do
-      log_Msg "Processing Modality: " $TXw
+
+      # skip modality if no image
+
+      if [ "${TXwInputImages}" = "NONE" ] ; then
+        log_Msg "Skipping Modality: " $TXw " - image not specified."
+        continue
+      else
+        log_Msg "Processing Modality: " $TXw
+      fi
 
       # set up appropriate input variables
       if [ $TXw = T1w ] ; then
@@ -555,12 +574,6 @@ if [ "$CustomBrain" = "NONE" ] ; then
           TXwTemplate2mm=${T2wTemplate2mm}
       fi
       OutputTXwImageSTRING=""
-
-      # skip modality if no image
-
-      if [ "${TXwInputImages}" = "NONE" ] ; then
-        continue
-      fi
 
       # Perform Gradient Nonlinearity Correction
 
@@ -646,12 +659,6 @@ if [ "$CustomBrain" = "NONE" ] ; then
   #  T2w to T1w Registration and Optional Readout Distortion Correction
   # ------------------------------------------------------------------------------
 
-  if [ "${T2wInputImages}" = "NONE" ] ; then
-    T2wImagePath="NONE"
-  else
-    T2wImagePath="${T2wFolder}/${T2wImage}_acpc"
-  fi
-
   case $AvgrdcSTRING in
 
     ${FIELDMAP_METHOD_OPT} | ${SPIN_ECHO_METHOD_OPT} | ${GENERAL_ELECTRIC_METHOD_OPT} | ${SIEMENS_METHOD_OPT})
@@ -672,7 +679,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --workingdir=${wdir} \
         --t1=${T1wFolder}/${T1wImage}_acpc \
         --t1brain=${T1wFolder}/${T1wImage}_acpc_brain \
-        --t2=${T2wImagePath} \
+        --t2=${T2wFolder}/${T2wImage}_acpc \
         --t2brain=${T2wFolder}/${T2wImage}_acpc_brain \
         --fmapmag=${MagnitudeInputName} \
         --fmapphase=${PhaseInputName} \
@@ -715,7 +722,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         ${wdir} \
         ${T1wFolder}/${T1wImage}_acpc \
         ${T1wFolder}/${T1wImage}_acpc_brain \
-        ${T2wImagePath} \
+        ${T2wFolder}/${T2wImage}_acpc \
         ${T2wFolder}/${T2wImage}_acpc_brain \
         ${T1wFolder}/${T1wImage}_acpc_dc \
         ${T1wFolder}/${T1wImage}_acpc_dc_brain \
@@ -773,7 +780,10 @@ if [ "$CustomBrain" = "NONE" ] ; then
 
     else
 
-      log_Msg "Skipping Bias Field Correction of T1w image"
+      log_Warn "Skipping Bias Field Correction of T1w image"
+      log_Warn "As Bias Field Correction is skipped note that:"
+      log_Warn "${T1wImage}_acpc_dc_restore* images should be considered misnamed and ARE NOT bias field corrected!"
+      log_Warn "${T1wFolder}/BiasField_acpc_dc IS NOT an estimate of the bias field!"
 
       cp ${T1wFolder}/${T1wImage}_acpc_dc.nii.gz ${T1wFolder}/${T1wImage}_acpc_dc_restore.nii.gz
       cp ${T1wFolder}/${T1wImage}_acpc_dc_brain.nii.gz ${T1wFolder}/${T1wImage}_acpc_dc_restore_brain.nii.gz
@@ -862,9 +872,9 @@ fi  # --- skipped to here if we are using custom brain
 # ------------------------------------------------------------------------------
 
 if [ ! "${T2wInputImages}" = "NONE" ] ; then
-  t2status="RUN"
+  t2avail="YES"
 else
-  t2status="SKIP"
+  t2avail="NO"
 fi
 
 log_Msg "Performing Atlas Registration to MNI152 (FLIRT and FNIRT)"
@@ -891,7 +901,7 @@ ${RUN} ${HCPPIPEDIR_PreFS}/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh \
   --ot2rest=${AtlasSpaceFolder}/${T2wImage}_restore \
   --ot2restbrain=${AtlasSpaceFolder}/${T2wImage}_restore_brain \
   --fnirtconfig=${FNIRTConfig} \
-  --t2status=${t2status}
+  --t2avail=${t2avail}
 
 log_Msg "Completed"
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -792,13 +792,6 @@ if [ "$CustomBrain" = "NONE" ] ; then
     fslmaths ${OutputT2wImage}_restore -mas ${T1wFolder}/${T1wImage}_acpc_dc_brain ${OutputT2wImage}_restore_brain
   fi
 
-  # Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
-  # i.e., whether the T1w/T1w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
-  # or the PostFreeSurferPipeline versions
-  OutputOrigT1wToT1wPostFS=OrigT1w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
-  imrm ${OutputOrigT1wToT1wPostFS}
-
-
 # -- Are we using a custom mask?
 
 elif [ "$CustomBrain" = "MASK" ] ; then
@@ -820,6 +813,13 @@ else
   verbose_red_echo "---> Using existing images"
 
 fi  # --- skipped all the way to here if using customized structural images (--custombrain=CUSTOM)
+
+# Remove the file (warpfield) that serves as a proxy in FreeSurferPipeline for whether PostFreeSurfer has been run
+# i.e., whether the T1w/T1w_acpc_dc* volumes reflect the PreFreeSurferPipeline versions (above)
+# or the PostFreeSurferPipeline versions
+OutputOrigT1wToT1wPostFS=OrigT1w2T1w  #Needs to match name used in both FreeSurferPipeline and PostFreeSurferPipeline
+imrm ${OutputOrigT1wToT1wPostFS}
+
 
 # ------------------------------------------------------------------------------
 #  Atlas Registration to MNI152: FLIRT + FNIRT

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -273,10 +273,10 @@ Usage: PreeFreeSurferPipeline.sh [options]
                                       - "<path>/T1w/T1w_acpc_dc_restore.nii.gz"
                                       - "<path>/T1w/T2w_acpc_dc_restore_brain.nii.gz"
                                       - "<path>/T1w/T2w_acpc_dc_restore.nii.gz"
-                                      to be used when peforming Atlas registration, specify "CUSTOM".
+                                      to be used when peforming MNI152 Atlas registration, specify "CUSTOM".
                                       When "MASK" or "CUSTOM" is specified, all the steps until Atlas registration 
                                       are skipped.
-                                      If the parameter is ommited or set to NONE (the default), 
+                                      If the parameter is omitted or set to NONE (the default), 
                                       standard image processing will take place.
 
 

--- a/PreFreeSurfer/scripts/ACPCAlignment.sh
+++ b/PreFreeSurfer/scripts/ACPCAlignment.sh
@@ -79,6 +79,10 @@ if [ X${BrainSizeOpt} != X ] ; then BrainSizeOpt="-b ${BrainSizeOpt}" ; fi
 
 log_Msg "START"
 
+verbose_echo " "
+verbose_red_echo " ===> Running AC-PC Alignment"
+verbose_echo " "
+
 mkdir -p $WD
 
 # Record the input options in a log file
@@ -90,22 +94,31 @@ echo " " >> $WD/log.txt
 ########################################## DO WORK ########################################## 
 
 # Crop the FOV
+verbose_echo " --> Croping the FOV"
 ${FSLDIR}/bin/robustfov -i "$Input" -m "$WD"/roi2full.mat -r "$WD"/robustroi.nii.gz $BrainSizeOpt
 
 # Invert the matrix (to get full FOV to ROI)
+verbose_echo " --> Inverting the matrix"
 ${FSLDIR}/bin/convert_xfm -omat "$WD"/full2roi.mat -inverse "$WD"/roi2full.mat
 
 # Register cropped image to MNI152 (12 DOF)
+verbose_echo " --> Registering cropped image to MNI152 (12 DOF)"
 ${FSLDIR}/bin/flirt -interp spline -in "$WD"/robustroi.nii.gz -ref "$Reference" -omat "$WD"/roi2std.mat -out "$WD"/acpc_final.nii.gz -searchrx -30 30 -searchry -30 30 -searchrz -30 30
 
 # Concatenate matrices to get full FOV to MNI
+verbose_echo " --> Concatenating matrices to get full FOV to MNI"
 ${FSLDIR}/bin/convert_xfm -omat "$WD"/full2std.mat -concat "$WD"/roi2std.mat "$WD"/full2roi.mat
 
 # Get a 6 DOF approximation which does the ACPC alignment (AC, ACPC line, and hemispheric plane)
+verbose_echo " --> Geting a 6 DOF approximation"
 ${FSLDIR}/bin/aff2rigid "$WD"/full2std.mat "$OutputMatrix"
 
 # Create a resampled image (ACPC aligned) using spline interpolation
+verbose_echo " --> Creating a resampled image"
 ${FSLDIR}/bin/applywarp --rel --interp=spline -i "$Input" -r "$Reference" --premat="$OutputMatrix" -o "$Output"
+
+verbose_green_echo "---> Finished AC-PC Alignment"
+verbose_echo " "
 
 log_Msg "END"
 echo " END: `date`" >> $WD/log.txt

--- a/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
+++ b/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
@@ -51,7 +51,6 @@ Usage() {
   echo "                --ot2rest=<output bias corrected t2w to MNI>"
   echo "                --ot2restbrain=<output bias corrected, brain extracted t2w to MNI>"
   echo "                [--fnirtconfig=<FNIRT configuration file>]"
-  echo "                [--t2avail=<TRUE or FALSE>]"
 }
 
 # function for parsing options
@@ -113,15 +112,12 @@ OutputT2wImage=`getopt1 "--ot2" $@`  # "${18}"
 OutputT2wImageRestore=`getopt1 "--ot2rest" $@`  # "${19}"
 OutputT2wImageRestoreBrain=`getopt1 "--ot2restbrain" $@`  # "${20}"
 FNIRTConfig=`getopt1 "--fnirtconfig" $@`  # "${21}"
-T2wAvailable=`getopt1 "--t2avail" $@`  # "${22}"
 
 # default parameters
 WD=`defaultopt $WD .`
 Reference2mm=`defaultopt $Reference2mm ${HCPPIPEDIR_Templates}/MNI152_T1_2mm.nii.gz`
 Reference2mmMask=`defaultopt $Reference2mmMask ${HCPPIPEDIR_Templates}/MNI152_T1_2mm_brain_mask_dil.nii.gz`
 FNIRTConfig=`defaultopt $FNIRTConfig ${HCPPIPEDIR_Config}/T1_2_MNI152_2mm.cnf`
-T2wAvailable=`defaultopt $T2wAvailable TRUE`
-
 
 T1wRestoreBasename=`remove_ext $T1wRestore`;
 T1wRestoreBasename=`basename $T1wRestoreBasename`;
@@ -162,7 +158,7 @@ ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T1wRestoreBrain} -r ${Reference} 
 ${FSLDIR}/bin/fslmaths ${OutputT1wImageRestore} -mas ${OutputT1wImageRestoreBrain} ${OutputT1wImageRestoreBrain}
 
 # T2w set of warped outputs (brain/whole-head + restored/orig)
-if [ "${T2wAvailable}" = "TRUE" ] ; then
+if [ ! "${T2wImage}" = "NONE" ] ; then
   verbose_echo " --> Creating T2w set of warped outputs"
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wImage} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImage}
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wRestore} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImageRestore}

--- a/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
+++ b/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
@@ -51,7 +51,7 @@ Usage() {
   echo "                --ot2rest=<output bias corrected t2w to MNI>"
   echo "                --ot2restbrain=<output bias corrected, brain extracted t2w to MNI>"
   echo "                [--fnirtconfig=<FNIRT configuration file>]"
-  echo "                [--t2avail=<YES or NO>]"
+  echo "                [--t2avail=<TRUE or FALSE>]"
 }
 
 # function for parsing options
@@ -113,14 +113,14 @@ OutputT2wImage=`getopt1 "--ot2" $@`  # "${18}"
 OutputT2wImageRestore=`getopt1 "--ot2rest" $@`  # "${19}"
 OutputT2wImageRestoreBrain=`getopt1 "--ot2restbrain" $@`  # "${20}"
 FNIRTConfig=`getopt1 "--fnirtconfig" $@`  # "${21}"
-t2avail=`getopt1 "--t2avail" $@`  # "${22}"
+T2wAvailable=`getopt1 "--t2avail" $@`  # "${22}"
 
 # default parameters
 WD=`defaultopt $WD .`
 Reference2mm=`defaultopt $Reference2mm ${HCPPIPEDIR_Templates}/MNI152_T1_2mm.nii.gz`
 Reference2mmMask=`defaultopt $Reference2mmMask ${HCPPIPEDIR_Templates}/MNI152_T1_2mm_brain_mask_dil.nii.gz`
 FNIRTConfig=`defaultopt $FNIRTConfig ${HCPPIPEDIR_Config}/T1_2_MNI152_2mm.cnf`
-t2avail=`defaultopt $t2avail YES`
+T2wAvailable=`defaultopt $T2wAvailable TRUE`
 
 
 T1wRestoreBasename=`remove_ext $T1wRestore`;
@@ -162,7 +162,7 @@ ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T1wRestoreBrain} -r ${Reference} 
 ${FSLDIR}/bin/fslmaths ${OutputT1wImageRestore} -mas ${OutputT1wImageRestoreBrain} ${OutputT1wImageRestoreBrain}
 
 # T2w set of warped outputs (brain/whole-head + restored/orig)
-if [ "${t2avail}" = "YES" ] ; then
+if [ "${T2wAvailable}" = "TRUE" ] ; then
   verbose_echo " --> Creating T2w set of warped outputs"
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wImage} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImage}
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wRestore} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImageRestore}

--- a/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
+++ b/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
@@ -51,7 +51,7 @@ Usage() {
   echo "                --ot2rest=<output bias corrected t2w to MNI>"
   echo "                --ot2restbrain=<output bias corrected, brain extracted t2w to MNI>"
   echo "                [--fnirtconfig=<FNIRT configuration file>]"
-  echo "                [--t2status=<RUN or SKIP>]"
+  echo "                [--t2avail=<YES or NO>]"
 }
 
 # function for parsing options
@@ -113,14 +113,14 @@ OutputT2wImage=`getopt1 "--ot2" $@`  # "${18}"
 OutputT2wImageRestore=`getopt1 "--ot2rest" $@`  # "${19}"
 OutputT2wImageRestoreBrain=`getopt1 "--ot2restbrain" $@`  # "${20}"
 FNIRTConfig=`getopt1 "--fnirtconfig" $@`  # "${21}"
-t2status=`getopt1 "--t2status" $@`  # "${22}"
+t2avail=`getopt1 "--t2avail" $@`  # "${22}"
 
 # default parameters
 WD=`defaultopt $WD .`
 Reference2mm=`defaultopt $Reference2mm ${HCPPIPEDIR_Templates}/MNI152_T1_2mm.nii.gz`
 Reference2mmMask=`defaultopt $Reference2mmMask ${HCPPIPEDIR_Templates}/MNI152_T1_2mm_brain_mask_dil.nii.gz`
 FNIRTConfig=`defaultopt $FNIRTConfig ${HCPPIPEDIR_Config}/T1_2_MNI152_2mm.cnf`
-t2status=`defaultopt $t2status RUN`
+t2avail=`defaultopt $t2avail YES`
 
 
 T1wRestoreBasename=`remove_ext $T1wRestore`;
@@ -155,7 +155,7 @@ ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T1wRestoreBrain} -r ${Reference} 
 ${FSLDIR}/bin/fslmaths ${OutputT1wImageRestore} -mas ${OutputT1wImageRestoreBrain} ${OutputT1wImageRestoreBrain}
 
 # T2w set of warped outputs (brain/whole-head + restored/orig)
-if [ "${t2status}" = "RUN" ] ; then
+if [ "${t2avail}" = "YES" ] ; then
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wImage} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImage}
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wRestore} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImageRestore}
   ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T2wRestoreBrain} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImageRestoreBrain}

--- a/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
+++ b/PreFreeSurfer/scripts/AtlasRegistrationToMNI152_FLIRTandFNIRT.sh
@@ -130,6 +130,10 @@ T1wRestoreBrainBasename=`basename $T1wRestoreBrainBasename`;
 
 log_Msg "START: AtlasRegistration to MNI152"
 
+verbose_echo " "
+verbose_red_echo " ===> Running Atlas Registration to MNI152"
+verbose_echo " "
+
 mkdir -p $WD
 
 # Record the input options in a log file
@@ -141,14 +145,17 @@ echo " " >> $WD/xfms/log.txt
 ########################################## DO WORK ##########################################
 
 # Linear then non-linear registration to MNI
+verbose_echo " --> Linear then non-linear registration to MNI"
 ${FSLDIR}/bin/flirt -interp spline -dof 12 -in ${T1wRestoreBrain} -ref ${ReferenceBrain} -omat ${WD}/xfms/acpc2MNILinear.mat -out ${WD}/xfms/${T1wRestoreBrainBasename}_to_MNILinear
 
 ${FSLDIR}/bin/fnirt --in=${T1wRestore} --ref=${Reference2mm} --aff=${WD}/xfms/acpc2MNILinear.mat --refmask=${Reference2mmMask} --fout=${OutputTransform} --jout=${WD}/xfms/NonlinearRegJacobians.nii.gz --refout=${WD}/xfms/IntensityModulatedT1.nii.gz --iout=${WD}/xfms/2mmReg.nii.gz --logout=${WD}/xfms/NonlinearReg.txt --intout=${WD}/xfms/NonlinearIntensities.nii.gz --cout=${WD}/xfms/NonlinearReg.nii.gz --config=${FNIRTConfig}
 
 # Input and reference spaces are the same, using 2mm reference to save time
+verbose_echo " --> Computing 2mm warp"
 ${FSLDIR}/bin/invwarp -w ${OutputTransform} -o ${OutputInvTransform} -r ${Reference2mm}
 
 # T1w set of warped outputs (brain/whole-head + restored/orig)
+verbose_echo " --> Generarting T1w set of warped outputs"
 ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T1wImage} -r ${Reference} -w ${OutputTransform} -o ${OutputT1wImage}
 ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T1wRestore} -r ${Reference} -w ${OutputTransform} -o ${OutputT1wImageRestore}
 ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T1wRestoreBrain} -r ${Reference} -w ${OutputTransform} -o ${OutputT1wImageRestoreBrain}
@@ -156,13 +163,17 @@ ${FSLDIR}/bin/fslmaths ${OutputT1wImageRestore} -mas ${OutputT1wImageRestoreBrai
 
 # T2w set of warped outputs (brain/whole-head + restored/orig)
 if [ "${t2avail}" = "YES" ] ; then
+  verbose_echo " --> Creating T2w set of warped outputs"
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wImage} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImage}
   ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${T2wRestore} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImageRestore}
   ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T2wRestoreBrain} -r ${Reference} -w ${OutputTransform} -o ${OutputT2wImageRestoreBrain}
   ${FSLDIR}/bin/fslmaths ${OutputT2wImageRestore} -mas ${OutputT2wImageRestoreBrain} ${OutputT2wImageRestoreBrain}
 else
-  echo " ... skipping T2w processing"
+  verbose_echo " ... skipping T2w processing"
 fi
+
+verbose_green_echo "---> Finished Atlas Registration to MNI152"
+verbose_echo " "
 
 log_Msg "END: AtlasRegistration to MNI152"
 echo " END: `date`" >> $WD/xfms/log.txt

--- a/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
+++ b/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
@@ -68,7 +68,7 @@ oT1wImage=`getopt1 "--oT1im" $@`
 oT1wBrain=`getopt1 "--oT1brain" $@`  
 BiasFieldSmoothingSigma=`getopt1 "--bfsigma" $@`
 
-# default parameters
+# A default value of 20 for bias smoothing sigma is the recommended default by FSL 
 BiasFieldSmoothingSigma=`defaultopt $BiasFieldSmoothingSigma 20` 
 WDir="$WD.anat"
 

--- a/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
+++ b/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
@@ -99,17 +99,17 @@ fi
 # Copy data out if output targets provided
 
 if [ ! -z ${oT1wImage} ] ; then 
-  cp ${WDir}/T1_biascorr.nii.gz ${oT1wImage}.nii.gz
+  ${FSLDIR}/bin/imcp ${WDir}/T1_biascorr ${oT1wImage}
   echo " --> Copied T1_biascorr.nii.gz to ${oT1wImage}.nii.gz"
 fi
 
 if [ ! -z ${oT1wBrain} ] ; then
-  cp ${WDir}/T1_biascorr_brain.nii.gz ${oT1wBrain}.nii.gz
+  ${FSLDIR}/bin/imcp ${WDir}/T1_biascorr_brain ${oT1wBrain}
   echo " --> Copied T1_biascorr_brain.nii.gz to ${oT1wBrain}.nii.gz"
 fi 
 
 if [ ! -z ${oBias} ] ; then
-  cp ${WDir}/T1_fast_bias.nii.gz ${oBias}.nii.gz
+  ${FSLDIR}/bin/imcp ${WDir}/T1_fast_bias ${oBias}
   echo " --> Copied T1_fast_bias.nii.gz to ${oBias}.nii.gz"
 fi
 

--- a/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
+++ b/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+source ${HCPPIPEDIR}/global/scripts/debug.shlib # Debugging functions
+
+# Requirements for this script
+#  installed versions of: FSL (version 5.0.6), caret7 (a.k.a. Connectome Workbench) (version 1.0)
+#  environment: FSLDIR  CARET7DIR
+
+################################################ SUPPORT FUNCTIONS ##################################################
+
+Usage() {
+  echo "`basename $0`: Tool for bias field correction based on T1w image only"
+  echo " "
+  echo "Usage: `basename $0` --workingdir=<working directory> --T1im=<input T1 image> [--oT1im=<output T1 image>] [-oT1brain=<output T1 brain>] [--bfsigma=<input T1 image>]"
+}
+
+# function for parsing options
+getopt1() {
+    sopt="$1"
+    shift 1
+    for fn in $@ ; do
+      	if [ `echo $fn | grep -- "^${sopt}=" | wc -w` -gt 0 ] ; then
+      	    echo $fn | sed "s/^${sopt}=//"
+      	    return 0
+      	fi
+    done
+}
+
+defaultopt() {
+    echo $1
+}
+
+################################################### OUTPUT FILES #####################################################
+
+# Output images and files (in $WD):
+# T1.nii.gz                         T1_fast_bias_vol2.nii.gz          T1_initfast2_brain_mask2.nii.gz
+# T1_biascorr.nii.gz                T1_fast_bias_vol32.nii.gz         T1_initfast2_maskedrestore.nii.gz
+# T1_biascorr_brain.nii.gz          T1_fast_restore.nii.gz            T1_initfast2_restore.nii.gz
+# T1_biascorr_brain_mask.nii.gz     T1_fast_seg.nii.gz                lesionmask.nii.gz
+# T1_fast_bias.nii.gz               T1_fast_totbias.nii.gz            lesionmaskinv.nii.gz
+# T1_fast_bias_idxmask.nii.gz       T1_initfast2_brain.nii.gz         log.txt
+# T1_fast_bias_init.nii.gz          T1_initfast2_brain_mask.nii.gz
+
+################################################## OPTION PARSING #####################################################
+
+# Just give usage if no arguments specified
+if [ $# -eq 0 ] ; then Usage; exit 0; fi
+# check for correct options
+if [ $# -lt 2 ] ; then Usage; exit 1; fi
+
+# parse arguments
+WD=`getopt1 "--workingdir" $@`  
+T1wImage=`getopt1 "--T1im" $@`  
+T1wBrain=`getopt1 "--T1brain" $@`  
+oBias=`getopt1 "--obias" $@`  
+oT1wImage=`getopt1 "--oT1im" $@`  
+oT1wBrain=`getopt1 "--oT1brain" $@`  
+BiasFieldSmoothingSigma=`getopt1 "--bfsigma" $@`
+
+# default parameters
+BiasFieldSmoothingSigma=`defaultopt $BiasFieldSmoothingSigma 20` 
+WDir="$WD.anat"
+
+echo " "
+echo " START: T1w BiasFieldCorrection"
+
+mkdir -p $WDir
+
+# Record the input options in a log file
+echo "$0 $@" >> $WDir/log.txt
+echo "PWD = `pwd`" >> $WDir/log.txt
+echo "date: `date`" >> $WDir/log.txt
+echo " " >> $WDir/log.txt
+
+########################################## DO WORK ##########################################
+
+# Compute T1w Bias Normalization using fsl_anat function
+
+${FSLDIR}/bin/fsl_anat -i $T1wImage -o $WD --noreorient --clobber --nocrop --noreg --nononlinreg --noseg --nosubcortseg -s ${BiasFieldSmoothingSigma} --nocleanup
+
+# Use existing brain mask if one is provided
+
+[ ! -z ${T1wBrain} ] && ${FSLDIR}/bin/fslmaths ${WDir}/T1_biascorr -mas ${T1wBrain} ${WDir}/T1_biascorr_brain  && echo " --> masked T1_biascorr.nii.gz using ${T1wBrain}"
+
+# Copy data out if output targets provided
+
+[ ! -z ${oT1wImage} ] &&  cp ${WDir}/T1_biascorr.nii.gz       ${oT1wImage}.nii.gz  && echo " --> Copied T1_biascorr.nii.gz to ${oT1wImage}.nii.gz"
+[ ! -z ${oT1wBrain} ] &&  cp ${WDir}/T1_biascorr_brain.nii.gz ${oT1wBrain}.nii.gz  && echo " --> Copied T1_biascorr_brain.nii.gz to ${oT1wBrain}.nii.gz"
+[ ! -z ${oBias} ]     &&  cp ${WDir}/T1_fast_bias.nii.gz      ${oBias}.nii.gz      && echo " --> Copied T1_fast_bias.nii.gz to ${oBias}.nii.gz"
+
+echo " "
+echo " END: T1w BiasFieldCorrection"
+echo " END: `date`" >> $WDir/log.txt
+
+########################################## QA STUFF ##########################################
+if [ -e $WDir/qa.txt ] ; then rm -f $WDir/qa.txt ; fi
+echo "cd `pwd`" >> $WDir/qa.txt
+echo "# Look at the quality of the bias corrected output (T1w is brain only)" >> $WDir/qa.txt
+echo "fslview $WDir/T1_biascorr_brain.nii.gz" >> $WDir/qa.txt
+
+##############################################################################################

--- a/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
+++ b/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 set -e
-source ${HCPPIPEDIR}/global/scripts/debug.shlib # Debugging functions
+# source ${HCPPIPEDIR}/global/scripts/debug.shlib # Debugging functions
 
 # Requirements for this script
-#  installed versions of: FSL (version 5.0.6), caret7 (a.k.a. Connectome Workbench) (version 1.0)
-#  environment: FSLDIR  CARET7DIR
+#  installed versions of: FSL (version 5.0.6)
+#  environment: FSLDIR
+
+# ------------------------------------------------------------------------------
+#  Verify required environment variables are set
+# ------------------------------------------------------------------------------
+
+if [ -z "${FSLDIR}" ]; then
+  echo "$(basename ${0}): ABORTING: FSLDIR environment variable must be set"
+  exit 1
+else
+  echo "$(basename ${0}): FSLDIR: ${FSLDIR}"
+fi
 
 ################################################ SUPPORT FUNCTIONS ##################################################
 
@@ -80,13 +91,27 @@ ${FSLDIR}/bin/fsl_anat -i $T1wImage -o $WD --noreorient --clobber --nocrop --nor
 
 # Use existing brain mask if one is provided
 
-[ ! -z ${T1wBrain} ] && ${FSLDIR}/bin/fslmaths ${WDir}/T1_biascorr -mas ${T1wBrain} ${WDir}/T1_biascorr_brain  && echo " --> masked T1_biascorr.nii.gz using ${T1wBrain}"
+if [ ! -z ${T1wBrain} ] ; then
+  ${FSLDIR}/bin/fslmaths ${WDir}/T1_biascorr -mas ${T1wBrain} ${WDir}/T1_biascorr_brain  
+  echo " --> masked T1_biascorr.nii.gz using ${T1wBrain}"
+fi
 
 # Copy data out if output targets provided
 
-[ ! -z ${oT1wImage} ] &&  cp ${WDir}/T1_biascorr.nii.gz       ${oT1wImage}.nii.gz  && echo " --> Copied T1_biascorr.nii.gz to ${oT1wImage}.nii.gz"
-[ ! -z ${oT1wBrain} ] &&  cp ${WDir}/T1_biascorr_brain.nii.gz ${oT1wBrain}.nii.gz  && echo " --> Copied T1_biascorr_brain.nii.gz to ${oT1wBrain}.nii.gz"
-[ ! -z ${oBias} ]     &&  cp ${WDir}/T1_fast_bias.nii.gz      ${oBias}.nii.gz      && echo " --> Copied T1_fast_bias.nii.gz to ${oBias}.nii.gz"
+if [ ! -z ${oT1wImage} ] ; then 
+  cp ${WDir}/T1_biascorr.nii.gz ${oT1wImage}.nii.gz
+  echo " --> Copied T1_biascorr.nii.gz to ${oT1wImage}.nii.gz"
+fi
+
+if [ ! -z ${oT1wBrain} ] ; then
+  cp ${WDir}/T1_biascorr_brain.nii.gz ${oT1wBrain}.nii.gz
+  echo " --> Copied T1_biascorr_brain.nii.gz to ${oT1wBrain}.nii.gz"
+fi 
+
+if [ ! -z ${oBias} ] ; then
+  cp ${WDir}/T1_fast_bias.nii.gz ${oBias}.nii.gz
+  echo " --> Copied T1_fast_bias.nii.gz to ${oBias}.nii.gz"
+fi
 
 echo " "
 echo " END: T1w BiasFieldCorrection"

--- a/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
+++ b/PreFreeSurfer/scripts/BiasFieldCorrection_T1wOnly.sh
@@ -72,8 +72,11 @@ BiasFieldSmoothingSigma=`getopt1 "--bfsigma" $@`
 BiasFieldSmoothingSigma=`defaultopt $BiasFieldSmoothingSigma 20` 
 WDir="$WD.anat"
 
-echo " "
-echo " START: T1w BiasFieldCorrection"
+log_Msg " START: T1wBiasFieldCorrection"
+
+verbose_echo "  "
+verbose_red_echo " ===> Running T1w Bias Field Correction"
+verbose_echo " "
 
 mkdir -p $WDir
 
@@ -93,28 +96,30 @@ ${FSLDIR}/bin/fsl_anat -i $T1wImage -o $WD --noreorient --clobber --nocrop --nor
 
 if [ ! -z ${T1wBrain} ] ; then
   ${FSLDIR}/bin/fslmaths ${WDir}/T1_biascorr -mas ${T1wBrain} ${WDir}/T1_biascorr_brain  
-  echo " --> masked T1_biascorr.nii.gz using ${T1wBrain}"
+  verbose_echo " --> masked T1_biascorr.nii.gz using ${T1wBrain}"
 fi
 
 # Copy data out if output targets provided
 
 if [ ! -z ${oT1wImage} ] ; then 
   ${FSLDIR}/bin/imcp ${WDir}/T1_biascorr ${oT1wImage}
-  echo " --> Copied T1_biascorr.nii.gz to ${oT1wImage}.nii.gz"
+  verbose_echo " --> Copied T1_biascorr.nii.gz to ${oT1wImage}.nii.gz"
 fi
 
 if [ ! -z ${oT1wBrain} ] ; then
   ${FSLDIR}/bin/imcp ${WDir}/T1_biascorr_brain ${oT1wBrain}
-  echo " --> Copied T1_biascorr_brain.nii.gz to ${oT1wBrain}.nii.gz"
+  verbose_echo " --> Copied T1_biascorr_brain.nii.gz to ${oT1wBrain}.nii.gz"
 fi 
 
 if [ ! -z ${oBias} ] ; then
   ${FSLDIR}/bin/imcp ${WDir}/T1_fast_bias ${oBias}
-  echo " --> Copied T1_fast_bias.nii.gz to ${oBias}.nii.gz"
+  verbose_echo " --> Copied T1_fast_bias.nii.gz to ${oBias}.nii.gz"
 fi
 
-echo " "
-echo " END: T1w BiasFieldCorrection"
+verbose_green_echo "---> Finished T1w Bias Field Correction"
+verbose_echo " "
+
+log_Msg " END: T1w BiasFieldCorrection"
 echo " END: `date`" >> $WDir/log.txt
 
 ########################################## QA STUFF ##########################################
@@ -124,3 +129,4 @@ echo "# Look at the quality of the bias corrected output (T1w is brain only)" >>
 echo "fslview $WDir/T1_biascorr_brain.nii.gz" >> $WDir/qa.txt
 
 ##############################################################################################
+

--- a/PreFreeSurfer/scripts/BiasFieldCorrection_sqrtT1wXT1w.sh
+++ b/PreFreeSurfer/scripts/BiasFieldCorrection_sqrtT1wXT1w.sh
@@ -102,7 +102,7 @@ echo " " >> $WD/log.txt
 ########################################## DO WORK ########################################## 
 
 # Form sqrt(T1w*T2w), mask this and normalise by the mean
-verbose_echo " --> Forming rt(T1w*T2w), masking this and normalising by the mean"
+verbose_echo " --> Forming sqrt(T1w*T2w), masking this and normalising by the mean"
 ${FSLDIR}/bin/fslmaths $T1wImage -mul $T2wImage -abs -sqrt $WD/T1wmulT2w.nii.gz -odt float
 ${FSLDIR}/bin/fslmaths $WD/T1wmulT2w.nii.gz -mas $T1wImageBrain $WD/T1wmulT2w_brain.nii.gz
 meanbrainval=`${FSLDIR}/bin/fslstats $WD/T1wmulT2w_brain.nii.gz -M`

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -84,7 +84,6 @@ Usage() {
   echo ""
   echo "            [--topupconfig=<topup config file>]"
   echo "            [--gdcoeffs=<gradient distortion coefficients (SIEMENS file)>]"
-  echo "            [--t2avail=<TRUE or FALSE>]"
 }
 
 # function for parsing options
@@ -159,11 +158,9 @@ DistortionCorrection=`getopt1 "--method" $@`
 TopupConfig=`getopt1 "--topupconfig" $@`  
 GradientDistortionCoeffs=`getopt1 "--gdcoeffs" $@`  
 UseJacobian=`getopt1 "--usejacobian" $@`
-T2wAvailable=`getopt1 "--t2avail" $@`
 
 # default parameters
 WD=`defaultopt $WD .`
-T2wAvailable=`defaultopt $T2wAvailable TRUE`
 
 T1wImage=`${FSLDIR}/bin/remove_ext $T1wImage`
 T1wImageBrain=`${FSLDIR}/bin/remove_ext $T1wImageBrain`
@@ -207,7 +204,6 @@ verbose_echo "           OutputT2wTransform             (ot2warp): $OutputT2wTra
 verbose_echo "         DistortionCorrection              (method): $DistortionCorrection"
 verbose_echo "                  TopupConfig         (topupconfig): $TopupConfig"
 verbose_echo "     GradientDistortionCoeffs            (gdcoeffs): $GradientDistortionCoeffs"
-verbose_echo "                 T2wAvailable             (t2avail): $T2wAvailable"
 verbose_echo " "
 
 
@@ -344,7 +340,7 @@ for TXw in $Modalities ; do
       TXwImageBrainBasename=$T2wImageBrainBasename
     fi
 
-    if [ "${T2wAvailable}" = "FALSE" ] ; then
+    if [ "${T2wImage}" = "NONE" ] ; then
       verbose_echo "      ... Skipping $TXw"
       continue
     else
@@ -403,7 +399,7 @@ done
 
 ### END LOOP over modalities ###
 
-if [ "${T2wAvailable}" == "FALSE" ] ; then
+if [ "${T2wImage}" == "NONE" ] ; then
   verbose_echo ""
   verbose_red_echo " ---> Skipping T2w to T1w registration"
 

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -341,7 +341,7 @@ for TXw in $Modalities ; do
       TXwImageBrainBasename=$T2wImageBrainBasename
     fi
 
-    if [ "${TXwImage}" = "NONE" ] ; then
+    if [[ "${TXwImage}" == "NONE"* ]] ; then
       echo "      ... Skipping $TXw"
       continue
     else
@@ -400,7 +400,7 @@ done
 
 ### END LOOP over modalities ###
 
-if [ "${T2wImage}" = "NONE" ] ; then
+if [[ "${T2wImage}" == "NONE"* ]] ; then
   echo ""
   # ceho " ---> Skipping T2w to T1w registration"
   echo " ---> Skipping T2w to T1w registration"

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -9,24 +9,24 @@ set -e
 # ------------------------------------------------------------------------------
 
 if [ -z "${FSLDIR}" ]; then
-	echo "$(basename ${0}): ABORTING: FSLDIR environment variable must be set"
-	exit 1
+  echo "$(basename ${0}): ABORTING: FSLDIR environment variable must be set"
+  exit 1
 else
-	echo "$(basename ${0}): FSLDIR: ${FSLDIR}"
+  echo "$(basename ${0}): FSLDIR: ${FSLDIR}"
 fi
 
 if [ -z "${HCPPIPEDIR_Global}" ]; then
-	echo "$(basename ${0}): ABORTING: HCPPIPEDIR_Global environment variable must be set"
-	exit 1
+  echo "$(basename ${0}): ABORTING: HCPPIPEDIR_Global environment variable must be set"
+  exit 1
 else
-	echo "$(basename ${0}): HCPPIPEDIR_Global: ${HCPPIPEDIR_Global}"
+  echo "$(basename ${0}): HCPPIPEDIR_Global: ${HCPPIPEDIR_Global}"
 fi
 
 if [ -z "${HCPPIPEDIR}" ]; then
-	echo "$(basename ${0}): ABORTING: HCPPIPEDIR environment variable must be set"
-	exit 1
+  echo "$(basename ${0}): ABORTING: HCPPIPEDIR environment variable must be set"
+  exit 1
 else
-	echo "$(basename ${0}): HCPPIPEDIR: ${HCPPIPEDIR}"
+  echo "$(basename ${0}): HCPPIPEDIR: ${HCPPIPEDIR}"
 fi
 
 # -----------------------------------------------------------------------------------
@@ -91,10 +91,10 @@ getopt1() {
     sopt="$1"
     shift 1
     for fn in $@ ; do
-	if [ `echo $fn | grep -- "^${sopt}=" | wc -w` -gt 0 ] ; then
-	    echo $fn | sed "s/^${sopt}=//"
-	    return 0
-	fi
+  if [ `echo $fn | grep -- "^${sopt}=" | wc -w` -gt 0 ] ; then
+      echo $fn | sed "s/^${sopt}=//"
+      return 0
+  fi
     done
 }
 
@@ -109,7 +109,7 @@ defaultopt() {
 # Output files (in $WD): Magnitude  Magnitude_brain  Phase  FieldMap
 #                        Magnitude_brain_warppedT1w  Magnitude_brain_warppedT1w2${TXwImageBrainBasename}
 #                        fieldmap2${T1wImageBrainBasename}.mat   FieldMap2${T1wImageBrainBasename}
-#                        FieldMap2${T1wImageBrainBasename}_ShiftMap  
+#                        FieldMap2${T1wImageBrainBasename}_ShiftMap
 #                        FieldMap2${T1wImageBrainBasename}_Warp ${T1wImageBasename}  ${T1wImageBrainBasename}
 #        Plus the versions with T1w -> T2w
 #
@@ -176,6 +176,37 @@ Modalities="T1w T2w"
 
 log_Msg "START"
 
+echo "  "
+ceho " ===> Running T2WToT1wDistortionCorrectAndReg"
+echo "  "
+echo "  Parameters"
+echo "                           WD          (workingdir): $WD"
+echo "                     T1wImage                  (t1): $T1wImage"
+echo "                T1wImageBrain             (t1brain): $T1wImageBrain"
+echo "                     T2wImage                  (t2): $T2wImage"
+echo "                T2wImageBrain             (t2brain): $T2wImageBrain"
+echo "           MagnitudeInputName             (fmapmag): $MagnitudeInputName"
+echo "               PhaseInputName           (fmapphase): $PhaseInputName"
+echo "                GEB0InputName (fmapgeneralelectric): $GEB0InputName"
+echo "                           TE            (echodiff): $TE"
+echo "  SpinEchoPhaseEncodeNegative          (SEPhaseNeg): $SpinEchoPhaseEncodeNegative"
+echo "  SpinEchoPhaseEncodePositive          (SEPhasePos): $SpinEchoPhaseEncodePositive"
+echo "               SEEchoSpacing        (seechospacing): $SEEchoSpacing"
+echo "                  SEUnwarpDir         (seunwarpdir): $SEUnwarpDir"
+echo "             T1wSampleSpacing       (t1sampspacing): $T1wSampleSpacing"
+echo "             T2wSampleSpacing       (t2sampspacing): $T2wSampleSpacing"
+echo "                    UnwarpDir           (unwarpdir): $UnwarpDir"
+echo "               OutputT1wImage                 (ot1): $OutputT1wImage"
+echo "          OutputT1wImageBrain            (ot1brain): $OutputT1wImageBrain"
+echo "           OutputT1wTransform             (ot1warp): $OutputT1wTransform"
+echo "               OutputT2wImage                 (ot2): $OutputT2wImage"
+echo "           OutputT2wTransform             (ot2warp): $OutputT2wTransform"
+echo "         DistortionCorrection              (method): $DistortionCorrection"
+echo "                  TopupConfig         (topupconfig): $TopupConfig"
+echo "     GradientDistortionCoeffs            (gdcoeffs): $GradientDistortionCoeffs"
+echo " "
+
+
 mkdir -p $WD
 mkdir -p ${WD}/FieldMap
 
@@ -186,12 +217,12 @@ echo "date: `date`" >> $WD/log.txt
 echo " " >> $WD/log.txt
 
 
-########################################## DO WORK ########################################## 
+########################################## DO WORK ##########################################
 
 case $DistortionCorrection in
 
     ${FIELDMAP_METHOD_OPT} | ${SIEMENS_METHOD_OPT})
-    
+
         # --------------------------------------
         # -- Siemens Gradient Echo Field Maps --
         # --------------------------------------
@@ -221,7 +252,7 @@ case $DistortionCorrection in
 
         ### Create fieldmaps (and apply gradient non-linearity distortion correction)
         echo " "
-        echo " " 
+        echo " "
         echo " " 
 
         ${HCPPIPEDIR_Global}/GeneralElectricFieldMapPreprocessingAll.sh \
@@ -237,15 +268,15 @@ case $DistortionCorrection in
     ${SPIN_ECHO_METHOD_OPT})
 
         # --------------------------
-        # -- Spin Echo Field Maps --  
+        # -- Spin Echo Field Maps --
         # --------------------------
 
         if [[ ${SEUnwarpDir} = [xyij] ]] ; then
-			ScoutInputName="${SpinEchoPhaseEncodePositive}"
+          ScoutInputName="${SpinEchoPhaseEncodePositive}"
         elif [[ ${SEUnwarpDir} = -[xyij] || ${SEUnwarpDir} = [xyij]- ]] ; then
-			ScoutInputName="${SpinEchoPhaseEncodeNegative}"
-		else
-			log_Err_Abort "Invalid entry for --seunwarpdir ($SEUnwarpDir)"
+          ScoutInputName="${SpinEchoPhaseEncodeNegative}"
+        else
+          log_Err_Abort "Invalid entry for --seunwarpdir ($SEUnwarpDir)"
         fi
 
         # Use topup to distortion correct the scout scans
@@ -289,26 +320,39 @@ if [ "${UnwarpDir}" = "-z" ] ; then
 fi
 
 ### LOOP over available modalities ###
+echo ""
+#ceho " ---> Looping over modalities"
+echo " ---> Looping over modalities"
 
 for TXw in $Modalities ; do
+
     # set up required variables
     if [ $TXw = T1w ] ; then
-	TXwImage=$T1wImage
-	TXwImageBrain=$T1wImageBrain
-	TXwSampleSpacing=$T1wSampleSpacing
-	TXwImageBasename=$T1wImageBasename
-	TXwImageBrainBasename=$T1wImageBrainBasename
+      TXwImage=$T1wImage
+      TXwImageBrain=$T1wImageBrain
+      TXwSampleSpacing=$T1wSampleSpacing
+      TXwImageBasename=$T1wImageBasename
+      TXwImageBrainBasename=$T1wImageBrainBasename
     else
-	TXwImage=$T2wImage
-	TXwImageBrain=$T2wImageBrain
-	TXwSampleSpacing=$T2wSampleSpacing
-	TXwImageBasename=$T2wImageBasename
-	TXwImageBrainBasename=$T2wImageBrainBasename
+      TXwImage=$T2wImage
+      TXwImageBrain=$T2wImageBrain
+      TXwSampleSpacing=$T2wSampleSpacing
+      TXwImageBasename=$T2wImageBasename
+      TXwImageBrainBasename=$T2wImageBrainBasename
+    fi
+
+    if [ "${TXwImage}" = "NONE" ] ; then
+      echo "      ... Skipping $TXw"
+      continue
+    else
+      echo "      ... $TXw"
     fi
 
     # Forward warp the fieldmap magnitude and register to TXw image (transform phase image too)
-    ${FSLDIR}/bin/fugue --loadfmap=${WD}/FieldMap --dwell=${TXwSampleSpacing} --saveshift=${WD}/FieldMap_ShiftMap${TXw}.nii.gz    
-    ${FSLDIR}/bin/convertwarp --relout --rel --ref=${WD}/Magnitude --shiftmap=${WD}/FieldMap_ShiftMap${TXw}.nii.gz --shiftdir=${UnwarpDir} --out=${WD}/FieldMap_Warp${TXw}.nii.gz    
+
+    echo "      ... Forward warping fieldmap"
+    ${FSLDIR}/bin/fugue --loadfmap=${WD}/FieldMap --dwell=${TXwSampleSpacing} --saveshift=${WD}/FieldMap_ShiftMap${TXw}.nii.gz
+    ${FSLDIR}/bin/convertwarp --relout --rel --ref=${WD}/Magnitude --shiftmap=${WD}/FieldMap_ShiftMap${TXw}.nii.gz --shiftdir=${UnwarpDir} --out=${WD}/FieldMap_Warp${TXw}.nii.gz
 
     case $DistortionCorrection in
 
@@ -325,52 +369,74 @@ for TXw in $Modalities ; do
         *)
             log_Err "Unable to apply readout distortion correction"
             log_Err_Abort "Unrecognized distortion correction method: ${DistortionCorrection}"
-			
+      
     esac
-    
+
     ${FSLDIR}/bin/flirt -in ${WD}/FieldMap.nii.gz -ref ${TXwImage} -applyxfm -init ${WD}/Fieldmap2${TXwImageBasename}.mat -out ${WD}/FieldMap2${TXwImageBasename}
-    
+
     # Convert to shift map then to warp field and unwarp the TXw
-    ${FSLDIR}/bin/fugue --loadfmap=${WD}/FieldMap2${TXwImageBasename} --dwell=${TXwSampleSpacing} --saveshift=${WD}/FieldMap2${TXwImageBasename}_ShiftMap.nii.gz    
-    ${FSLDIR}/bin/convertwarp --relout --rel --ref=${TXwImageBrain} --shiftmap=${WD}/FieldMap2${TXwImageBasename}_ShiftMap.nii.gz --shiftdir=${UnwarpDir} --out=${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz    
+
+    echo "      ... Converting to shift map, to warp field and unwarping $TWx"
+    ${FSLDIR}/bin/fugue --loadfmap=${WD}/FieldMap2${TXwImageBasename} --dwell=${TXwSampleSpacing} --saveshift=${WD}/FieldMap2${TXwImageBasename}_ShiftMap.nii.gz
+    ${FSLDIR}/bin/convertwarp --relout --rel --ref=${TXwImageBrain} --shiftmap=${WD}/FieldMap2${TXwImageBasename}_ShiftMap.nii.gz --shiftdir=${UnwarpDir} --out=${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz
     ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${TXwImage} -r ${TXwImage} -w ${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz -o ${WD}/${TXwImageBasename}
-    
+
     # Make a brain image (transform to make a mask, then apply it)
-    ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${TXwImageBrain} -r ${TXwImageBrain} -w ${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz -o ${WD}/${TXwImageBrainBasename} 
+
+    echo "      ... Making a brain image"
+    ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${TXwImageBrain} -r ${TXwImageBrain} -w ${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz -o ${WD}/${TXwImageBrainBasename}
     ${FSLDIR}/bin/fslmaths ${WD}/${TXwImageBasename} -mas ${WD}/${TXwImageBrainBasename} ${WD}/${TXwImageBrainBasename}
-    
+
     # Copy files to specified destinations
-    if [ $TXw = T1w ] ; then 
+
+    echo "      ... Copying files"
+    if [ $TXw = T1w ] ; then
        ${FSLDIR}/bin/imcp ${WD}/FieldMap2${TXwImageBasename}_Warp ${OutputT1wTransform}
        ${FSLDIR}/bin/imcp ${WD}/${TXwImageBasename} ${OutputT1wImage}
        ${FSLDIR}/bin/imcp ${WD}/${TXwImageBrainBasename} ${OutputT1wImageBrain}
     fi
-    
+
 done
 
 ### END LOOP over modalities ###
 
+if [ "${T2wImage}" = "NONE" ] ; then
+  echo ""
+  # ceho " ---> Skipping T2w to T1w registration"
+  echo " ---> Skipping T2w to T1w registration"
 
-### Now do T2w to T1w registration
-mkdir -p ${WD}/T2w2T1w
-    
-# Main registration: between corrected T2w and corrected T1w
-${FSLDIR}/bin/epi_reg --epi=${WD}/${T2wImageBrainBasename} --t1=${WD}/${T1wImageBasename} --t1brain=${WD}/${T1wImageBrainBasename} --out=${WD}/T2w2T1w/T2w_reg
-    
-# Make a warpfield directly from original (non-corrected) T2w to corrected T1w  (and apply it)
-${FSLDIR}/bin/convertwarp --relout --rel --ref=${T1wImage} --warp1=${WD}/FieldMap2${T2wImageBasename}_Warp.nii.gz --postmat=${WD}/T2w2T1w/T2w_reg.mat -o ${WD}/T2w2T1w/T2w_dc_reg
-    
-${FSLDIR}/bin/applywarp --rel --interp=spline --in=${T2wImage} --ref=${T1wImage} --warp=${WD}/T2w2T1w/T2w_dc_reg --out=${WD}/T2w2T1w/T2w_reg
-   
-# Add 1 to avoid exact zeros within the image (a problem for myelin mapping?)
-${FSLDIR}/bin/fslmaths ${WD}/T2w2T1w/T2w_reg.nii.gz -add 1 ${WD}/T2w2T1w/T2w_reg.nii.gz -odt float
+else
+        
+  echo ""
+  # ceho " ---> Running T2w to T1w registration"
+  echo " ---> Running T2w to T1w registration"
 
-# QA image
-${FSLDIR}/bin/fslmaths ${WD}/T2w2T1w/T2w_reg -mul ${T1wImage} -sqrt ${WD}/T2w2T1w/sqrtT1wbyT2w -odt float
-    
-# Copy files to specified destinations
-${FSLDIR}/bin/imcp ${WD}/T2w2T1w/T2w_dc_reg ${OutputT2wTransform}
-${FSLDIR}/bin/imcp ${WD}/T2w2T1w/T2w_reg ${OutputT2wImage}
+  ### Now do T2w to T1w registration
+  mkdir -p ${WD}/T2w2T1w
+
+  # Main registration: between corrected T2w and corrected T1w
+  echo "      ... Corrected T2w to T1w"
+  ${FSLDIR}/bin/epi_reg --epi=${WD}/${T2wImageBrainBasename} --t1=${WD}/${T1wImageBasename} --t1brain=${WD}/${T1wImageBrainBasename} --out=${WD}/T2w2T1w/T2w_reg
+
+  # Make a warpfield directly from original (non-corrected) T2w to corrected T1w  (and apply it)
+  echo "      ... Making a warpfield from original"
+  ${FSLDIR}/bin/convertwarp --relout --rel --ref=${T1wImage} --warp1=${WD}/FieldMap2${T2wImageBasename}_Warp.nii.gz --postmat=${WD}/T2w2T1w/T2w_reg.mat -o ${WD}/T2w2T1w/T2w_dc_reg
+  echo "      ... Applying warpfield"
+  ${FSLDIR}/bin/applywarp --rel --interp=spline --in=${T2wImage} --ref=${T1wImage} --warp=${WD}/T2w2T1w/T2w_dc_reg --out=${WD}/T2w2T1w/T2w_reg
+
+  # Add 1 to avoid exact zeros within the image (a problem for myelin mapping?)
+  echo "      ... Adding 1"
+  ${FSLDIR}/bin/fslmaths ${WD}/T2w2T1w/T2w_reg.nii.gz -add 1 ${WD}/T2w2T1w/T2w_reg.nii.gz -odt float
+
+  # QA image
+  echo "      ... Creating QA image"
+  ${FSLDIR}/bin/fslmaths ${WD}/T2w2T1w/T2w_reg -mul ${T1wImage} -sqrt ${WD}/T2w2T1w/sqrtT1wbyT2w -odt float
+
+  # Copy files to specified destinations
+  echo "      ... Copying files"
+  ${FSLDIR}/bin/imcp ${WD}/T2w2T1w/T2w_dc_reg ${OutputT2wTransform}
+  ${FSLDIR}/bin/imcp ${WD}/T2w2T1w/T2w_reg ${OutputT2wImage}
+fi
 
 log_Msg "END"
 echo " END: `date`" >> $WD/log.txt

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -204,6 +204,7 @@ verbose_echo "           OutputT2wTransform             (ot2warp): $OutputT2wTra
 verbose_echo "         DistortionCorrection              (method): $DistortionCorrection"
 verbose_echo "                  TopupConfig         (topupconfig): $TopupConfig"
 verbose_echo "     GradientDistortionCoeffs            (gdcoeffs): $GradientDistortionCoeffs"
+verbose_echo "                  UseJacobian         (usejacobian): $UseJacobian"
 verbose_echo " "
 
 

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -176,35 +176,35 @@ Modalities="T1w T2w"
 
 log_Msg "START"
 
-echo "  "
-ceho " ===> Running T2WToT1wDistortionCorrectAndReg"
-echo "  "
-echo "  Parameters"
-echo "                           WD          (workingdir): $WD"
-echo "                     T1wImage                  (t1): $T1wImage"
-echo "                T1wImageBrain             (t1brain): $T1wImageBrain"
-echo "                     T2wImage                  (t2): $T2wImage"
-echo "                T2wImageBrain             (t2brain): $T2wImageBrain"
-echo "           MagnitudeInputName             (fmapmag): $MagnitudeInputName"
-echo "               PhaseInputName           (fmapphase): $PhaseInputName"
-echo "                GEB0InputName (fmapgeneralelectric): $GEB0InputName"
-echo "                           TE            (echodiff): $TE"
-echo "  SpinEchoPhaseEncodeNegative          (SEPhaseNeg): $SpinEchoPhaseEncodeNegative"
-echo "  SpinEchoPhaseEncodePositive          (SEPhasePos): $SpinEchoPhaseEncodePositive"
-echo "               SEEchoSpacing        (seechospacing): $SEEchoSpacing"
-echo "                  SEUnwarpDir         (seunwarpdir): $SEUnwarpDir"
-echo "             T1wSampleSpacing       (t1sampspacing): $T1wSampleSpacing"
-echo "             T2wSampleSpacing       (t2sampspacing): $T2wSampleSpacing"
-echo "                    UnwarpDir           (unwarpdir): $UnwarpDir"
-echo "               OutputT1wImage                 (ot1): $OutputT1wImage"
-echo "          OutputT1wImageBrain            (ot1brain): $OutputT1wImageBrain"
-echo "           OutputT1wTransform             (ot1warp): $OutputT1wTransform"
-echo "               OutputT2wImage                 (ot2): $OutputT2wImage"
-echo "           OutputT2wTransform             (ot2warp): $OutputT2wTransform"
-echo "         DistortionCorrection              (method): $DistortionCorrection"
-echo "                  TopupConfig         (topupconfig): $TopupConfig"
-echo "     GradientDistortionCoeffs            (gdcoeffs): $GradientDistortionCoeffs"
-echo " "
+verbose_echo "  "
+verbose_red_echo " ===> Running T2WToT1wDistortionCorrectAndReg"
+verbose_echo "  "
+verbose_echo "  Parameters"
+verbose_echo "                           WD          (workingdir): $WD"
+verbose_echo "                     T1wImage                  (t1): $T1wImage"
+verbose_echo "                T1wImageBrain             (t1brain): $T1wImageBrain"
+verbose_echo "                     T2wImage                  (t2): $T2wImage"
+verbose_echo "                T2wImageBrain             (t2brain): $T2wImageBrain"
+verbose_echo "           MagnitudeInputName             (fmapmag): $MagnitudeInputName"
+verbose_echo "               PhaseInputName           (fmapphase): $PhaseInputName"
+verbose_echo "                GEB0InputName (fmapgeneralelectric): $GEB0InputName"
+verbose_echo "                           TE            (echodiff): $TE"
+verbose_echo "  SpinEchoPhaseEncodeNegative          (SEPhaseNeg): $SpinEchoPhaseEncodeNegative"
+verbose_echo "  SpinEchoPhaseEncodePositive          (SEPhasePos): $SpinEchoPhaseEncodePositive"
+verbose_echo "               SEEchoSpacing        (seechospacing): $SEEchoSpacing"
+verbose_echo "                  SEUnwarpDir         (seunwarpdir): $SEUnwarpDir"
+verbose_echo "             T1wSampleSpacing       (t1sampspacing): $T1wSampleSpacing"
+verbose_echo "             T2wSampleSpacing       (t2sampspacing): $T2wSampleSpacing"
+verbose_echo "                    UnwarpDir           (unwarpdir): $UnwarpDir"
+verbose_echo "               OutputT1wImage                 (ot1): $OutputT1wImage"
+verbose_echo "          OutputT1wImageBrain            (ot1brain): $OutputT1wImageBrain"
+verbose_echo "           OutputT1wTransform             (ot1warp): $OutputT1wTransform"
+verbose_echo "               OutputT2wImage                 (ot2): $OutputT2wImage"
+verbose_echo "           OutputT2wTransform             (ot2warp): $OutputT2wTransform"
+verbose_echo "         DistortionCorrection              (method): $DistortionCorrection"
+verbose_echo "                  TopupConfig         (topupconfig): $TopupConfig"
+verbose_echo "     GradientDistortionCoeffs            (gdcoeffs): $GradientDistortionCoeffs"
+verbose_echo " "
 
 
 mkdir -p $WD
@@ -320,9 +320,8 @@ if [ "${UnwarpDir}" = "-z" ] ; then
 fi
 
 ### LOOP over available modalities ###
-echo ""
-#ceho " ---> Looping over modalities"
-echo " ---> Looping over modalities"
+verbose_echo ""
+verbose_red_echo " ---> Looping over modalities"
 
 for TXw in $Modalities ; do
 
@@ -342,15 +341,15 @@ for TXw in $Modalities ; do
     fi
 
     if [[ "${TXwImage}" == "NONE"* ]] ; then
-      echo "      ... Skipping $TXw"
+      verbose_echo "      ... Skipping $TXw"
       continue
     else
-      echo "      ... $TXw"
+      verbose_echo "      ... $TXw"
     fi
 
     # Forward warp the fieldmap magnitude and register to TXw image (transform phase image too)
 
-    echo "      ... Forward warping fieldmap"
+    verbose_echo "      ... Forward warping fieldmap"
     ${FSLDIR}/bin/fugue --loadfmap=${WD}/FieldMap --dwell=${TXwSampleSpacing} --saveshift=${WD}/FieldMap_ShiftMap${TXw}.nii.gz
     ${FSLDIR}/bin/convertwarp --relout --rel --ref=${WD}/Magnitude --shiftmap=${WD}/FieldMap_ShiftMap${TXw}.nii.gz --shiftdir=${UnwarpDir} --out=${WD}/FieldMap_Warp${TXw}.nii.gz
 
@@ -376,20 +375,20 @@ for TXw in $Modalities ; do
 
     # Convert to shift map then to warp field and unwarp the TXw
 
-    echo "      ... Converting to shift map, to warp field and unwarping $TWx"
+    verbose_echo "      ... Converting to shift map, to warp field and unwarping $TWx"
     ${FSLDIR}/bin/fugue --loadfmap=${WD}/FieldMap2${TXwImageBasename} --dwell=${TXwSampleSpacing} --saveshift=${WD}/FieldMap2${TXwImageBasename}_ShiftMap.nii.gz
     ${FSLDIR}/bin/convertwarp --relout --rel --ref=${TXwImageBrain} --shiftmap=${WD}/FieldMap2${TXwImageBasename}_ShiftMap.nii.gz --shiftdir=${UnwarpDir} --out=${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz
     ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${TXwImage} -r ${TXwImage} -w ${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz -o ${WD}/${TXwImageBasename}
 
     # Make a brain image (transform to make a mask, then apply it)
 
-    echo "      ... Making a brain image"
+    verbose_echo "      ... Making a brain image"
     ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${TXwImageBrain} -r ${TXwImageBrain} -w ${WD}/FieldMap2${TXwImageBasename}_Warp.nii.gz -o ${WD}/${TXwImageBrainBasename}
     ${FSLDIR}/bin/fslmaths ${WD}/${TXwImageBasename} -mas ${WD}/${TXwImageBrainBasename} ${WD}/${TXwImageBrainBasename}
 
     # Copy files to specified destinations
 
-    echo "      ... Copying files"
+    verbose_echo "      ... Copying files"
     if [ $TXw = T1w ] ; then
        ${FSLDIR}/bin/imcp ${WD}/FieldMap2${TXwImageBasename}_Warp ${OutputT1wTransform}
        ${FSLDIR}/bin/imcp ${WD}/${TXwImageBasename} ${OutputT1wImage}
@@ -401,42 +400,41 @@ done
 ### END LOOP over modalities ###
 
 if [[ "${T2wImage}" == "NONE"* ]] ; then
-  echo ""
-  # ceho " ---> Skipping T2w to T1w registration"
-  echo " ---> Skipping T2w to T1w registration"
+  verbose_echo ""
+  verbose_red_echo " ---> Skipping T2w to T1w registration"
 
 else
         
-  echo ""
-  # ceho " ---> Running T2w to T1w registration"
-  echo " ---> Running T2w to T1w registration"
+  verbose_echo ""
+  verbose_red_echo " ---> Running T2w to T1w registration"
 
   ### Now do T2w to T1w registration
   mkdir -p ${WD}/T2w2T1w
 
   # Main registration: between corrected T2w and corrected T1w
-  echo "      ... Corrected T2w to T1w"
+  verbose_echo "      ... Corrected T2w to T1w"
   ${FSLDIR}/bin/epi_reg --epi=${WD}/${T2wImageBrainBasename} --t1=${WD}/${T1wImageBasename} --t1brain=${WD}/${T1wImageBrainBasename} --out=${WD}/T2w2T1w/T2w_reg
 
   # Make a warpfield directly from original (non-corrected) T2w to corrected T1w  (and apply it)
-  echo "      ... Making a warpfield from original"
+  verbose_echo "      ... Making a warpfield from original"
   ${FSLDIR}/bin/convertwarp --relout --rel --ref=${T1wImage} --warp1=${WD}/FieldMap2${T2wImageBasename}_Warp.nii.gz --postmat=${WD}/T2w2T1w/T2w_reg.mat -o ${WD}/T2w2T1w/T2w_dc_reg
-  echo "      ... Applying warpfield"
+  verbose_echo "      ... Applying warpfield"
   ${FSLDIR}/bin/applywarp --rel --interp=spline --in=${T2wImage} --ref=${T1wImage} --warp=${WD}/T2w2T1w/T2w_dc_reg --out=${WD}/T2w2T1w/T2w_reg
 
   # Add 1 to avoid exact zeros within the image (a problem for myelin mapping?)
-  echo "      ... Adding 1"
   ${FSLDIR}/bin/fslmaths ${WD}/T2w2T1w/T2w_reg.nii.gz -add 1 ${WD}/T2w2T1w/T2w_reg.nii.gz -odt float
 
   # QA image
-  echo "      ... Creating QA image"
+  verbose_echo "      ... Creating QA image"
   ${FSLDIR}/bin/fslmaths ${WD}/T2w2T1w/T2w_reg -mul ${T1wImage} -sqrt ${WD}/T2w2T1w/sqrtT1wbyT2w -odt float
 
   # Copy files to specified destinations
-  echo "      ... Copying files"
+  verbose_echo "      ... Copying files"
   ${FSLDIR}/bin/imcp ${WD}/T2w2T1w/T2w_dc_reg ${OutputT2wTransform}
   ${FSLDIR}/bin/imcp ${WD}/T2w2T1w/T2w_reg ${OutputT2wImage}
 fi
+
+verbose_green_echo "---> Finished T2w To T1w Distortion Correction and Registration"
 
 log_Msg "END"
 echo " END: `date`" >> $WD/log.txt
@@ -453,4 +451,5 @@ echo "# Compare pre- and post-distortion correction for T2w" >> $WD/qa.txt
 echo "fslview ${T2wImage} ${WD}/${T2wImageBasename}" >> $WD/qa.txt
 
 ##############################################################################################
+
 

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -84,6 +84,7 @@ Usage() {
   echo ""
   echo "            [--topupconfig=<topup config file>]"
   echo "            [--gdcoeffs=<gradient distortion coefficients (SIEMENS file)>]"
+  echo "            [--t2avail=<TRUE or FALSE>]"
 }
 
 # function for parsing options
@@ -158,9 +159,11 @@ DistortionCorrection=`getopt1 "--method" $@`
 TopupConfig=`getopt1 "--topupconfig" $@`  
 GradientDistortionCoeffs=`getopt1 "--gdcoeffs" $@`  
 UseJacobian=`getopt1 "--usejacobian" $@`
+T2wAvailable=`getopt1 "--t2avail" $@`
 
 # default parameters
 WD=`defaultopt $WD .`
+T2wAvailable=`defaultopt $T2wAvailable TRUE`
 
 T1wImage=`${FSLDIR}/bin/remove_ext $T1wImage`
 T1wImageBrain=`${FSLDIR}/bin/remove_ext $T1wImageBrain`
@@ -204,6 +207,7 @@ verbose_echo "           OutputT2wTransform             (ot2warp): $OutputT2wTra
 verbose_echo "         DistortionCorrection              (method): $DistortionCorrection"
 verbose_echo "                  TopupConfig         (topupconfig): $TopupConfig"
 verbose_echo "     GradientDistortionCoeffs            (gdcoeffs): $GradientDistortionCoeffs"
+verbose_echo "                 T2wAvailable             (t2avail): $T2wAvailable"
 verbose_echo " "
 
 
@@ -340,7 +344,7 @@ for TXw in $Modalities ; do
       TXwImageBrainBasename=$T2wImageBrainBasename
     fi
 
-    if [[ "${TXwImage}" == "NONE"* ]] ; then
+    if [ "${T2wAvailable}" = "FALSE" ] ; then
       verbose_echo "      ... Skipping $TXw"
       continue
     else
@@ -399,7 +403,7 @@ done
 
 ### END LOOP over modalities ###
 
-if [[ "${T2wImage}" == "NONE"* ]] ; then
+if [ "${T2wAvailable}" == "FALSE" ] ; then
   verbose_echo ""
   verbose_red_echo " ---> Skipping T2w to T1w registration"
 

--- a/PreFreeSurfer/scripts/T2wToT1wReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wReg.sh
@@ -33,12 +33,13 @@ OutputT1wImageBrain="$7"
 OutputT1wTransform="$8"
 OutputT2wImage="$9"
 OutputT2wTransform="${10}"
+T2wAvailable="${11}"
 
 T1wImageBrainFile=`basename "$T1wImageBrain"`
 
 ${FSLDIR}/bin/imcp "$T1wImageBrain" "$WD"/"$T1wImageBrainFile"
 
-if [[ "${T2wImage}" = "NONE"* ]] ; then
+if [[ "${T2wAvailable}" = "FALSE" ]] ; then
     log_Msg "Skipping T2w to T1w registration --- no T2w image."
 else
     ${FSLDIR}/bin/epi_reg --epi="$T2wImageBrain" --t1="$T1wImage" --t1brain="$WD"/"$T1wImageBrainFile" --out="$WD"/T2w2T1w
@@ -51,7 +52,7 @@ ${FSLDIR}/bin/imcp "$T1wImageBrain" "$OutputT1wImageBrain"
 ${FSLDIR}/bin/fslmerge -t $OutputT1wTransform "$T1wImage".nii.gz "$T1wImage".nii.gz "$T1wImage".nii.gz
 ${FSLDIR}/bin/fslmaths $OutputT1wTransform -mul 0 $OutputT1wTransform
 
-if [[ "${T2wImage}" != "NONE"* ]] ; then
+if [[ "${T2wAvailable}" = "TRUE" ]] ; then
     ${FSLDIR}/bin/imcp "$WD"/T2w2T1w "$OutputT2wImage"
     ${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
 fi

--- a/PreFreeSurfer/scripts/T2wToT1wReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wReg.sh
@@ -38,7 +38,7 @@ T1wImageBrainFile=`basename "$T1wImageBrain"`
 
 cp "$T1wImageBrain".nii.gz "$WD"/"$T1wImageBrainFile".nii.gz
 
-if [ "${T2wImage}" = "NONE" ] ; then
+if [[ "${T2wImage}" = "NONE"* ]] ; then
     log_Msg "Skipping T2w to T1w registration --- no T2w image."
 else
     ${FSLDIR}/bin/epi_reg --epi="$T2wImageBrain" --t1="$T1wImage" --t1brain="$WD"/"$T1wImageBrainFile" --out="$WD"/T2w2T1w
@@ -51,9 +51,10 @@ cp "$T1wImageBrain".nii.gz "$OutputT1wImageBrain".nii.gz
 ${FSLDIR}/bin/fslmerge -t $OutputT1wTransform "$T1wImage".nii.gz "$T1wImage".nii.gz "$T1wImage".nii.gz
 ${FSLDIR}/bin/fslmaths $OutputT1wTransform -mul 0 $OutputT1wTransform
 
-[ "${T2wImage}" != "NONE" ] && cp "$WD"/T2w2T1w.nii.gz "$OutputT2wImage".nii.gz
-[ "${T2wImage}" != "NONE" ] && ${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
-
+if [[ "${T2wImage}" != "NONE"* ]] ; then
+    cp "$WD"/T2w2T1w.nii.gz "$OutputT2wImage".nii.gz
+    ${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
+fi
 log_Msg "END: T2w2T1Reg"
 
 

--- a/PreFreeSurfer/scripts/T2wToT1wReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wReg.sh
@@ -36,7 +36,7 @@ OutputT2wTransform="${10}"
 
 T1wImageBrainFile=`basename "$T1wImageBrain"`
 
-cp "$T1wImageBrain".nii.gz "$WD"/"$T1wImageBrainFile".nii.gz
+${FSLDIR}/bin/imcp "$T1wImageBrain" "$WD"/"$T1wImageBrainFile"
 
 if [[ "${T2wImage}" = "NONE"* ]] ; then
     log_Msg "Skipping T2w to T1w registration --- no T2w image."
@@ -46,13 +46,13 @@ else
     ${FSLDIR}/bin/fslmaths "$WD"/T2w2T1w -add 1 "$WD"/T2w2T1w -odt float
 fi
 
-cp "$T1wImage".nii.gz "$OutputT1wImage".nii.gz
-cp "$T1wImageBrain".nii.gz "$OutputT1wImageBrain".nii.gz
+${FSLDIR}/bin/imcp "$T1wImage" "$OutputT1wImage"
+${FSLDIR}/bin/imcp "$T1wImageBrain" "$OutputT1wImageBrain"
 ${FSLDIR}/bin/fslmerge -t $OutputT1wTransform "$T1wImage".nii.gz "$T1wImage".nii.gz "$T1wImage".nii.gz
 ${FSLDIR}/bin/fslmaths $OutputT1wTransform -mul 0 $OutputT1wTransform
 
 if [[ "${T2wImage}" != "NONE"* ]] ; then
-    cp "$WD"/T2w2T1w.nii.gz "$OutputT2wImage".nii.gz
+    ${FSLDIR}/bin/imcp "$WD"/T2w2T1w "$OutputT2wImage"
     ${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
 fi
 log_Msg "END: T2w2T1Reg"

--- a/PreFreeSurfer/scripts/T2wToT1wReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wReg.sh
@@ -33,13 +33,12 @@ OutputT1wImageBrain="$7"
 OutputT1wTransform="$8"
 OutputT2wImage="$9"
 OutputT2wTransform="${10}"
-T2wAvailable="${11}"
 
 T1wImageBrainFile=`basename "$T1wImageBrain"`
 
 ${FSLDIR}/bin/imcp "$T1wImageBrain" "$WD"/"$T1wImageBrainFile"
 
-if [[ "${T2wAvailable}" = "FALSE" ]] ; then
+if [ "${T2wImage}" = "NONE" ] ; then
     log_Msg "Skipping T2w to T1w registration --- no T2w image."
 else
     ${FSLDIR}/bin/epi_reg --epi="$T2wImageBrain" --t1="$T1wImage" --t1brain="$WD"/"$T1wImageBrainFile" --out="$WD"/T2w2T1w
@@ -52,7 +51,7 @@ ${FSLDIR}/bin/imcp "$T1wImageBrain" "$OutputT1wImageBrain"
 ${FSLDIR}/bin/fslmerge -t $OutputT1wTransform "$T1wImage".nii.gz "$T1wImage".nii.gz "$T1wImage".nii.gz
 ${FSLDIR}/bin/fslmaths $OutputT1wTransform -mul 0 $OutputT1wTransform
 
-if [[ "${T2wAvailable}" = "TRUE" ]] ; then
+if [ ! "${T2wImage}" = "NONE" ]] ; then
     ${FSLDIR}/bin/imcp "$WD"/T2w2T1w "$OutputT2wImage"
     ${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
 fi

--- a/PreFreeSurfer/scripts/T2wToT1wReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wReg.sh
@@ -37,14 +37,23 @@ OutputT2wTransform="${10}"
 T1wImageBrainFile=`basename "$T1wImageBrain"`
 
 cp "$T1wImageBrain".nii.gz "$WD"/"$T1wImageBrainFile".nii.gz
-${FSLDIR}/bin/epi_reg --epi="$T2wImageBrain" --t1="$T1wImage" --t1brain="$WD"/"$T1wImageBrainFile" --out="$WD"/T2w2T1w
-${FSLDIR}/bin/applywarp --rel --interp=spline --in="$T2wImage" --ref="$T1wImage" --premat="$WD"/T2w2T1w.mat --out="$WD"/T2w2T1w
-${FSLDIR}/bin/fslmaths "$WD"/T2w2T1w -add 1 "$WD"/T2w2T1w -odt float
+
+if [ "${T2wImage}" = "NONE" ] ; then
+    log_Msg "Skipping T2w to T1w registration --- no T2w image."
+else
+    ${FSLDIR}/bin/epi_reg --epi="$T2wImageBrain" --t1="$T1wImage" --t1brain="$WD"/"$T1wImageBrainFile" --out="$WD"/T2w2T1w
+    ${FSLDIR}/bin/applywarp --rel --interp=spline --in="$T2wImage" --ref="$T1wImage" --premat="$WD"/T2w2T1w.mat --out="$WD"/T2w2T1w
+    ${FSLDIR}/bin/fslmaths "$WD"/T2w2T1w -add 1 "$WD"/T2w2T1w -odt float
+fi
+
 cp "$T1wImage".nii.gz "$OutputT1wImage".nii.gz
 cp "$T1wImageBrain".nii.gz "$OutputT1wImageBrain".nii.gz
 ${FSLDIR}/bin/fslmerge -t $OutputT1wTransform "$T1wImage".nii.gz "$T1wImage".nii.gz "$T1wImage".nii.gz
 ${FSLDIR}/bin/fslmaths $OutputT1wTransform -mul 0 $OutputT1wTransform
-cp "$WD"/T2w2T1w.nii.gz "$OutputT2wImage".nii.gz
-${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
+
+[ "${T2wImage}" != "NONE" ] && cp "$WD"/T2w2T1w.nii.gz "$OutputT2wImage".nii.gz
+[ "${T2wImage}" != "NONE" ] && ${FSLDIR}/bin/convertwarp --relout --rel -r "$OutputT2wImage".nii.gz -w $OutputT1wTransform --postmat="$WD"/T2w2T1w.mat --out="$OutputT2wTransform"
 
 log_Msg "END: T2w2T1Reg"
+
+


### PR DESCRIPTION
## Changes to `PreFreeSurferPipeline.sh`

### 1/ Cosmetic changes
Changed tabs to spaces amd removed spaces at end of lines

### 2/ Added optional `--mppversion` parameter
The parameter has the followinig possible values:
* hcp -> enable only strict HCP pipelines functionality (the default if the parameter is not specified)
* legacy -> enable extended pipelines functionality to work with legacy datasets

A check is performed based on this parameter. If ‘hcp’ is specified then the script ends with an error if:
* T2w input image is specified as NONE
* a custom brain / brain mask is used

The check is performed and logged before any processing is started, with explicit warning that the use does not conform to Glasser et al. (2013) paper when ‘legacy’ option is used.

### 3/ Added optional `--custombrain` parameter
The parameter has the following possible values:
* NONE -> do not use a custom brain (the default if the parameter is not provided)
* CUSTOM -> Use a custom brain image
* MASK -> Use a custom mask

Both CUSTOM and MASK options are provided for cases when  `PreFreeSurfer` has been run once before and the preparation of the structural images (e.g. brain masking) have not resulted in correct structural brain images. If either of these options is specifed, all the steps until “Performance of  Atlas Registration” are skipped.

If MASK is specified, then the user had to have placed a custom brain mask in a file  `${T1wFolder}/custom_acpc_dc_restore_mask` , which is then used  to mask the `${T1wFolder}/${T1wImage}_acpc_dc_restore` image to get the `${T1wFolder}/${T1wImage}_acpc_dc_restore_brain`  before the processing resumes with Atlas Registration.

If CUSTOM is specified, then the user had to have (re)placed the desired images and the processing resumes with Atlas Registration directly. 

### 4/ Enabled possibility to specify T2w input image as NONE
If T2w input image is specified as none, (and ‘legacy’  mppversion) is specified then:
* Gradient Nonlinearity Correction, Scan Averaging, ACPC alignment, and BrainExtraction steps are skipped for (nonexistent) T2w image
* Regular Bias Field Correction is skipped and (if so specified by the `--t1biascorrect` parameter) Bias Filed Correction is applied to T1w image only
* Creating one-step resampled version of T2w image is skipped

### 5/ Added optional `--t1biascorrect` parameter,
The parameter has the following possible values:
* YES -> do perform bias correction on T1w image only, the default and used when the parameter is not specified
* NONE -> do not perform bias correction on T1w image only

This functionality is relevant in cases when no T2w image is specified. It allows the user to run Bias correction on a T1w image only.

## Added `BiasFieldCorrection_T1wOnly.sh` script
The script performs Bias field correction of T1w image. It is only used when no T2w image is specified and the `--t1biascorrect` is set to YES or left empty to default value of YES.

## Changes to `AtlasRegistrationToMNI152_FLIRTandFNIRT.sh`
### 1/ Cosmetic changes
Changed tabs to spaces amd removed spaces at end of lines

### 2/ Added optional `--t2status` parameter
The possible values are RUN (the default) or SKIP. If SKIP is specified, operations on T2w image are skipped. Relevant when no T2w image exists.

## Changes to `BrainExtraction_FNIRTbased.sh`
### 1/ Cosmetic changes
Changed tabs to spaces amd removed spaces at end of lines

### 2/ The parameters used are printed out expilictly

### 3/ The progress of individual steps is printed out explicitly

### 4/ The colored echo is currently suppressed and replaced with regular `echo`
This would change after acceptance of the debugging script pull request.

## Changes to `T2wToT1wDistortionCorrectAndReg.sh`
### 1/ Cosmetic changes
Changed tabs to spaces amd removed spaces at end of lines

### 2/ The parameters used are printed out expilictly

### 3/ The progress of individual steps is printed out explicitly

### 4/ Enabled use w/o T2w image
If no T2w image is present (set to NONE) then 
* T2w distortion correction steps are skipped
* T2w to T1w image registration is skipped

## Changes to `T2wToT1wReg.sh`
### 1/ Cosmetic changes
Changed tabs to spaces amd removed spaces at end of lines

### 2/ Enabled use w/o T2w image
All the steps that require T2w image are skipped when T2w image is defined as NONE. It enables processing when no T2w image is available.