### PR TITLE
Puts isodd function back into the script

### DIFF
--- a/DiffusionPreprocessing/scripts/basic_preproc_best_b0.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc_best_b0.sh
@@ -13,6 +13,10 @@ echo "${scriptName}: Input Parameter: ro_time: ${ro_time}" # Readout time in sec
 echo "${scriptName}: Input Parameter: PEdir: ${PEdir}"
 echo "${scriptName}: Input Parameter: b0maxbval: ${b0maxbval}"
 
+isodd() {
+	echo "$(($1 % 2))"
+}
+
 rawdir=${workingdir}/rawdata
 topupdir=${workingdir}/topup
 eddydir=${workingdir}/eddy


### PR DESCRIPTION
This is a bug fix, which reverses the change  made in the last commit, which took isodd out.
That removal was not desired, because isodd is actually being used in this script.