### PR TITLE
fMRIVolume Related Pull Request — Use a specific BOLD for reference

### DIFF
--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -220,6 +220,23 @@ then
 	log_Err_Abort "the --usejacobian option must be 'true' or 'false'"
 fi
 
+
+# ------------------------------------------------------------------------------
+#  Compliance check
+# ------------------------------------------------------------------------------
+
+MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
+MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
+Compliance="HCPStyleData"
+ComplianceMsg=""
+
+check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
+
+
+# -- End compliance check
+
+
+
 # Setup PATHS
 PipelineScripts=${HCPPIPEDIR_fMRIVol}
 GlobalScripts=${HCPPIPEDIR_Global}

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -235,14 +235,14 @@ fMRIReference=${fMRIReference:-NONE}
 #  Compliance check
 # ------------------------------------------------------------------------------
 
-MPPMode=`opts_GetOpt1 "--mpp-mode" $@`
+MPPMode=`opts_GetOpt1 "--processing-mode" $@`
 MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
 Compliance="HCPStyleData"
 ComplianceMsg=""
 
 # -- Use of BOLD reference
 
-if [ ! "${fMRIReference}" = 'NONE' ]; then
+if [ ! "${fMRIReference}" = "NONE" ]; then
   ComplianceMsg+=" --fmriref=${fMRIReference}"
   Compliance="LegacyStyleData"
 fi
@@ -391,7 +391,7 @@ fi
 ${RUN} "$PipelineScripts"/MotionCorrection.sh \
        "$fMRIFolder"/MotionCorrection \
        "$fMRIFolder"/"$NameOffMRI"_gdc \
-       "$fMRIFolder"/"$ScoutName"_gdc \
+       "$reference" \
        "$fMRIFolder"/"$NameOffMRI"_mc \
        "$fMRIFolder"/"$MovementRegressor" \
        "$fMRIFolder"/"$MotionMatrixFolder" \
@@ -441,12 +441,12 @@ if [ $fMRIReference = "NONE" ] ; then
          --biascorrection=${BiasCorrection} \
          --usejacobian=${UseJacobian}
 else
-    log_Msg "linking EPI distorsion correction and T1 registration from ${fMRIReference}"
+    log_Msg "linking EPI distortion correction and T1 registration from ${fMRIReference}"
     if [ -e ${fMRIFolder}/${DCFolderName} ] ; then
         log_Msg "     ... removing stale link (or preexisiting files)"
         rm -r ${fMRIFolder}/${DCFolderName}
     fi
-    ln -s -f ${fMRIReference}/${DCFolderName} ${fMRIFolder}/${DCFolderName}
+    ln -s ${fMRIReference}/${DCFolderName} ${fMRIFolder}/${DCFolderName}
  
     WD=${fMRIReference}/${DCFolderName}
     ${FSLDIR}/bin/imcp ${fMRIReference}/${RegOutput} ${fMRIFolder}/${RegOutput}

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -225,7 +225,7 @@ fi
 #  Legacy Style Data Options
 # ------------------------------------------------------------------------------
 
-fMRIReference=`opts_GetOpt1 "--fmriref" $@`                          # reference BOLD run to use for movement correction target and to copy atlas registration from (or NONE; default)
+fMRIReference=`opts_GetOpt1 "--fmriref" $@`                          # reference BOLD name run to use for movement correction target and to copy atlas registration from (or NONE; default)
 
 # Defaults
 fMRIReference=${fMRIReference:-NONE}
@@ -242,8 +242,8 @@ ComplianceMsg=""
 
 # -- Use of BOLD reference
 
-if [ ! "${DoSliceTimeCorrection}" = 'NONE' ]; then
-  ComplianceMsg+=" --t2=NONE"
+if [ ! "${fMRIReference}" = 'NONE' ]; then
+  ComplianceMsg+=" --fmriref=${fMRIReference}"
   Compliance="LegacyStyleData"
 fi
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -222,6 +222,11 @@ fi
 
 
 # ------------------------------------------------------------------------------
+#  Legacy Style Data Options
+# ------------------------------------------------------------------------------
+
+
+# ------------------------------------------------------------------------------
 #  Compliance check
 # ------------------------------------------------------------------------------
 
@@ -230,8 +235,9 @@ MPPMode=`opts_DefaultOpt $MPPMode "HCPStyleData"`
 Compliance="HCPStyleData"
 ComplianceMsg=""
 
-check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
 
+
+check_mpp_compliance "${MPPMode}" "${Compliance}" "${ComplianceMsg}"
 
 # -- End compliance check
 


### PR DESCRIPTION
Added ability to specify another BOLD image as reference. In that case the reference BOLD image is the target for motion correction and the distortion correction computed for the reference BOLD image is reused instead of recomputed. 

This option has shown to provide better between-bold registration for lower resolution single-band images. It also speeds up computation time as distortion correction need not be recomputed for each bold, but is computed just for the reference bold, usually the first BOLD in a series of acquisitions, and reused. It does require the reference BOLD processing to be finished beforehand.