### PR TITLE
Extend the checking of the subcortical segmentation

### DIFF
--- a/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh
+++ b/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh
@@ -285,8 +285,8 @@ for GrayordinatesResolution in ${GrayordinatesResolutions} ; do
 
 	# Cleanup
 	rm ${AtlasROIsSplit}* ${SubjROIsSplit}* ${MissingSplit}*
-	rm "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".dil2x.nii.gz
 	rm ${MissingGrayordinates}.dil2xBrainMask.nii.gz
+	#rm "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".dil2x.nii.gz
 
     ### End report on subcortical segmentation
 done

--- a/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh
+++ b/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh
@@ -214,7 +214,7 @@ for GrayordinatesResolution in ${GrayordinatesResolutions} ; do
     [ "${T2wImage}" != "NONE" ] && applywarp --interp=spline -i "$AtlasSpaceFolder"/"$AtlasSpaceT2wImage".nii.gz -r "$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".nii.gz -o "$AtlasSpaceFolder"/"$AtlasSpaceT2wImage"."$GrayordinatesResolution".nii.gz
     applywarp --interp=spline -i "$AtlasSpaceFolder"/"$AtlasSpaceT1wImage".nii.gz -r "$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".nii.gz -o "$AtlasSpaceFolder"/"$AtlasSpaceT1wImage"."$GrayordinatesResolution".nii.gz
     
-    ### Report on subcortical segmentation
+    ### Report on subcortical segmentation (missing voxels and overlap with Atlas)
 
     # Generate brain mask at appropriate resolution
     applywarp --interp=nn -i "$AtlasSpaceFolder"/"$T1wImageBrainMask".nii.gz -r "$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".nii.gz -o "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".nii.gz
@@ -224,6 +224,13 @@ for GrayordinatesResolution in ${GrayordinatesResolutions} ; do
     ${CARET7DIR}/wb_command -volume-math "(!Brainmask)*CIFTIStandardSpace" ${MissingGrayordinates}.nii.gz -var Brainmask "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".nii.gz -var CIFTIStandardSpace "$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".nii.gz
     MissingGrayordinatesTotal=$(fslstats ${MissingGrayordinates}.nii.gz -V | awk '{print $1}')
 
+	# Repeat with brain mask dilated by 2 x GrayordinatesResolution
+	# Use -volume-dilate rather than 'fslmaths -dilF -dilF', for explicit control over the dilation distance
+	dilDist=$(echo "2 * $GrayordinatesResolution" | bc -l)
+	${CARET7DIR}/wb_command -volume-dilate "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".nii.gz $dilDist NEAREST "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".dil2x.nii.gz
+	${CARET7DIR}/wb_command -volume-math "(!BrainmaskDil2x)*CIFTIStandardSpace" ${MissingGrayordinates}.dil2xBrainMask.nii.gz -var BrainmaskDil2x "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".dil2x.nii.gz -var CIFTIStandardSpace "$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".nii.gz
+    MissingGrayordinatesDil2xTotal=$(fslstats ${MissingGrayordinates}.dil2xBrainMask.nii.gz -V | awk '{print $1}')
+
 	# Split the Atlas and subject-specific ROIs into individual structures, so we can compute counts of missing voxels and overlap relative to specific structures
 	AtlasROIsSplit="$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".split
 	SubjROIsSplit="$AtlasSpaceFolder"/ROIs/ROIs."$GrayordinatesResolution".split
@@ -231,19 +238,33 @@ for GrayordinatesResolution in ${GrayordinatesResolutions} ; do
 	${CARET7DIR}/wb_command -volume-all-labels-to-rois "$AtlasSpaceFolder"/ROIs/Atlas_ROIs."$GrayordinatesResolution".nii.gz 1 ${AtlasROIsSplit}.nii.gz
 	${CARET7DIR}/wb_command -volume-all-labels-to-rois "$AtlasSpaceFolder"/ROIs/ROIs."$GrayordinatesResolution".nii.gz 1 ${SubjROIsSplit}.nii.gz
 
+	# Create a version of subject-specific ROIs, dilated by 2 x GrayordinatesResolution
+	${CARET7DIR}/wb_command -volume-dilate ${SubjROIsSplit}.nii.gz $dilDist NEAREST ${SubjROIsSplit}.dil2x.nii.gz
+
 	# Volume with the *brainmask* voxels missing from the Atlas, with each structure as a separate frame
 	# (Note: need to binarize "Missing" to turn it into a mask, since it uses the original label values)
 	${CARET7DIR}/wb_command -volume-math "(Missing > 0) * Atlas" ${MissingSplit}.nii.gz -var Missing ${MissingGrayordinates}.nii.gz -repeat -var Atlas ${AtlasROIsSplit}.nii.gz
+
+	# Volume with the *brainmask* voxels after 2x dilation that are missing from the Atlas, with each structure as a separate frame
+	${CARET7DIR}/wb_command -volume-math "(MissingDil2x > 0) * Atlas" ${MissingSplit}.dil2xBrainMask.nii.gz -var MissingDil2x ${MissingGrayordinates}.dil2xBrainMask.nii.gz -repeat -var Atlas ${AtlasROIsSplit}.nii.gz
+
 	# Volume with the subject-specific subcortical labels that are *missing* from the corresponding Atlas label, with each structure as a separate frame
 	${CARET7DIR}/wb_command -volume-math "Atlas * (!Subj)" ${SubjROIsSplit}.missing.nii.gz -var Atlas ${AtlasROIsSplit}.nii.gz -var Subj ${SubjROIsSplit}.nii.gz
+
+	# Volume with the subject-specific subcortical labels after 2x dilation that *overlap* with the corresponding Atlas label, with each structure as a separate frame
+	${CARET7DIR}/wb_command -volume-math "(Atlas) * SubjDil2x" ${SubjROIsSplit}.dil2x.overlap.nii.gz -var Atlas ${AtlasROIsSplit}.nii.gz -var SubjDil2x ${SubjROIsSplit}.dil2x.nii.gz
+
 	# Volume with the subject-specific subcortical labels that *overlap* with the corresponding Atlas label, with each structure as a separate frame
 	${CARET7DIR}/wb_command -volume-math "(Atlas) * Subj" ${SubjROIsSplit}.overlap.nii.gz -var Atlas ${AtlasROIsSplit}.nii.gz -var Subj ${SubjROIsSplit}.nii.gz
+
 	# Volume with the subject-specific subcortical labels that are *outside* of the corresponding Atlas label, with each structure as a separate frame
 	${CARET7DIR}/wb_command -volume-math "(!Atlas) * Subj" ${SubjROIsSplit}.outside.nii.gz -var Atlas ${AtlasROIsSplit}.nii.gz -var Subj ${SubjROIsSplit}.nii.gz
 
 	# Extract summary counts
 	${CARET7DIR}/wb_command -volume-stats ${MissingSplit}.nii.gz -reduce SUM -show-map-name > ${MissingSplit}.stats.txt
+	${CARET7DIR}/wb_command -volume-stats ${MissingSplit}.dil2xBrainMask.nii.gz -reduce SUM -show-map-name > ${MissingSplit}.dil2xBrainMask.stats.txt
 	${CARET7DIR}/wb_command -volume-stats ${SubjROIsSplit}.missing.nii.gz -reduce SUM -show-map-name > ${SubjROIsSplit}.missing.stats.txt
+	${CARET7DIR}/wb_command -volume-stats ${SubjROIsSplit}.dil2x.overlap.nii.gz -reduce SUM -show-map-name > ${SubjROIsSplit}.dil2x.overlap.stats.txt
 	${CARET7DIR}/wb_command -volume-stats ${SubjROIsSplit}.overlap.nii.gz -reduce SUM -show-map-name > ${SubjROIsSplit}.overlap.stats.txt
 	${CARET7DIR}/wb_command -volume-stats ${SubjROIsSplit}.outside.nii.gz -reduce SUM -show-map-name > ${SubjROIsSplit}.outside.stats.txt
 
@@ -251,17 +272,21 @@ for GrayordinatesResolution in ${GrayordinatesResolutions} ; do
 	# We assume in the following (without checking) that the structures from -volume-stats -show-map-name are consistent across all files
 	cut -d ':' -f 2 ${MissingSplit}.stats.txt > ${MissingSplit}.stats.roinames.txt
 	cut -d ':' -f 3 ${MissingSplit}.stats.txt > ${MissingSplit}.stats.value.txt
+	cut -d ':' -f 3 ${MissingSplit}.dil2xBrainMask.stats.txt > ${MissingSplit}.dil2xBrainMask.stats.value.txt
 	cut -d ':' -f 3 ${SubjROIsSplit}.missing.stats.txt > ${SubjROIsSplit}.missing.stats.value.txt
+	cut -d ':' -f 3 ${SubjROIsSplit}.dil2x.overlap.stats.txt > ${SubjROIsSplit}.dil2x.overlap.stats.value.txt
 	cut -d ':' -f 3 ${SubjROIsSplit}.overlap.stats.txt > ${SubjROIsSplit}.overlap.stats.value.txt
 	cut -d ':' -f 3 ${SubjROIsSplit}.outside.stats.txt > ${SubjROIsSplit}.outside.stats.value.txt
 
 	outFile="$AtlasSpaceFolder"/ROIs/MissingGrayordinates."$GrayordinatesResolution".txt
-	echo "Structure,nMissingBrainMaskFromAtlas,nMissingROIFromAtlas,nROIOverlapAtlas,nROIOutsideAtlas" > ${outFile}
-	echo "ALL,${MissingGrayordinatesTotal},,," >> ${outFile}
-	paste -d ',' ${MissingSplit}.stats.roinames.txt ${MissingSplit}.stats.value.txt ${SubjROIsSplit}.missing.stats.value.txt ${SubjROIsSplit}.overlap.stats.value.txt ${SubjROIsSplit}.outside.stats.value.txt | tr -d '[:blank:]' >> ${outFile}
+	echo "Structure,nMissing2xDilBrainMaskFromAtlas,nMissingBrainMaskFromAtlas,nMissing2xDilROIFromAtlas,nMissingROIFromAtlas,nROIOverlapAtlas,nROIOutsideAtlas" > ${outFile}
+	echo "ALL,${MissingGrayordinatesDil2xTotal},${MissingGrayordinatesTotal},,,," >> ${outFile}
+	paste -d ',' ${MissingSplit}.stats.roinames.txt ${MissingSplit}.dil2xBrainMask.stats.value.txt ${MissingSplit}.stats.value.txt ${SubjROIsSplit}.missing.stats.value.txt ${SubjROIsSplit}.dil2x.overlap.stats.value.txt ${SubjROIsSplit}.overlap.stats.value.txt ${SubjROIsSplit}.outside.stats.value.txt | tr -d '[:blank:]' >> ${outFile}
 
 	# Cleanup
 	rm ${AtlasROIsSplit}* ${SubjROIsSplit}* ${MissingSplit}*
+	rm "$AtlasSpaceFolder"/"$T1wImageBrainMask"."$GrayordinatesResolution".dil2x.nii.gz
+	rm ${MissingGrayordinates}.dil2xBrainMask.nii.gz
 
     ### End report on subcortical segmentation
 done


### PR DESCRIPTION
With these changes, it will now report separately for each structure, and include additional info regarding overlap with the Atlas ROIs.

Example output file (from the same subject that prompted us to add this report in the first place):
```
Structure,nMissingBrainMaskFromAtlas,nMissingROIFromAtlas,nROIOverlapAtlas,nROIOutsideAtlas
ALL,409,,,
CEREBELLUM_LEFT,155,1304,7405,957
THALAMUS_LEFT,0,217,1071,203
CAUDATE_LEFT,0,303,425,96
PUTAMEN_LEFT,0,606,454,120
PALLIDUM_LEFT,0,129,168,110
BRAIN_STEM,19,468,3004,183
HIPPOCAMPUS_LEFT,28,317,447,139
AMYGDALA_LEFT,44,163,152,87
ACCUMBENS_LEFT,0,89,46,32
DIENCEPHALON_VENTRAL_LEFT,0,150,556,98
CEREBELLUM_RIGHT,81,1279,7865,914
THALAMUS_RIGHT,0,268,980,149
CAUDATE_RIGHT,0,332,423,114
PUTAMEN_RIGHT,0,359,651,102
PALLIDUM_RIGHT,0,93,167,95
HIPPOCAMPUS_RIGHT,19,390,405,92
AMYGDALA_RIGHT,61,175,157,34
ACCUMBENS_RIGHT,0,107,33,40
DIENCEPHALON_VENTRAL_RIGHT,2,210,502,66
```

Note that the sum of `nROIOverlapAtlas` and `nROIOutsideAtlas` is the number of voxels in the subject-specific ROI.  And the sum of `nMissingROIFromAtlas` and `nROIOverlapAtlas` is the number of voxels in the Atlas ROIs.

Having this info readily available will be valuable I think. For example, in the example above, we can quickly discern that a number of structures had rather poor overlap with the Atlas ROIs (e.g., `nMissingROIFromAtlas` > `nROIOverlapAtlas`), such as PUTAMEN_LEFT, both AMYGDALA, and both ACCUMBENS.