### PR TITLE
add 'set -E' to debug.shlib to abort on abnormal exit inside functions

### DIFF
--- a/global/scripts/debug.shlib
+++ b/global/scripts/debug.shlib
@@ -102,13 +102,10 @@ fi
 
 #note: 'set -u' complaints will not call 'trap ... ERR', but will do a 'set -e' exit
 #if we don't have -u but we do have -e, we are in an unintended state
-#but until a disable function is called, it is harmless (for non-interactive), so only warn
-#except, 'trap ... ERR' by default doesn't get inherited by functions except with the errtrace shopt
-#for now, just disable the warning, until we have time for testing
-#if [[ "$-" != *u* && "$-" == *e* ]]
-#then
-#    log_Warn "this script is using debug.shlib, but also specifies 'set -e', which is redundant"
-#fi
+if [[ "$-" != *u* && "$-" == *e* ]]
+then
+    log_Warn "this script is using debug.shlib, but also specifies 'set -e', which is redundant"
+fi
 
 #if interactive, always disable set -e
 if [[ "$-" == *i* ]]
@@ -328,5 +325,7 @@ verbose_echo()
 
 
 debug_defaults
-
+#in order for 'trap ... ERR' to work inside functions, we need -E (aka errtrace)
+set -E
 trap 'debug_on_error "$LINENO" "$BASH_COMMAND" "$?"' ERR
+


### PR DESCRIPTION
This needs nearly-exhaustive testing, because despite being a small edit, a lot of scripts now use debug.shlib.

The base issue is that `trap ... ERR` does not work inside functions by default, so any processing that occurs inside a function that would have aborted with `set -e` set, does NOT get caught by debug.shlib (until this edit).  However, from reading the bash manpage, it seems that with this new edit, `trap ... ERR` may apply in some contexts where `set -e` may have allowed the script to continue.

This edit also re-enables the warning about `set -e` being redundant.