### PR TITLE
Support CombineDataFlag of 0 when averaging rotated bvecs

### DIFF
--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -114,7 +114,7 @@ else # Combining across diffusion directions with opposing phase-encoding polari
 
 	# Average Eddy-Rotated bvecs. Get for each direction the two b matrices, average those and then eigendecompose the average b-matrix to get the new bvec and bval.
 	# Also outputs an index file (1-based) with the indices of the input (Pos/Neg) volumes that have been retained in the output
-	${globalscriptsdir}/average_bvecs.py ${eddydir}/Pos.bval ${eddydir}/Pos_rotated.bvec ${eddydir}/Neg.bval ${eddydir}/Neg_rotated.bvec ${datadir}/avg_data ${eddydir}/Pos_SeriesVolNum.txt ${eddydir}/Neg_SeriesVolNum.txt
+	${globalscriptsdir}/average_bvecs.py ${eddydir}/Pos.bval ${eddydir}/Pos_rotated.bvec ${eddydir}/Neg.bval ${eddydir}/Neg_rotated.bvec ${datadir}/avg_data ${CombineDataFlag} ${eddydir}/Pos_SeriesVolNum.txt ${eddydir}/Neg_SeriesVolNum.txt
 
 	mv ${datadir}/avg_data.bval ${datadir}/bvals
 	mv ${datadir}/avg_data.bvec ${datadir}/bvecs

--- a/global/scripts/average_bvecs.py
+++ b/global/scripts/average_bvecs.py
@@ -190,6 +190,9 @@ def extract_overlaps(bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2, only_co
         session_bv1_indices.append(          bv1_indices + 1)
         session_bv2_indices.append(          bv2_indices + 1)
 
+        offset1 += overlaps
+        offset2 += overlaps
+
         if not only_combine:
             for phase_encoding, overlap, bvals, bvecs, offset in [
                 (1, overlap1, bvals1, bvecs1, offset1),
@@ -213,8 +216,8 @@ def extract_overlaps(bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2, only_co
                     session_bv1_indices.append([-1] * unique)
                     session_bv2_indices.append(indices)
 
-        offset1 += overlap1[session, 1]
-        offset2 += overlap2[session, 1]
+        offset1 += overlap1[session, 1] - overlaps
+        offset2 += overlap2[session, 1] - overlaps
 
     bvals1   = np.concatenate(session_bvals1)
     bvals2   = np.concatenate(session_bvals2)

--- a/global/scripts/average_bvecs.py
+++ b/global/scripts/average_bvecs.py
@@ -27,6 +27,7 @@ def main(bvals1file,
          bvalsoutfile,
          bvecsoutfile,
          indicesoutfile,
+         only_combine,
          overlap1file,
          overlap2file):
     """Averages the bvals/bvecs pairs in the given files, and writes
@@ -76,7 +77,7 @@ def main(bvals1file,
     # Extract the directions which overlap
     # between the two sets of bvals/vecs
     bvals1, bvecs1, bvals2, bvecs2, indices1, indices2 = extract_overlaps(
-        bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2)
+        bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2, only_combine)
 
     # Average the bvals/vecs
     bvals, bvecs = average_bvecs(bvals1, bvecs1, bvals2, bvecs2)
@@ -139,7 +140,7 @@ def loadFile(filename, ndims, dimlens):
     return data
 
 
-def extract_overlaps(bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2):
+def extract_overlaps(bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2, only_combine=False):
     """Figures out the intersection of the bval/bvec pairs, given their
     session overlaps.
 
@@ -150,9 +151,9 @@ def extract_overlaps(bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2):
       - Corresponding bvals from the second set
       - Corresponding bvecs from the second set
       - Indices of the bvals/bvecs included from the first set (starting from
-        1)
+        1); -1 for any missing data
       - Indices of the bvals/bvecs included from the second set (starting
-        from 1)
+        from 1); -1 for any missing data
     """
 
     session_bvals1 = [] 
@@ -188,6 +189,29 @@ def extract_overlaps(bvals1, bvecs1, bvals2, bvecs2, overlap1, overlap2):
         # Indices start from 1
         session_bv1_indices.append(          bv1_indices + 1)
         session_bv2_indices.append(          bv2_indices + 1)
+
+        if not only_combine:
+            for phase_encoding, overlap, bvals, bvecs, offset in [
+                (1, overlap1, bvals1, bvecs1, offset1),
+                (2, overlap2, bvals2, bvecs2, offset2)
+            ]:
+                unique = int(overlap[session, 1] - overlaps)
+                indices = np.arange(offset, offset + unique, dtype=np.int)
+
+                # if there is only one phase encode direction just store same b-value/gradient orientation
+                # for both directions to allow for averaging code to work properly
+                session_bvals1.append(bvals[indices])
+                session_bvals2.append(bvals[indices])
+
+                session_bvecs1.append(bvecs[:, indices])
+                session_bvecs2.append(bvecs[:, indices])
+
+                if phase_encoding == 1:
+                    session_bv1_indices.append(indices)
+                    session_bv2_indices.append([-1] * unique)
+                else:
+                    session_bv1_indices.append([-1] * unique)
+                    session_bv2_indices.append(indices)
 
         offset1 += overlap1[session, 1]
         offset2 += overlap2[session, 1]
@@ -265,10 +289,10 @@ def average_bvecs(bvals1, bvecs1, bvals2, bvecs2):
     
 if __name__ == '__main__':
 
-    if len(sys.argv) not in (6, 8):
+    if len(sys.argv) not in (7, 9):
         print('usage: average_bvecs bvals1 bvecs1 '
               'bvals2 bvecs2 '
-              'output_basename '
+              'output_basename combine_data_flag '
               '[overlap1 overlap2]')
         sys.exit(1)
 
@@ -277,20 +301,21 @@ if __name__ == '__main__':
     bvals2          = sys.argv[3]
     bvecs2          = sys.argv[4]
     output_basename = sys.argv[5]
+    combine_data_flag = int(sys.argv[6])
     bvals_out       = '{0}.bval'.format(output_basename)
     bvecs_out       = '{0}.bvec'.format(output_basename)
     indices_out     = '{0}.idxs'.format(output_basename)
 
-    if len(sys.argv) == 6:
+    if len(sys.argv) == 7:
         overlap1 = None
         overlap2 = None
         
     else:
-        overlap1 = sys.argv[6]
-        overlap2 = sys.argv[7]
+        overlap1 = sys.argv[7]
+        overlap2 = sys.argv[8]
 
     main(bvals1,      bvecs1,
          bvals2,      bvecs2,
          bvals_out,   bvecs_out,
-         indices_out, overlap1,
-         overlap2)
+         indices_out, combine_data_flag == 1,
+         overlap1, overlap2)


### PR DESCRIPTION
It seems like this was never actually supported