### PR TITLE
fix the high pass argument

### DIFF
--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -51,7 +51,7 @@ opts_AddMandatory '--low-res-meshes' 'LowResMeshes' 'meshnum@meshnum@...' "low r
 opts_AddMandatory '--registration-name' 'RegName' 'MSMAll' "the registration string corresponding to the input files, e.g. 'MSMAll_InitalReg'"
 opts_AddMandatory '--maps' 'Maps' 'non@myelin@maps' "@-delimited map name strings corresponding to maps that are not myelin maps, e.g. 'sulc@curvature@corrThickness@thickness'"
 opts_AddMandatory '--smoothing-fwhm' 'SmoothingFWHM' 'number' "Smoothing FWHM that matches what was used in the fMRISurface pipeline"
-opts_AddMandatory '--highpass' 'HighPass' 'integer' 'the high pass value that was used when running FIX' '--melodic-high-pass'
+opts_AddMandatory '--high-pass' 'HighPass' 'integer' 'the high pass value that was used when running FIX' '--melodic-high-pass'
 opts_AddMandatory '--motion-regression' 'MotionRegression' 'TRUE or FALSE' 'whether FIX should do motion regression'
 opts_AddMandatory '--msm-all-templates' 'MSMAllTemplates' 'path' "path to directory containing MSM All template files, e.g. 'YourFolder/global/templates/MSMAll'"
 # optional inputs

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -51,7 +51,7 @@ opts_AddMandatory '--low-res-meshes' 'LowResMeshes' 'meshnum@meshnum@...' "low r
 opts_AddMandatory '--registration-name' 'RegName' 'MSMAll' "the registration string corresponding to the input files, e.g. 'MSMAll_InitalReg'"
 opts_AddMandatory '--maps' 'Maps' 'non@myelin@maps' "@-delimited map name strings corresponding to maps that are not myelin maps, e.g. 'sulc@curvature@corrThickness@thickness'"
 opts_AddMandatory '--smoothing-fwhm' 'SmoothingFWHM' 'number' "Smoothing FWHM that matches what was used in the fMRISurface pipeline"
-opts_AddMandatory '--high-pass' 'HighPass' 'integer' 'the high pass value that was used when running FIX' '--melodic-high-pass'
+opts_AddMandatory '--high-pass' 'HighPass' 'integer' 'the high pass value that was used when running FIX' '--melodic-high-pass' '--highpass'
 opts_AddMandatory '--motion-regression' 'MotionRegression' 'TRUE or FALSE' 'whether FIX should do motion regression'
 opts_AddMandatory '--msm-all-templates' 'MSMAllTemplates' 'path' "path to directory containing MSM All template files, e.g. 'YourFolder/global/templates/MSMAll'"
 # optional inputs

--- a/Examples/Scripts/DeDriftAndResamplePipelineBatch.sh
+++ b/Examples/Scripts/DeDriftAndResamplePipelineBatch.sh
@@ -154,7 +154,7 @@ for Subject in "${Subjlist[@]}" ; do
         --fix-names="$fixNames" \
         --dont-fix-names="$dontFixNames" \
         --smoothing-fwhm="$SmoothingFWHM" \
-        --highpass="$HighPass" \
+        --high-pass="$HighPass" \
         --matlab-run-mode="$MatlabMode" \
         --motion-regression="$MotionRegression"
 done


### PR DESCRIPTION
## Background
The `Examples/Scripts/DeDriftAndResamplePipelineBatch.sh` doesn't set the correct argument of high pass value, and as a result the `DeDriftAndResample/DeDriftAndResamplePipeline.sh` was wrongly updated about this argument.

## Main change
replace the `--highpass` with `--high-pass` to stay consistency of the same argument in the other scripts, e.g. ICAFix, MSMAll.
