### PR TITLE
Made imrm calls at two locations in the Diffusion pipeline more robust and immune to the bug in FSL 6.0.6.2

### DIFF
--- a/DiffusionPreprocessing/scripts/basic_preproc_norm_intensity.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc_norm_intensity.sh
@@ -54,7 +54,7 @@ for entry in ${rawdir}/${basePos}_[0-9]*.nii* ${rawdir}/${baseNeg}_[0-9]*.nii*; 
 
 	echo "${scriptName}: About to fslmaths ${basename}_mean -Tmean ${basename}_mean"
 	${FSLDIR}/bin/fslmaths ${basename}_mean -Tmean ${basename}_mean #This is the mean baseline b0 intensity for the series
-	${FSLDIR}/bin/imrm ${basename}_b0_????
+	${FSLDIR}/bin/imrm ${basename}_b0_????.nii*
 	if [ ${entry_cnt} -eq 0 ]; then #Do not rescale the first series
 		rescale=$(fslmeants -i ${basename}_mean)
 	else

--- a/DiffusionPreprocessing/scripts/basic_preproc_norm_intensity.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc_norm_intensity.sh
@@ -54,7 +54,7 @@ for entry in ${rawdir}/${basePos}_[0-9]*.nii* ${rawdir}/${baseNeg}_[0-9]*.nii*; 
 
 	echo "${scriptName}: About to fslmaths ${basename}_mean -Tmean ${basename}_mean"
 	${FSLDIR}/bin/fslmaths ${basename}_mean -Tmean ${basename}_mean #This is the mean baseline b0 intensity for the series
-# Include nii in filename of imrm command due to bug in behavior of imrm introduced in FSL 6.0.6
+	# Include nii in filename of imrm command due to bug in behavior of imrm introduced in FSL 6.0.6
 	${FSLDIR}/bin/imrm ${basename}_b0_????.nii*
 	if [ ${entry_cnt} -eq 0 ]; then #Do not rescale the first series
 		rescale=$(fslmeants -i ${basename}_mean)

--- a/DiffusionPreprocessing/scripts/basic_preproc_norm_intensity.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc_norm_intensity.sh
@@ -54,6 +54,7 @@ for entry in ${rawdir}/${basePos}_[0-9]*.nii* ${rawdir}/${baseNeg}_[0-9]*.nii*; 
 
 	echo "${scriptName}: About to fslmaths ${basename}_mean -Tmean ${basename}_mean"
 	${FSLDIR}/bin/fslmaths ${basename}_mean -Tmean ${basename}_mean #This is the mean baseline b0 intensity for the series
+# Include nii in filename of imrm command due to bug in behavior of imrm introduced in FSL 6.0.6
 	${FSLDIR}/bin/imrm ${basename}_b0_????.nii*
 	if [ ${entry_cnt} -eq 0 ]; then #Do not rescale the first series
 		rescale=$(fslmeants -i ${basename}_mean)

--- a/DiffusionPreprocessing/scripts/basic_preproc_sequence.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc_sequence.sh
@@ -140,6 +140,7 @@ done
 echo "Merging Pos and Neg images"
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Pos_b0 $(${FSLDIR}/bin/imglob ${rawdir}/Pos_b0_????.*)
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Neg_b0 $(${FSLDIR}/bin/imglob ${rawdir}/Neg_b0_????.*)
+# Include nii in filename of imrm command due to bug in behavior of imrm introduced in FSL 6.0.6
 ${FSLDIR}/bin/imrm ${rawdir}/Pos_b0_????.nii*
 ${FSLDIR}/bin/imrm ${rawdir}/Neg_b0_????.nii*
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Pos $(echo ${rawdir}/${basePos}_[0-9]*.nii*)

--- a/DiffusionPreprocessing/scripts/basic_preproc_sequence.sh
+++ b/DiffusionPreprocessing/scripts/basic_preproc_sequence.sh
@@ -140,8 +140,8 @@ done
 echo "Merging Pos and Neg images"
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Pos_b0 $(${FSLDIR}/bin/imglob ${rawdir}/Pos_b0_????.*)
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Neg_b0 $(${FSLDIR}/bin/imglob ${rawdir}/Neg_b0_????.*)
-${FSLDIR}/bin/imrm ${rawdir}/Pos_b0_????
-${FSLDIR}/bin/imrm ${rawdir}/Neg_b0_????
+${FSLDIR}/bin/imrm ${rawdir}/Pos_b0_????.nii*
+${FSLDIR}/bin/imrm ${rawdir}/Neg_b0_????.nii*
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Pos $(echo ${rawdir}/${basePos}_[0-9]*.nii*)
 ${FSLDIR}/bin/fslmerge -t ${rawdir}/Neg $(echo ${rawdir}/${baseNeg}_[0-9]*.nii*)
 

--- a/DiffusionPreprocessing/scripts/eddy_postproc.sh
+++ b/DiffusionPreprocessing/scripts/eddy_postproc.sh
@@ -161,7 +161,10 @@ if [ ! $GdCoeffs = "NONE" ]; then
 	${FSLDIR}/bin/calc_grad_perc_dev --fullwarp=${warpedDir}/fullWarp -o ${datadir}/grad_dev
 	${FSLDIR}/bin/fslmerge -t ${datadir}/grad_dev ${datadir}/grad_dev_x ${datadir}/grad_dev_y ${datadir}/grad_dev_z
 	${FSLDIR}/bin/fslmaths ${datadir}/grad_dev -div 100 ${datadir}/grad_dev #Convert from % deviation to absolute
-	${FSLDIR}/bin/imrm ${datadir}/grad_dev_?
+	# Delete each of the grad_dev files individualy due to bug in behavior of imrm introduced in FSL 6.0.6
+	${FSLDIR}/bin/imrm ${datadir}/grad_dev_x
+	${FSLDIR}/bin/imrm ${datadir}/grad_dev_y
+	${FSLDIR}/bin/imrm ${datadir}/grad_dev_z
 	${FSLDIR}/bin/imrm ${datadir}/trilinear
 	${FSLDIR}/bin/imrm ${warpedDir}/data_dilated_vol1
 fi


### PR DESCRIPTION
This pull request pertains to issue #246 (https://github.com/Washington-University/HCPpipelines/issues/246).