### PR TITLE
Fixed variable name typo

### DIFF
--- a/Examples/Scripts/GenericfMRISurfaceProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRISurfaceProcessingPipelineBatch.sh
@@ -4,7 +4,7 @@ get_batch_options() {
     local arguments=("$@")
 
     unset command_line_specified_study_folder
-    unset command_line_specified_subj_list
+    unset command_line_specified_subj
     unset command_line_specified_run_local
 
     local index=0


### PR DESCRIPTION
Fixed typo and made a variable name consistent between VolumeProcessingPipelineBatch and SurfaceProcessingPipelineBatch