### PR TITLE
*Bugfix and improvements to dimensionality estimation

### DIFF
--- a/ICAFIX/scripts/functionhighpassandvariancenormalize.m
+++ b/ICAFIX/scripts/functionhighpassandvariancenormalize.m
@@ -162,13 +162,13 @@ end
 %% Compute VN map
 if hp>=0
     if dovol > 0
-        Outcts=icaDim(cts,0,1,2,2); %Volume fits two distributions to deal with processing interpolation and multiband
+        Outcts=icaDim(cts,0,1,-1,2); %0=Don't detrend, 1=Initialize variance normalization at 1, -1=Converge with running dim average, Volume fits two distributions to deal with MNI transform 
     end
     
-    OutBO=icaDim(BO.cdata,0,1,2,3); %CIFTI fits three because of the effects of volume to CIFTI mapping and regularization
+    OutBO=icaDim(BO.cdata,0,1,-1,3); %0=Don't detrend, 1=Initialize variance normalization at 1, -1=Converge with running dim average, CIFTI fits three distributions to deal with volume to CIFTI mapping
 else
     if dovol > 0
-        Outcts=icaDim(cts,0,1,2,3); %Volume fits three distributions to deal with processing interpolation and multiband and concatenation effects
+        Outcts=icaDim(cts,0,1,-1,2); %0=Don't detrend, 1=Initialize variance normalization at 1, -1=Converge with running dim average, Volume fits two distributions to deal with MNI transform  
     end
 end
 

--- a/ICAFIX/scripts/icaDim.m
+++ b/ICAFIX/scripts/icaDim.m
@@ -5,14 +5,14 @@ function [Out] = icaDim(Origdata,DEMDT,VN,Iterate,NDist)
 %Variables
 Out.VNDIM=VN; %Variance Normalization Dimensionality initially set to 1
 lnb = 0.5; %Lower noise bound for Golden Section Search
-stabThresh = Iterate; %How many iterations meeting dimThresh criterion (1 for VNDIM=1 results, 2 for legacy converged results, -1 for new converged results, >2 for fixed iterations)
+stabThresh = Iterate; %How many iterations meeting dimThresh criterion (1 for VNDIM=1 results, 2 for legacy converged results, -1 for new converged results, >3 for fixed iterations)
 
 if Iterate < 0
      stabThresh=0.25; %Difference in running average
      priordimavg=0;
 end
 
-if Iterate > 2
+if Iterate > 3
      stabThresh=Iterate; %Difference in running average
      priordimavg=0;
 end
@@ -163,7 +163,7 @@ while stabCount < stabThresh %Loop until dim output is stable
         end
     end
 
-    if Iterate > 2
+    if Iterate > 3
         stabCount=c;
         priordimavg = mean(Out.VNDIM(4:end));
         disp(['   dimavg: ' mat2str(priordimavg)]);
@@ -172,7 +172,7 @@ end %End while loop for dim calcs
 if Iterate < 0 
     Out.calcDim=round(priordimavg);
 end
-if Iterate > 2 
+if Iterate > 3 
     Out.calcDim=round(mean(Out.VNDIM(4:end)));
 end
 

--- a/ICAFIX/scripts/pca_dim.m
+++ b/ICAFIX/scripts/pca_dim.m
@@ -8,7 +8,7 @@ function prob=pca_dim(lambda,N);
 % Methods described in
 %   Thomas Minka:
 %                  Automatic choice of dimensionality for PCA
-%   Implemented by Christian Beckmann
+%   Implemented by Christian Beckmann, Bugfix by Alex Yang and Tim Coalson
    
    logLambda=log(lambda);
    d=length(lambda);
@@ -41,7 +41,8 @@ function prob=pca_dim(lambda,N);
    t2(t2<=0)=1;
    t1=cumsum(sum(log(t1),2));
    t2=cumsum(sum(log(t2),2));
-   l_Az=0.5*(t1+t1)';
+   %l_Az=0.5*(t1+t1)'; %typo t1+t1, 0.5 not present in melodic c++
+   l_Az=(t1+t2)'; 
 
 
    l_lam=-(N/2)*cumsum(log(lambda));


### PR DESCRIPTION
This pull request improves the accuracy and stability of dimensionality estimation for MR+FIX and related code.  In particular, the pca_dim.m function now aligns with the implementation in melodic, dimensionality is now estimated using the full set of normalized eigenvalues, rather than just the left most when using multiple Wishart distributions (i.e. the left most eigenvalues >1 are padded with ones to match the original number of eigenvalues), and when using multiple Wishart distributions a single overall Wishart distribution is fit to the estimated null eigenvalues for the purposes of the pca_dim.m estimation.  Also, two new modes of convergence are now available for icaDim.m including -1, which converges when the incremental change in dimensionality estimate is less that 0.25, and numbers > 3, which just run the specified number of iterations and compute the average estimated dimensionality from this number.  