### PR TITLE
Pass on gpu options

### DIFF
--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -517,7 +517,7 @@ main() {
 	fi
 
 	log_Msg "pre_eddy_cmd: ${pre_eddy_cmd}"
-	#${pre_eddy_cmd}
+	${pre_eddy_cmd}
 
 	log_Msg "Invoking Eddy Step"
 	local eddy_cmd=""
@@ -542,7 +542,7 @@ main() {
 	fi
 
 	log_Msg "eddy_cmd: ${eddy_cmd}"
-	#${eddy_cmd}
+	${eddy_cmd}
 
 	log_Msg "Invoking Post-Eddy Steps"
 	local post_eddy_cmd=""
@@ -559,7 +559,7 @@ main() {
 	fi
 
 	log_Msg "post_eddy_cmd: ${post_eddy_cmd}"
-	#${post_eddy_cmd}
+	${post_eddy_cmd}
 
 	log_Msg "Completed!"
 	exit 0

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -528,12 +528,12 @@ main() {
 	eddy_cmd+=" --dwiname=${DWIName} "
 	eddy_cmd+=" --printcom=${runcmd} "
 
-	if [ "${no_gpu}" != "true" ]; then
+	if [ "${no_gpu}" == "true" ]; then
 		# default is to use the GPU-enabled version
-		run_eddy_cmd+=" --no_gpu "
+		eddy_cmd+=" --no-gpu "
 	else
 		if [ ! -z "${cuda_version}" ]; then
-			run_eddy_cmd+=" --cuda-version=${cuda_version}"
+			eddy_cmd+=" --cuda-version=${cuda_version}"
 		fi
 	fi
 	if [ ! -z "${extra_eddy_args}" ]; then

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -239,6 +239,8 @@ EOF
 #                         empty string.
 #  ${extra_eddy_args}     Generic string of arguments to be passed to the
 #                         eddy binary
+#  ${SelectBestB0}        true if we should preselect the least motion corrupted b0's for topup
+#                         Anything else or unset means use uniformly sampled b0's
 #  ${no_gpu}              true if we should use the non-GPU-enabled version of eddy
 #                         Anything else or unset means use the GPU-enabled version of eddy
 #  ${cuda_version}        If using the GPU-enabled version, this value _may_ be
@@ -269,7 +271,8 @@ get_options() {
 	b0maxbval=${DEFAULT_B0_MAX_BVAL}
 	runcmd=""
 	extra_eddy_args=""
-	no_gpu=""
+	SelectBestB0="false"
+	no_gpu="false"
 	cuda_version=""
 	CombineDataFlag=1
 
@@ -427,17 +430,13 @@ get_options() {
 	echo "   b0maxbval: ${b0maxbval}"
 	echo "   runcmd: ${runcmd}"
 	echo "   CombineDataFlag: ${CombineDataFlag}"
-	if [ ! -z ${SelectBestB0} ]; then
-		echo "   SelectBestB0: ${SelectBestB0}"
-	fi
+	echo "   SelectBestB0: ${SelectBestB0}"
 	echo "   extra_eddy_args: ${extra_eddy_args}"
-	if [ ! -z ${no_gpu} ]; then
-		echo "   no_gpu: ${no_gpu}"
-	fi
+	echo "   no_gpu: ${no_gpu}"
 	echo "   cuda-version: ${cuda_version}"
 	echo "-- ${g_script_name}: Specified Command-Line Parameters - End --"
 
-	if [ ! -z "${SelectBestB0}" ]; then
+	if [ "${SelectBestB0}" == "true" ]; then
 		dont_peas_set=false
 		fwhm_set=false
 		if [ ! -z "${extra_eddy_args}" ]; then
@@ -513,12 +512,12 @@ main() {
 	pre_eddy_cmd+=" --echospacing=${echospacing} "
 	pre_eddy_cmd+=" --b0maxbval=${b0maxbval} "
 	pre_eddy_cmd+=" --printcom=${runcmd} "
-	if [ ! -z "${SelectBestB0}" ]; then
+	if [ "${SelectBestB0}" == "true" ]; then
 		pre_eddy_cmd+=" --select-best-b0 "
 	fi
 
 	log_Msg "pre_eddy_cmd: ${pre_eddy_cmd}"
-	${pre_eddy_cmd}
+	#${pre_eddy_cmd}
 
 	log_Msg "Invoking Eddy Step"
 	local eddy_cmd=""
@@ -543,7 +542,7 @@ main() {
 	fi
 
 	log_Msg "eddy_cmd: ${eddy_cmd}"
-	${eddy_cmd}
+	#${eddy_cmd}
 
 	log_Msg "Invoking Post-Eddy Steps"
 	local post_eddy_cmd=""
@@ -555,12 +554,12 @@ main() {
 	post_eddy_cmd+=" --dof=${DegreesOfFreedom} "
 	post_eddy_cmd+=" --combine-data-flag=${CombineDataFlag} "
 	post_eddy_cmd+=" --printcom=${runcmd} "
-	if [ ! -z "${SelectBestB0}" ]; then
+	if [ "${SelectBestB0}" == "true" ]; then
 		post_eddy_cmd+=" --select-best-b0 "
 	fi
 
 	log_Msg "post_eddy_cmd: ${post_eddy_cmd}"
-	${post_eddy_cmd}
+	#${post_eddy_cmd}
 
 	log_Msg "Completed!"
 	exit 0

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -214,12 +214,12 @@ EOF
 #  ${StudyFolder}         Path to subject's data folder
 #  ${Subject}             Subject ID
 #  ${PEdir}               Phase Encoding Direction, 1=LR/RL, 2=AP/PA
-#  ${PosInputImages}	  @ symbol separated list of data with 'positive' phase
+#  ${PosInputImages}      @ symbol separated list of data with 'positive' phase
 #                         encoding direction
 #  ${NegInputImages}      @ symbol separated lsit of data with 'negative' phase
 #                         encoding direction
 #  ${echospacing}         Echo spacing in msecs
-#  ${GdCoeffs}			  Path to file containing coefficients that describe
+#  ${GdCoeffs}            Path to file containing coefficients that describe
 #                         spatial variations of the scanner gradients. NONE
 #                         if not available.
 #  ${DWIName}             Name to give DWI output directories
@@ -230,7 +230,7 @@ EOF
 #  ${runcmd}              Set to a user specifed command to use if user has
 #                         requested that commands be echo'd (or printed)
 #                         instead of actually executed. Otherwise, set to
-#						  empty string.
+#                         empty string.
 #  ${extra_eddy_args}     Generic string of arguments to be passed to the
 #                         eddy binary
 #  ${CombineDataFlag}     CombineDataFlag value to pass to

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
@@ -379,7 +379,9 @@ get_options() {
 	echo "   resamp_value: ${resamp_value}"
 	echo "   ol_nstd_value: ${ol_nstd_value}"
 	echo "   extra_eddy_args: ${extra_eddy_args}"
-	echo "   no_gpu: ${no_gpu}"
+	if [ ! -z ${no_gpu} ]; then
+		echo "   no_gpu: ${no_gpu}"
+	fi
 	echo "   cuda-version: ${cuda_version}"
 	echo "-- ${g_script_name}: Specified Command-Line Parameters - End --"
 }

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
@@ -223,7 +223,7 @@ get_options() {
 	resamp_value=""
 	unset ol_nstd_value
 	extra_eddy_args=""
-	no_gpu=""
+	no_gpu="False"
 	cuda_version=""
 
 	# parse arguments
@@ -379,9 +379,7 @@ get_options() {
 	echo "   resamp_value: ${resamp_value}"
 	echo "   ol_nstd_value: ${ol_nstd_value}"
 	echo "   extra_eddy_args: ${extra_eddy_args}"
-	if [ ! -z ${no_gpu} ]; then
-		echo "   no_gpu: ${no_gpu}"
-	fi
+	echo "   no_gpu: ${no_gpu}"
 	echo "   cuda-version: ${cuda_version}"
 	echo "-- ${g_script_name}: Specified Command-Line Parameters - End --"
 }

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -158,6 +158,7 @@ get_options() {
 	DegreesOfFreedom=${DEFAULT_DEGREES_OF_FREEDOM}
 	runcmd=""
 	CombineDataFlag=1
+	SelectBestB0="false"
 
 	# parse arguments
 	local index=0
@@ -259,9 +260,7 @@ get_options() {
 	echo "   DegreesOfFreedom: ${DegreesOfFreedom}"
 	echo "   runcmd: ${runcmd}"
 	echo "   CombineDataFlag: ${CombineDataFlag}"
-	if [ -z "${SelectBestB0}" ]; then
-		echo "   SelectBestB0: ${SelectBestB0}"
-	fi
+	echo "   SelectBestB0: ${SelectBestB0}"
 	echo "-- ${g_script_name}: Specified Command-Line Parameters - End --"
 }
 
@@ -315,7 +314,7 @@ main() {
 	log_Msg "Running Eddy PostProcessing"
 	# Note that gradient distortion correction is applied after 'eddy' in the dMRI Pipeline
 	select_flag="0"
-	if [ ! -z "${SelectBestB0}" ]; then
+	if [ "${SelectBestB0}" == "true" ]; then
 		select_flag="1"
 	fi
 	${runcmd} ${HCPPIPEDIR_dMRI}/eddy_postproc.sh ${outdir} ${GdCoeffs} ${CombineDataFlag} ${select_flag}

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -164,6 +164,7 @@ get_options() {
 	DWIName="Diffusion"
 	b0maxbval=${DEFAULT_B0_MAX_BVAL}
 	runcmd=""
+	SelectBestB0="false"
 
 	# parse arguments
 	local index=0
@@ -283,9 +284,7 @@ get_options() {
 	echo "   DWIName: ${DWIName}"
 	echo "   b0maxbval: ${b0maxbval}"
 	echo "   runcmd: ${runcmd}"
-	if [ ! -z "${SelectBestB0}" ]; then
-		echo "   SelectBestB0: ${SelectBestB0}"
-	fi
+	echo "   SelectBestB0: ${SelectBestB0}"
 	echo "-- ${g_script_name}: Specified Command-Line Parameters - End --"
 }
 
@@ -483,7 +482,7 @@ main() {
 	log_Msg "Running Intensity Normalisation"
 	${runcmd} ${HCPPIPEDIR_dMRI}/basic_preproc_norm_intensity.sh ${outdir} ${b0maxbval}
 
-	if [ ! -z "${SelectBestB0}" ]; then
+	if [ "${SelectBestB0}" == "true" ]; then
 		log_Msg "Running basic preprocessing in preparation of topup (using least distorted b0's)"
 		${runcmd} ${HCPPIPEDIR_dMRI}/basic_preproc_best_b0.sh ${outdir} ${ro_time} ${PEdir} ${b0maxbval}
 	else


### PR DESCRIPTION
Passes on the --no-gpu and --cuda-version flag from DiffPreprocPipeline.sh to DiffPreprocPipeline_Eddy.sh.

Also contains two other minor fixes:
- replaces some tabs with spaces, so that they are not mixed together
- only print no_gpu when running DiffPreprocPipeline_Eddy.sh if no_gpu has actually been set to something