### PR TITLE
FreeSurfer Pipeline related pull request

### DIFF
--- a/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
+++ b/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
@@ -78,13 +78,23 @@ log_Msg "seed_cmd_appendix: ${seed_cmd_appendix}"
 
 
 # ------------------------------------------------------------------------------
-#  Check MMP Mode
+#  Compliance check
 # ------------------------------------------------------------------------------
 
 MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
 MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+Compliance="HCPStyleData"
+ComplianceMsg=""
 
-check_mpp_compliance "FreeSurfer53HCP"
+# -- T2w image
+
+if [ "${T2wInputImages}" = "NONE" ]; then
+  ComplianceMsg+=" --t2=NONE"
+  Compliance="LegacyStyleData"
+fi
+
+check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
+
 
 # ------------------------------------------------------------------------------
 #  Show Environment Variables

--- a/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
+++ b/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
@@ -19,7 +19,7 @@ set -e
 
 source $HCPPIPEDIR/global/scripts/log.shlib  # Logging related functions
 source $HCPPIPEDIR/global/scripts/opts.shlib # Command line option functions
-source ${HCPPIPEDIR}/global/scripts/mppmodecheck.shlib  # Functions to check the validity of MPP mode specification
+source ${HCPPIPEDIR}/global/scripts/processingmodecheck.shlib
 
 ########################################## SUPPORT FUNCTIONS ########################################## 
 
@@ -81,8 +81,8 @@ log_Msg "seed_cmd_appendix: ${seed_cmd_appendix}"
 #  Compliance check
 # ------------------------------------------------------------------------------
 
-MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
-MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+ProcessingMode=`opts_GetOpt1 "--processing-mode" $@`
+ProcessingMode=`opts_DefaultOpt $ProcessingMode "HCPStyleData"`
 Compliance="HCPStyleData"
 ComplianceMsg=""
 
@@ -93,7 +93,7 @@ if [ "${T2wInputImages}" = "NONE" ]; then
   Compliance="LegacyStyleData"
 fi
 
-check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
+check_mode_compliance "${ProcessingMoce}" "${Compliance}" "${ComplianceMsg}"
 
 
 # ------------------------------------------------------------------------------

--- a/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
+++ b/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
@@ -19,6 +19,7 @@ set -e
 
 source $HCPPIPEDIR/global/scripts/log.shlib  # Logging related functions
 source $HCPPIPEDIR/global/scripts/opts.shlib # Command line option functions
+source ${HCPPIPEDIR}/global/scripts/mppmodecheck.shlib  # Functions to check the validity of MPP mode specification
 
 ########################################## SUPPORT FUNCTIONS ########################################## 
 
@@ -74,6 +75,16 @@ else
 	seed_cmd_appendix="-norandomness -rng-seed ${recon_all_seed}"
 fi
 log_Msg "seed_cmd_appendix: ${seed_cmd_appendix}"
+
+
+# ------------------------------------------------------------------------------
+#  Check MMP Mode
+# ------------------------------------------------------------------------------
+
+MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
+MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+
+check_mpp_compliance "FreeSurfer53HCP"
 
 # ------------------------------------------------------------------------------
 #  Show Environment Variables

--- a/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
+++ b/FreeSurfer/FreeSurferPipeline-v5.3.0-HCP.sh
@@ -93,7 +93,7 @@ if [ "${T2wInputImages}" = "NONE" ]; then
   Compliance="LegacyStyleData"
 fi
 
-check_mode_compliance "${ProcessingMoce}" "${Compliance}" "${ComplianceMsg}"
+check_mode_compliance "${ProcessingMode}" "${Compliance}" "${ComplianceMsg}"
 
 
 # ------------------------------------------------------------------------------

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -205,7 +205,7 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
                  e.g., [--existing-subject --extra-reconall-arg=-show-edits --no-conf2hires]
 
   [--pipeline-mode={HCPStyleData, LegacyStyleData}]
-      Indicates, which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps 
+      Indicates, which processing mode to use. "HCPStyleData" (the default) follows the processing steps 
          described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. "LegacyStyleData" 
          allows additional processing functionality and use of some acquisitions that do not conform 
          to 'HCP-Style' expectations; i.e., in this case missing high-resolution T2w image 
@@ -379,7 +379,7 @@ get_options()
 	fi
 
 
-	# NOTE: Check for T2w image has moved upwards, as missing T2w is allowed in LegacyStyleData MPP mode.
+	# NOTE: Check for T2w image has moved upwards, as missing T2w is allowed in LegacyStyleData processing mode.
 
 
 	# show optional parameters if specified

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -204,7 +204,7 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
             (ii) you want to be able to run some flag in recon-all, without also regenerating the surfaces.
                  e.g., [--existing-subject --extra-reconall-arg=-show-edits --no-conf2hires]
 
-  [--pipeline-mode={HCPStyleData, LegacyStyleData}]
+  [--processing-mode={HCPStyleData, LegacyStyleData}]
       Indicates, which processing mode to use. "HCPStyleData" (the default) follows the processing steps 
          described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. "LegacyStyleData" 
          allows additional processing functionality and use of some acquisitions that do not conform 

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -646,8 +646,6 @@ main()
 	# accomplished using --extra-reconall-arg=-noT2pial
 	if [ "${T2wImage}" != "NONE" ]; then
 		recon_all_cmd+=" -T2pial"
-	else
-		recon_all_cmd+=" -noT2pial"
 	fi
 
 	recon_all_cmd+=" -openmp ${num_cores}"

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -215,7 +215,7 @@ PARAMETERs can also be specified positionally as:
   ${g_script_name} <path to subject directory> <subject ID> <path to T1 image> <path to T1w brain mask> <path to T2w image> [<recon-all seed value>]
 
   Note that the positional approach to specifying parameters does NOT support the 
-      --existing-subject, --extra-reconall-arg, --no-conf2hires, and --pipeline-mode options.
+      --existing-subject, --extra-reconall-arg, --no-conf2hires, and --processing-mode options.
   The positional approach should be considered deprecated, and may be removed in a future version.
 
 EOF
@@ -300,8 +300,8 @@ get_options()
 				p_extra_reconall_args+="${extra_reconall_arg} "
 				index=$(( index + 1 ))
 				;;
-			--pipeline-mode=*)
-				p_pipelinemode=${argument#*=}
+			--processing-mode=*)
+				p_processing_mode=${argument#*=}
 				index=$(( index + 1 ))
 				;;
 			--no-conf2hires)
@@ -322,7 +322,7 @@ get_options()
 	#  Compliance check
 	# ------------------------------------------------------------------------------
 	
-	ProcessingMoce=${p_pipelinemode:-HCPStyleData}	
+	ProcessingMode=${p_processing_mode:-HCPStyleData}	
     Compliance="HCPStyleData"
     ComplianceMsg=""
 
@@ -336,7 +336,7 @@ get_options()
         p_t2w_image="NONE"
     fi
 
-    check_mode_compliance "${ProcessingMoce}" "${Compliance}" "${ComplianceMsg}"
+    check_mode_compliance "${ProcessingMode}" "${Compliance}" "${ComplianceMsg}"
 
 	# ------------------------------------------------------------------------------
 	#  check required parameters
@@ -395,8 +395,8 @@ get_options()
 	if [ ! -z "${p_conf2hires}" ]; then
 		log_Msg "Include -conf2hires flag in recon-all: ${p_conf2hires}"
 	fi
-	if [ ! -z "${p_pipelinemode}" ] ; then
-  		log_Msg "Set --pipeline-mode to: ${p_pipelinemode}"
+	if [ ! -z "${p_processing_mode}" ] ; then
+  		log_Msg "Set --processing-mode to: ${p_processing_mode}"
 	fi
 
 	if [ ${error_count} -gt 0 ]; then

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -208,7 +208,7 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
       Indicates, which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps 
          described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. "LegacyStyleData" 
          allows additional processing functionality and use of some acquisitions that do not conform 
-         to 'HCP-Style' expectations in this case missing high-resolution T2w image 
+         to 'HCP-Style' expectations; i.e., in this case missing high-resolution T2w image 
 
 PARAMETERs can also be specified positionally as:
 
@@ -364,6 +364,10 @@ get_options()
 	else
 		log_Msg "T1w Brain: ${p_t1w_brain}"
 	fi
+
+
+	# NOTE: Check for T2w image is moved to check_mpp_compliance(), as missing T2w is allowed in LegacyStyleData MPP mode.
+
 
 	# show optional parameters if specified
 	if [ ! -z "${p_seed}" ]; then
@@ -641,9 +645,9 @@ main()
 		recon_all_cmd+=" -emregmask ${T1wImageBrain}"
 	fi
 
-	# By default, refine pial surfaces using T2.
-	# If for some reason the -T2pial flag needs to be excluded from recon-all, this can be
-	# accomplished using --extra-reconall-arg=-noT2pial
+	# By default, refine pial surfaces using T2 (if T2w image provided).
+	# If for some other reason the -T2pial flag needs to be excluded from recon-all, 
+	# this can be accomplished using --extra-reconall-arg=-noT2pial
 	if [ "${T2wImage}" != "NONE" ]; then
 		recon_all_cmd+=" -T2pial"
 	fi

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -319,11 +319,24 @@ get_options()
 	local error_count=0
 
 	# ------------------------------------------------------------------------------
-	#  Check MMP Mode
+	#  Compliance check
 	# ------------------------------------------------------------------------------
 	
-	MPPMode=${p_mppmode:-HCPStyleData}
-	check_mpp_compliance "FreeSurfer"
+	MPPMode=${p_mppmode:-HCPStyleData}	
+    Compliance="HCPStyleData"
+    ComplianceMsg=""
+
+     # -- T2w image
+
+    if [ -z "${p_t2w_image}" ] || [ "${p_t2w_image}" = "NONE" ]; then
+        if [ -z "${p_existing_subject}" ]; then
+            ComplianceMsg+=" --t2w-image= or --t2= not present or set to NONE"
+            Compliance="LegacyStyleData"
+        fi
+        p_t2w_image="NONE"
+    fi
+
+    check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
 
 	# ------------------------------------------------------------------------------
 	#  check required parameters

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -204,7 +204,7 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
             (ii) you want to be able to run some flag in recon-all, without also regenerating the surfaces.
                  e.g., [--existing-subject --extra-reconall-arg=-show-edits --no-conf2hires]
 
-  [--mpp-mode={HCPStyleData, LegacyStyleData}]
+  [--pipeline-mode={HCPStyleData, LegacyStyleData}]
       Indicates, which variant of MPP to use. "HCPStyleData" (the default) follows the processing steps 
          described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. "LegacyStyleData" 
          allows additional processing functionality and use of some acquisitions that do not conform 
@@ -215,7 +215,7 @@ PARAMETERs can also be specified positionally as:
   ${g_script_name} <path to subject directory> <subject ID> <path to T1 image> <path to T1w brain mask> <path to T2w image> [<recon-all seed value>]
 
   Note that the positional approach to specifying parameters does NOT support the 
-      --existing-subject, --extra-reconall-arg, --no-conf2hires, and --mpp-mode options.
+      --existing-subject, --extra-reconall-arg, --no-conf2hires, and --pipeline-mode options.
   The positional approach should be considered deprecated, and may be removed in a future version.
 
 EOF
@@ -300,8 +300,8 @@ get_options()
 				p_extra_reconall_args+="${extra_reconall_arg} "
 				index=$(( index + 1 ))
 				;;
-			--mpp-mode=*)
-				p_mppmode=${argument#*=}
+			--pipeline-mode=*)
+				p_pipelinemode=${argument#*=}
 				index=$(( index + 1 ))
 				;;
 			--no-conf2hires)
@@ -322,11 +322,11 @@ get_options()
 	#  Compliance check
 	# ------------------------------------------------------------------------------
 	
-	MPPMode=${p_mppmode:-HCPStyleData}	
+	ProcessingMoce=${p_pipelinemode:-HCPStyleData}	
     Compliance="HCPStyleData"
     ComplianceMsg=""
 
-     # -- T2w image
+    # -- T2w image
 
     if [ -z "${p_t2w_image}" ] || [ "${p_t2w_image}" = "NONE" ]; then
         if [ -z "${p_existing_subject}" ]; then
@@ -336,7 +336,7 @@ get_options()
         p_t2w_image="NONE"
     fi
 
-    check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
+    check_mode_compliance "${ProcessingMoce}" "${Compliance}" "${ComplianceMsg}"
 
 	# ------------------------------------------------------------------------------
 	#  check required parameters
@@ -395,8 +395,8 @@ get_options()
 	if [ ! -z "${p_conf2hires}" ]; then
 		log_Msg "Include -conf2hires flag in recon-all: ${p_conf2hires}"
 	fi
-	if [ ! -z "${p_mppmode}" ] ; then
-  		log_Msg "Set --mpp-mode to: ${p_mppmode}"
+	if [ ! -z "${p_pipelinemode}" ] ; then
+  		log_Msg "Set --pipeline-mode to: ${p_pipelinemode}"
 	fi
 
 	if [ ${error_count} -gt 0 ]; then
@@ -848,7 +848,7 @@ fi
 
 # Load Function Libraries
 source ${HCPPIPEDIR}/global/scripts/log.shlib
-source ${HCPPIPEDIR}/global/scripts/mppmodecheck.shlib
+source ${HCPPIPEDIR}/global/scripts/processingmodecheck.shlib
 log_Msg "HCPPIPEDIR: ${HCPPIPEDIR}"
 
 # Verify any other needed environment variables are set

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -205,10 +205,12 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
                  e.g., [--existing-subject --extra-reconall-arg=-show-edits --no-conf2hires]
 
   [--processing-mode={HCPStyleData, LegacyStyleData}]
-      Indicates, which processing mode to use. "HCPStyleData" (the default) follows the processing steps 
-         described in Glasser et al. (2013) and requires 'HCP-Style' data acquistion. "LegacyStyleData" 
-         allows additional processing functionality and use of some acquisitions that do not conform 
-         to 'HCP-Style' expectations; i.e., in this case missing high-resolution T2w image 
+      Controls whether the HCP acquisition and processing guidelines should be treated as requirements.
+      "HCPStyleData" (the default) follows the processing steps described in Glasser et al. (2013) 
+         and requires 'HCP-Style' data acquistion. 
+      "LegacyStyleData" allows additional processing functionality and use of some acquisitions
+         that do not conform to 'HCP-Style' expectations.
+         i.e., in this case no high-resolution T2w image acquisition 
 
 PARAMETERs can also be specified positionally as:
 

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -563,7 +563,7 @@ main()
 	local mri_surf2surf_cmd
 
 	local T2wtoT1wFile="T2wtoT1w.mat"
-	local OutputOrigT2wToT1w="OrigT2w2T1w"  #Needs to match name used in PostFreeSurfer (N.B. "OrigT2" here refers to the T2w/T2w.nii.gz file; NOT FreeSurfer's "orig" space)
+	local OutputOrigT1wToT1w="OrigT1w2T1w" # Needs to match name used in PostFreeSurfer (N.B. "OrigT1" here refers to the T1w/T1w.nii.gz file; NOT FreeSurfer's "orig" space)
 
 	# ----------------------------------------------------------------------
 	log_Msg "Starting main functionality"
@@ -625,7 +625,7 @@ main()
 
 		# If --existing-subject is NOT set, AND PostFreeSurfer has been run, then
 		# certain files need to be reverted to their PreFreeSurfer output versions
-		if [ `imtest ${SubjectDIR}/xfms/${OutputOrigT2wToT1w}` = 1 ]; then
+		if [ `imtest ${SubjectDIR}/xfms/${OutputOrigT1wToT1w}` = 1 ]; then
 			log_Err "The --existing-subject flag was not invoked AND PostFreeSurfer has already been run."
 			log_Err "If attempting to run FreeSurfer de novo, certain files (e.g., <subj>/T1w/{T1w,T2w}_acpc_dc*) need to be reverted to their PreFreeSurfer outputs."
 			log_Err_Abort "If this is the goal, delete ${SubjectDIR}/${SubjectID} AND re-run PreFreeSurfer, before invoking FreeSurfer again."

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -210,7 +210,7 @@ PARAMETERs are: [ ] = optional; < > = user supplied value
          and requires 'HCP-Style' data acquistion. 
       "LegacyStyleData" allows additional processing functionality and use of some acquisitions
          that do not conform to 'HCP-Style' expectations.
-         i.e., in this case no high-resolution T2w image acquisition 
+         In this script, it allows not having a high-resolution T2w image.
 
 PARAMETERs can also be specified positionally as:
 

--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -379,7 +379,7 @@ get_options()
 	fi
 
 
-	# NOTE: Check for T2w image is moved to check_mpp_compliance(), as missing T2w is allowed in LegacyStyleData MPP mode.
+	# NOTE: Check for T2w image has moved upwards, as missing T2w is allowed in LegacyStyleData MPP mode.
 
 
 	# show optional parameters if specified
@@ -395,8 +395,8 @@ get_options()
 	if [ ! -z "${p_conf2hires}" ]; then
 		log_Msg "Include -conf2hires flag in recon-all: ${p_conf2hires}"
 	fi
-	if [ "${p_t2w_image}" = "NONE" ] ; then
-  		Compliance="legacy"
+	if [ ! -z "${p_mppmode}" ] ; then
+  		log_Msg "Set --mpp-mode to: ${p_mppmode}"
 	fi
 
 	if [ ${error_count} -gt 0 ]; then

--- a/FreeSurfer/scripts/FreeSurferHiresPial.sh
+++ b/FreeSurfer/scripts/FreeSurferHiresPial.sh
@@ -190,7 +190,7 @@ if [ ! "${T2wImage}" = "NONE" ] ; then
   mris_make_surfaces -nsigma_above 2 -nsigma_below 3 -aseg aseg.hires -filled filled.hires -wm wm.hires -mgz -sdir $SubjectDIR -orig white.deformed -nowhite -orig_white white.deformed -orig_pial pial -T2 "$mridir"/T2w_hires.norm -T1 T1w_hires.norm -output $outputSuffix2 $SubjectID rh
 else
   verbose_red_echo "---> No T2w image, skipping generation of pial second pass surfaces with T2 adjustment."
-  outputSuffix2=""
+  outputSuffix2="preT2.pass2"
 fi
 
 # Create final Xh.pial surfaces in FS conformed space

--- a/FreeSurfer/scripts/FreeSurferHiresPial.sh
+++ b/FreeSurfer/scripts/FreeSurferHiresPial.sh
@@ -77,8 +77,7 @@ cp --preserve=timestamps $SubjectDIR/$SubjectID/surf/lh.thickness $SubjectDIR/$S
 cp --preserve=timestamps $SubjectDIR/$SubjectID/surf/rh.thickness $SubjectDIR/$SubjectID/surf/rh.thickness.preT2.pass1
 
 if [ ! "${T2wImage}" = "NONE" ] ; then
-  # ceho "---> Generating pial first pass surfaces with T2 adjustment."
-  echo "---> Generating pial first pass surfaces with T2 adjustment."
+  verbose_red_echo "---> Generating pial first pass surfaces with T2 adjustment."
   # Generate pial surfaces with T2 adjustment, still first pass.
   # Same 4 files created as above, but have $outputSuffix1 ("postT2.pass1") appended through use of -output flag.
   # Use -T2 flag (rather than -T2dura), since -T2 is the flag used within recon-all script of FS 5.3 (but -T2 and -T2dura generate same results)
@@ -87,8 +86,7 @@ if [ ! "${T2wImage}" = "NONE" ] ; then
   mris_make_surfaces -nsigma_above 2 -nsigma_below 3 -aseg aseg.hires -filled filled.hires -wm wm.hires -mgz -sdir $SubjectDIR -orig white.deformed -nowhite -orig_white white.deformed -orig_pial pial -T2 "$mridir"/T2w_hires.norm -T1 T1w_hires.norm -output $outputSuffix1 $SubjectID lh
   mris_make_surfaces -nsigma_above 2 -nsigma_below 3 -aseg aseg.hires -filled filled.hires -wm wm.hires -mgz -sdir $SubjectDIR -orig white.deformed -nowhite -orig_white white.deformed -orig_pial pial -T2 "$mridir"/T2w_hires.norm -T1 T1w_hires.norm -output $outputSuffix1 $SubjectID rh
 else
-  #ceho "---> No T2w image, skipping generation of pial first pass surfaces with T2 adjustment."
-  echo "---> No T2w image, skipping generation of pial first pass surfaces with T2 adjustment."
+  verbose_red_echo "---> No T2w image, skipping generation of pial first pass surfaces with T2 adjustment."
   outputSuffix1=""
 fi
 
@@ -183,8 +181,7 @@ cp --preserve=timestamps $SubjectDIR/$SubjectID/surf/rh.thickness $SubjectDIR/$S
 
 
 if [ ! "${T2wImage}" = "NONE" ] ; then
-  #ceho "---> Generating pial second pass surfaces with T2 adjustment."
-  echo "---> Generating pial second pass surfaces with T2 adjustment."
+  verbose_red_echo "---> Generating pial second pass surfaces with T2 adjustment."
   # Generate pial surfaces with T2 adjustment, second pass.
   # Same 4 files created as above, but have $outputSuffix2 ("postT2.pass2") appended through use of -output flag
   #Could go from 3 to 2 potentially...
@@ -192,8 +189,7 @@ if [ ! "${T2wImage}" = "NONE" ] ; then
   mris_make_surfaces -nsigma_above 2 -nsigma_below 3 -aseg aseg.hires -filled filled.hires -wm wm.hires -mgz -sdir $SubjectDIR -orig white.deformed -nowhite -orig_white white.deformed -orig_pial pial -T2 "$mridir"/T2w_hires.norm -T1 T1w_hires.norm -output $outputSuffix2 $SubjectID lh
   mris_make_surfaces -nsigma_above 2 -nsigma_below 3 -aseg aseg.hires -filled filled.hires -wm wm.hires -mgz -sdir $SubjectDIR -orig white.deformed -nowhite -orig_white white.deformed -orig_pial pial -T2 "$mridir"/T2w_hires.norm -T1 T1w_hires.norm -output $outputSuffix2 $SubjectID rh
 else
-  # ceho "---> No T2w image, skipping generation of pial second pass surfaces with T2 adjustment."
-  echo "---> No T2w image, skipping generation of pial second pass surfaces with T2 adjustment."
+  verbose_red_echo "---> No T2w image, skipping generation of pial second pass surfaces with T2 adjustment."
   outputSuffix2=""
 fi
 

--- a/FreeSurfer/scripts/FreeSurferHiresPial.sh
+++ b/FreeSurfer/scripts/FreeSurferHiresPial.sh
@@ -87,7 +87,7 @@ if [ ! "${T2wImage}" = "NONE" ] ; then
   mris_make_surfaces -nsigma_above 2 -nsigma_below 3 -aseg aseg.hires -filled filled.hires -wm wm.hires -mgz -sdir $SubjectDIR -orig white.deformed -nowhite -orig_white white.deformed -orig_pial pial -T2 "$mridir"/T2w_hires.norm -T1 T1w_hires.norm -output $outputSuffix1 $SubjectID rh
 else
   verbose_red_echo "---> No T2w image, skipping generation of pial first pass surfaces with T2 adjustment."
-  outputSuffix1=""
+  outputSuffix1=".preT2.pass1"
 fi
 
 

--- a/FreeSurfer/scripts/FreeSurferHiresWhite.sh
+++ b/FreeSurfer/scripts/FreeSurferHiresWhite.sh
@@ -91,8 +91,7 @@ echo "round" >> "$mridir"/transforms/eye.dat
 
 if [ ! "${T2wImage}" = "NONE" ] || [ ! "${T2wImage}" = ""] ; then
 
-  #ceho "---> computing T2 to T1 transform"
-  echo "---> computing T2 to T1 transform"
+  verbose_red_echo "---> computing T2 to T1 transform"
 
   if [ ! -e "$mridir"/transforms/T2wtoT1w.mat ] ; then
     bbregister --s "$SubjectID" --mov "$T2wImage" --surf white.deformed --init-reg "$mridir"/transforms/eye.dat --t2 --reg "$mridir"/transforms/T2wtoT1w.dat --o "$mridir"/T2w_hires.nii.gz
@@ -106,8 +105,7 @@ if [ ! "${T2wImage}" = "NONE" ] || [ ! "${T2wImage}" = ""] ; then
     echo "Verify that "$T2wImage" has not been fine tuned and then remove "$mridir"/transforms/T2wtoT1w.mat"
   fi
 else
-  #ceho "---> No T2 image present, skipping computation of T2w to T1w transform."
-  echo "---> No T2 image present, skipping computation of T2w to T1w transform."
+  verbose_red_echo "---> No T2 image present, skipping computation of T2w to T1w transform."
 fi
 
 


### PR DESCRIPTION
## `FreeSurferPipeline.sh` related changes

### 1/ Addition of optional `—mppversion`  parameter
The parameter has the same functionality as in the PreFreeSurfer pipeline. And is related to the MPP version checking, which in this case only checks for the presence of T2w image.

### 2/ Ability to process w/o T2w image
If T2w image is set to NONE and legacy MPP version is selected then:
* `-T2` option is excluded from `recon_all_cmd`
* `-T2pial` is replaced with `-noT2pial`  in `recon_all_cmd`
* Making T2w to T1w registration available in FSL format section is skipped
* `make_t2w_hires_nifti_file` and `make_t1wxtw2_qc_file` is skipped

### 3/ Cosmetic changes
Switch from tabs to spaces and remove trailing line spaces

## `FreeSurferHiresPial.sh` related changes
### 1/ Cosmetic changes
Switching from tabs to spaces, removing trailing spaces in lines

### 2/ Skipping operations that depend on T2w image
When T2wImage is set to NONE, operations that depend on the presence of T2wImage are skipped.:
* creation of normalized T2w image
* generation of pial first surface with T2 adjustment
* generation of pial second pass surface with T2 adjustment

### 3/ Resolving a bug with computing c_ras.mat
We identified a bug in a code that was triggered in some cases and replaced it with alternative more robust implementation (lines 104-112)

### 4/ The use of ceho is suppressed until debugging library is pulled in

## `FreeSurferHiresWhite.sh` related changes
### 1/ Cosmetic changes
Switching from tabs to spaces, removing trailing spaces in lines

### 2/ Skipping operations that depend on T2w image 
When T2wImage is set to NONE the following is skipped:
* computing T2 to T1 transform

### 3/ The use of ceho is suppressed until debugging library is pulled in