### PR TITLE
Remove old num_cores related code from FreeSurferPipeline.sh

### DIFF
--- a/FreeSurfer/FreeSurferPipeline.sh
+++ b/FreeSurfer/FreeSurferPipeline.sh
@@ -574,7 +574,6 @@ main()
 	local extra_reconall_args
 	local conf2hires="TRUE"
 
-	local num_cores
 	local zero_threshold_T1wImage
 	local return_code
 	local recon_all_cmd
@@ -635,20 +634,6 @@ main()
 	log_Msg "extra_reconall_args: ${extra_reconall_args}"
 	log_Msg "conf2hires: ${conf2hires}"
 
-	# ----------------------------------------------------------------------
-	log_Msg "Figure out the number of cores to use."
-	# ----------------------------------------------------------------------
-	# Both the SGE and PBS cluster schedulers use the environment variable NSLOTS to indicate the
-	# number of cores a job will use. If this environment variable is set, we will use it to
-	# determine the number of cores to tell recon-all to use.
-
-	num_cores=0
-	if [[ -z ${NSLOTS} ]]; then
-		num_cores=8
-	else
-		num_cores="${NSLOTS}"
-	fi
-	log_Msg "num_cores: ${num_cores}"
 
 	if [ "${existing_subject}" != "TRUE" ]; then
 
@@ -703,8 +688,6 @@ main()
 			recon_all_cmd+=" -T2pial"
 		fi
 	fi
-
-	recon_all_cmd+=" -openmp ${num_cores}"
 
 	if [ ! -z "${recon_all_seed}" ]; then
 		recon_all_cmd+=" -norandomness -rng-seed ${recon_all_seed}"


### PR DESCRIPTION
FreeSurferPipeline.sh does not need explicit code for setting the number of cores.

The deleted code in the PR actually results in undesired behavior on the WU SLURM system. (i.e., "-openmp 8" is getting set).

If someone still wants to set the "-openmp" flag in the call to `recon-all`, they can use the `--extra-reconall-arg` flag.  Additionally, the `OMP_NUM_THREADS` environment variable is available.