### PR TITLE
[TYPO] Remove colon from path of git diff-index

### DIFF
--- a/show_version
+++ b/show_version
@@ -104,7 +104,7 @@ if [[ -d "$HCPPIPEDIR"/.git ]] && which git &> /dev/null
 then
     modified=no
     #ignore modification of things in Examples?
-    if ! (cd "$HCPPIPEDIR"; git diff-index --quiet HEAD -- ':!/Examples/')
+    if ! (cd "$HCPPIPEDIR"; git diff-index HEAD -- '!Examples/')
     then
         modified=YES
         verstring="$verstring"-MOD


### PR DESCRIPTION
This PR addresses a minor TYPO/ERROR that does not cause the rest of the pipeline to fail.

I believe the current command has a mistaken `:` 
```bash
[user@~ HCPpipelines]$ git diff-index --quiet HEAD -- ':!/Examples/'
fatal: Unimplemented pathspec magic '!' in ':!/Examples/'
```

I have removed the `:`. In addition, I have removed `--quiet` because I could not find this flag in `git diff-index` help message. Morever, I don't see why the preceding `/` is necessary. In total, I have removed `:/` and `--quiet`. 

Now everything is fine:

```
[user@~ HCPpipelines]$ git diff-index --quiet HEAD -- '!Examples/'
[user@~ HCPpipelines]$
```

(Any change in `Examples` directory has been suppressed. You can edit any file inside `Examples/` and test it.)