### PR TITLE
fix DeDriftAndResample and MyelinMap_BC module

### DIFF
--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -123,8 +123,10 @@ log_Msg "After delimiter substitution, Maps: ${Maps}"
 #these elses result in empty when given the empty string, make NONE do the same
 if [[ "${MyelinMaps}" == "NONE" ]] ; then
 	MyelinMaps=""
+	MyelinMapsArray=()
 else
 	MyelinMaps=`echo "$MyelinMaps" | sed s/"@"/" "/g`
+	IFS=' ' read -a MyelinMapsArray <<< "${MyelinMaps}"
 fi
 log_Msg "After delimiter substitution, MyelinMaps: ${MyelinMaps}"
 
@@ -411,68 +413,72 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 
 	for Map in ${Maps} ${MyelinMaps} SphericalDistortion ArealDistortion EdgeDistortion StrainJ StrainR ; do
 		log_Msg "Map: ${Map}"
-
-		for MapMap in ${MyelinMaps} ; do
+		
+		for ((index = 0; index < ${#MyelinMapsArray[@]}; ++index))
+		do
+			MapMap="${MyelinMapsArray[index]}"
 			log_Msg "MapMap: ${MapMap}"
-
+			
 			if [ ${MapMap} = ${Map} ] ; then
+				# only compute the bias field once when fed with multiple types of myelin maps
+				if ((index==0)) ; then
+					# ----- Begin moved statements -----
 
-				# ----- Begin moved statements -----
+					# Recompute Myelin Map Bias Field Based on Better Registration
+					log_Msg "Recompute Myelin Map Bias Field Based on Better Registration"
 
-				# Recompute Myelin Map Bias Field Based on Better Registration
-				log_Msg "Recompute Myelin Map Bias Field Based on Better Registration"
+					cifti_in=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
+					log_File_Must_Exist "${cifti_in}" # 1
 
-				cifti_in=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
-				log_File_Must_Exist "${cifti_in}" # 1
+					cifti_template=${DownSampleFolder}/${Subject}.MyelinMap.${LowResMesh}k_fs_LR.dscalar.nii
+					log_File_Must_Exist "${cifti_template}" # 2
 
-				cifti_template=${DownSampleFolder}/${Subject}.MyelinMap.${LowResMesh}k_fs_LR.dscalar.nii
-				log_File_Must_Exist "${cifti_template}" # 2
+					cifti_out=${DownSampleFolder}/${Subject}.MyelinMap_${OutputRegName}.${LowResMesh}k_fs_LR.dscalar.nii
 
-				cifti_out=${DownSampleFolder}/${Subject}.MyelinMap_${OutputRegName}.${LowResMesh}k_fs_LR.dscalar.nii
+					left_spheres_current_sphere=${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii
+					log_File_Must_Exist "${left_spheres_current_sphere}" # 3
 
-				left_spheres_current_sphere=${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii
-				log_File_Must_Exist "${left_spheres_current_sphere}" # 3
+					left_spheres_new_sphere=${DownSampleFolder}/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii
+					log_File_Must_Exist "${left_spheres_new_sphere}" # 4
 
-				left_spheres_new_sphere=${DownSampleFolder}/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii
-				log_File_Must_Exist "${left_spheres_new_sphere}" # 4
+					left_area_surfs_current_area=${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii
+					log_File_Must_Exist "${left_area_surfs_current_area}" # 5
 
-				left_area_surfs_current_area=${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii
-				log_File_Must_Exist "${left_area_surfs_current_area}" # 5
+					left_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.L.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
+					log_File_Must_Exist "${left_area_surfs_new_area}" # 6 - This is the one that doesn't exist
 
-				left_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.L.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
-				log_File_Must_Exist "${left_area_surfs_new_area}" # 6 - This is the one that doesn't exist
+					right_spheres_current_sphere=${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii
+					log_File_Must_Exist "${right_spheres_current_sphere}"
 
-				right_spheres_current_sphere=${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii
-				log_File_Must_Exist "${right_spheres_current_sphere}"
+					right_spheres_new_sphere=${DownSampleFolder}/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii
+					log_File_Must_Exist "${right_spheres_new_sphere}"
 
-				right_spheres_new_sphere=${DownSampleFolder}/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii
-				log_File_Must_Exist "${right_spheres_new_sphere}"
+					right_area_surfs_current_area=${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii
+					log_File_Must_Exist "${right_area_surfs_current_area}"
 
-				right_area_surfs_current_area=${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii
-				log_File_Must_Exist "${right_area_surfs_current_area}"
+					right_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.R.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
+					log_File_Must_Exist "${right_area_surfs_new_area}"
 
-				right_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.R.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
-				log_File_Must_Exist "${right_area_surfs_new_area}"
-
-				log_Debug_Msg "Point 1.1"
-
-				${Caret7_Command} -cifti-resample ${cifti_in} COLUMN ${cifti_template} COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL ${cifti_out} -surface-postdilate 40 -left-spheres ${left_spheres_current_sphere} ${left_spheres_new_sphere} -left-area-surfs ${left_area_surfs_current_area} ${left_area_surfs_new_area} -right-spheres ${right_spheres_current_sphere} ${right_spheres_new_sphere} -right-area-surfs ${right_area_surfs_current_area} ${right_area_surfs_new_area}
-
-				log_Debug_Msg "Point 1.2"
-				# Myelin Map BC using 32k
-				"$HCPPIPEDIR"/global/scripts/MyelinMap_BC.sh \
-					--study-folder="$StudyFolder" \
-					--subject="$Subject" \
-					--registration-name="$RegName" \
-					--msm-all-templates="$MSMAllTemplates" \
-					--use-ind-mean="$UseIndMean" \
-					--low-res-mesh="$LowResMesh" \
-					--myelin-target-file="$MyelinTargetFile" \
-					--map="$Map"
-				# ----- End moved statements -----
+					log_Debug_Msg "Point 1.1"
+					
+					# Myelin Map BC using 32k
+					"$HCPPIPEDIR"/global/scripts/MyelinMap_BC.sh \
+						--study-folder="$StudyFolder" \
+						--subject="$Subject" \
+						--registration-name="$OutputRegName" \
+						--msm-all-templates="$MSMAllTemplates" \
+						--use-ind-mean="$UseIndMean" \
+						--low-res-mesh="$LowResMesh" \
+						--myelin-target-file="$MyelinTargetFile" \
+						--map="$Map"
+					# ----- End moved statements -----
+				else
+					# bias field in native space is already generated
+					# BC the other types of given myelin maps
+					${Caret7_Command} -cifti-math "Var - Bias" ${NativeFolder}/${Subject}.${Map}_BC_${OutputRegName}.native.dscalar.nii -var Var ${NativeFolder}/${Subject}.${Map}.native.dscalar.nii -var Bias ${NativeFolder}/${Subject}.BiasField_${OutputRegName}.native.dscalar.nii
+				fi
 				Map="${Map}_BC"
-
-				log_Debug_Msg "Point 1.3"
+				log_Debug_Msg "Point 1.2"
 			fi
 		done
 

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -467,7 +467,8 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 					--msm-all-templates="$MSMAllTemplates" \
 					--use-ind-mean="$UseIndMean" \
 					--low-res-mesh="$LowResMesh" \
-					--myelin-target-file="$MyelinTargetFile"
+					--myelin-target-file="$MyelinTargetFile" \
+					--map="$Map"
 				# ----- End moved statements -----
 				Map="${Map}_BC"
 

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -136,7 +136,7 @@ else
 	#fixNames=`echo "$fixNames" | sed s/"@"/" "/g`
 	IFS=@ read -a fixNames <<< "${fixNames}"
 fi
-log_Msg "After delimiter substitution, fixNames: ${fixNames[@]}"
+log_Msg "After delimiter substitution, fixNames: ${fixNames[*]+${fixNames[*]}}"
 
 if [[ "${dontFixNames}" == "NONE" ]] ; then
 	dontFixNames=()
@@ -144,7 +144,7 @@ else
 	#dontFixNames=`echo "$dontFixNames" | sed s/"@"/" "/g`
 	IFS=@ read -a dontFixNames <<< "${dontFixNames}"
 fi
-log_Msg "After delimiter substitution, dontFixNames: ${dontFixNames[@]}"
+log_Msg "After delimiter substitution, dontFixNames: ${dontFixNames[*]+${dontFixNames[*]}}"
 
 if [[ "${mrFIXNames}" == "NONE" ]] ; then
 	mrFIXNames=()
@@ -154,7 +154,7 @@ else
 	#two-level list, % and @, parse only one stage here
 	IFS=% read -a mrFIXNames <<< "${mrFIXNames}"
 fi
-log_Msg "After delimiter substitution, mrFIXNames: ${mrFIXNames[@]}"
+log_Msg "After delimiter substitution, mrFIXNames: ${mrFIXNames[*]+${mrFIXNames[*]}}"
 
 if [[ "$mrFIXConcatNames" == "NONE" ]]
 then
@@ -162,7 +162,7 @@ then
 else
 	IFS=@ read -a mrFIXConcatNames <<< "$mrFIXConcatNames"
 fi
-log_Msg "After delimiter substitution, mrFIXConcatNames: ${mrFIXConcatNames[@]}"
+log_Msg "After delimiter substitution, mrFIXConcatNames: ${mrFIXConcatNames[*]+${mrFIXConcatNames[*]}}"
 
 if (( ${#mrFIXNames[@]} != ${#mrFIXConcatNames[@]} ))
 then
@@ -175,7 +175,7 @@ else
 	#two-level list, % and @, parse only one stage here
 	IFS=% read -a mrFIXExtractNamesArr <<< "${mrFIXExtractNames}"
 fi
-log_Msg "After delimiter substitution, mrFIXExtractNamesArr: ${mrFIXExtractNamesArr[@]}"
+log_Msg "After delimiter substitution, mrFIXExtractNamesArr: ${mrFIXExtractNamesArr[*]+${mrFIXExtractNamesArr[*]}}"
 
 if [[ "$mrFIXExtractConcatNames" == "NONE" ]]
 then
@@ -183,7 +183,7 @@ then
 else
 	IFS=@ read -a mrFIXExtractConcatNamesArr <<< "$mrFIXExtractConcatNames"
 fi
-log_Msg "After delimiter substitution, mrFIXExtractConcatNamesArr: ${mrFIXExtractConcatNamesArr[@]}"
+log_Msg "After delimiter substitution, mrFIXExtractConcatNamesArr: ${mrFIXExtractConcatNamesArr[*]+${mrFIXExtractConcatNamesArr[*]}}"
 
 if (( ${#mrFIXExtractNamesArr[@]} != ${#mrFIXExtractConcatNamesArr[@]} ))
 then
@@ -201,7 +201,7 @@ then
 else
 	IFS=@ read -a extractExtraRegNamesArr <<< "$mrFIXExtractExtraRegNames"
 fi
-log_Msg "After delimiter substitution, extractExtraRegNamesArr: ${extractExtraRegNamesArr[@]}"
+log_Msg "After delimiter substitution, extractExtraRegNamesArr: ${extractExtraRegNamesArr[*]+${extractExtraRegNamesArr[*]}}"
 
 if ((mrFIXExtractDoVolBool && ${#mrFIXExtractConcatNamesArr[@]} == 0))
 then
@@ -494,7 +494,7 @@ LowResMesh=`echo ${LowResMeshes} | cut -d " " -f 1`
 
 # Resample (and resmooth) TS from Native 
 log_Msg "Resample (and resmooth) TS from Native"
-for fMRIName in "${fixNames[@]}" "${dontFixNames[@]}" "${mrFIXNamesAll[@]}" ; do
+for fMRIName in ${fixNames[@]+"${fixNames[@]}"} ${dontFixNames[@]+"${dontFixNames[@]}"} ${mrFIXNamesAll[@]+"${mrFIXNamesAll[@]}"} ; do
 	log_Msg "fMRIName: ${fMRIName}"
 	cp ${ResultsFolder}/${fMRIName}/${fMRIName}_Atlas${InRegName}.dtseries.nii ${ResultsFolder}/${fMRIName}/${fMRIName}_Atlas_${OutputRegName}.dtseries.nii
 	for Hemisphere in L R ; do
@@ -518,8 +518,8 @@ done
 
 # ReApply FIX Cleanup
 log_Msg "ReApply FIX Cleanup"
-log_Msg "fixNames: ${fixNames[@]}"
-for fMRIName in "${fixNames[@]}" ; do
+log_Msg "fixNames: ${fixNames[*]+${fixNames[*]}}"
+for fMRIName in ${fixNames[@]+"${fixNames[@]}"} ; do
 	log_Msg "fMRIName: ${fMRIName}"
 	reapply_fix_cmd=("${HCPPIPEDIR}/ICAFIX/ReApplyFixPipeline.sh" --path="${StudyFolder}" --subject="${Subject}" --fmri-name="${fMRIName}" --high-pass="${HighPass}" --reg-name="${OutputRegName}" --matlab-run-mode="${MatlabRunMode}" --motion-regression="${MotionRegression}")
 	log_Msg "reapply_fix_cmd: ${reapply_fix_cmd[*]}"
@@ -537,7 +537,7 @@ do
 	log_Msg "reapply_mr_fix_cmd: ${reapply_mr_fix_cmd[*]}"
 	"${reapply_mr_fix_cmd[@]}"
 
-	for regname in "$OutputRegName" "${extractExtraRegNamesArr[@]+"${extractExtraRegNamesArr[@]}"}"
+	for regname in "$OutputRegName" ${extractExtraRegNamesArr[@]+"${extractExtraRegNamesArr[@]}"}
 	do
 		#MSMSulc special naming convention
 		if [[ "$regname" == "MSMSulc" ]]

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -410,77 +410,74 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 
 	# Resample scalar maps and apply new bias field
 	log_Msg "Resample scalar maps and apply new bias field"
-
+	
+	BiasFieldComputed=false
 	for Map in ${Maps} ${MyelinMaps} SphericalDistortion ArealDistortion EdgeDistortion StrainJ StrainR ; do
 		log_Msg "Map: ${Map}"
 		
-		for ((index = 0; index < ${#MyelinMapsArray[@]}; ++index))
-		do
-			MapMap="${MyelinMapsArray[index]}"
-			log_Msg "MapMap: ${MapMap}"
-			
-			if [ ${MapMap} = ${Map} ] ; then
-				# only compute the bias field once when fed with multiple types of myelin maps
-				if ((index==0)) ; then
-					# ----- Begin moved statements -----
+		if [[ " ${MyelinMapsArray[*]} " =~ " ${Map} " ]]; then
+			# only compute the bias field once when the Map is a part of the MyelinMaps
+			if [ "$BiasFieldComputed" = false ]; then
+				# ----- Begin moved statements -----
 
-					# Recompute Myelin Map Bias Field Based on Better Registration
-					log_Msg "Recompute Myelin Map Bias Field Based on Better Registration"
+				# Recompute Myelin Map Bias Field Based on Better Registration
+				log_Msg "Recompute Myelin Map Bias Field Based on Better Registration"
 
-					cifti_in=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
-					log_File_Must_Exist "${cifti_in}" # 1
+				cifti_in=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
+				log_File_Must_Exist "${cifti_in}" # 1
 
-					cifti_template=${DownSampleFolder}/${Subject}.MyelinMap.${LowResMesh}k_fs_LR.dscalar.nii
-					log_File_Must_Exist "${cifti_template}" # 2
+				cifti_template=${DownSampleFolder}/${Subject}.MyelinMap.${LowResMesh}k_fs_LR.dscalar.nii
+				log_File_Must_Exist "${cifti_template}" # 2
 
-					cifti_out=${DownSampleFolder}/${Subject}.MyelinMap_${OutputRegName}.${LowResMesh}k_fs_LR.dscalar.nii
+				cifti_out=${DownSampleFolder}/${Subject}.MyelinMap_${OutputRegName}.${LowResMesh}k_fs_LR.dscalar.nii
 
-					left_spheres_current_sphere=${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii
-					log_File_Must_Exist "${left_spheres_current_sphere}" # 3
+				left_spheres_current_sphere=${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii
+				log_File_Must_Exist "${left_spheres_current_sphere}" # 3
 
-					left_spheres_new_sphere=${DownSampleFolder}/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii
-					log_File_Must_Exist "${left_spheres_new_sphere}" # 4
+				left_spheres_new_sphere=${DownSampleFolder}/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii
+				log_File_Must_Exist "${left_spheres_new_sphere}" # 4
 
-					left_area_surfs_current_area=${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii
-					log_File_Must_Exist "${left_area_surfs_current_area}" # 5
+				left_area_surfs_current_area=${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii
+				log_File_Must_Exist "${left_area_surfs_current_area}" # 5
 
-					left_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.L.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
-					log_File_Must_Exist "${left_area_surfs_new_area}" # 6 - This is the one that doesn't exist
+				left_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.L.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
+				log_File_Must_Exist "${left_area_surfs_new_area}" # 6 - This is the one that doesn't exist
 
-					right_spheres_current_sphere=${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii
-					log_File_Must_Exist "${right_spheres_current_sphere}"
+				right_spheres_current_sphere=${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii
+				log_File_Must_Exist "${right_spheres_current_sphere}"
 
-					right_spheres_new_sphere=${DownSampleFolder}/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii
-					log_File_Must_Exist "${right_spheres_new_sphere}"
+				right_spheres_new_sphere=${DownSampleFolder}/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii
+				log_File_Must_Exist "${right_spheres_new_sphere}"
 
-					right_area_surfs_current_area=${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii
-					log_File_Must_Exist "${right_area_surfs_current_area}"
+				right_area_surfs_current_area=${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii
+				log_File_Must_Exist "${right_area_surfs_current_area}"
 
-					right_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.R.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
-					log_File_Must_Exist "${right_area_surfs_new_area}"
+				right_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.R.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
+				log_File_Must_Exist "${right_area_surfs_new_area}"
 
-					log_Debug_Msg "Point 1.1"
-					
-					# Myelin Map BC using 32k
-					"$HCPPIPEDIR"/global/scripts/MyelinMap_BC.sh \
-						--study-folder="$StudyFolder" \
-						--subject="$Subject" \
-						--registration-name="$OutputRegName" \
-						--msm-all-templates="$MSMAllTemplates" \
-						--use-ind-mean="$UseIndMean" \
-						--low-res-mesh="$LowResMesh" \
-						--myelin-target-file="$MyelinTargetFile" \
-						--map="$Map"
-					# ----- End moved statements -----
-				else
-					# bias field in native space is already generated
-					# BC the other types of given myelin maps
-					${Caret7_Command} -cifti-math "Var - Bias" ${NativeFolder}/${Subject}.${Map}_BC_${OutputRegName}.native.dscalar.nii -var Var ${NativeFolder}/${Subject}.${Map}.native.dscalar.nii -var Bias ${NativeFolder}/${Subject}.BiasField_${OutputRegName}.native.dscalar.nii
-				fi
-				Map="${Map}_BC"
-				log_Debug_Msg "Point 1.2"
+				log_Debug_Msg "Point 1.1"
+				
+				# Myelin Map BC using 32k
+				"$HCPPIPEDIR"/global/scripts/MyelinMap_BC.sh \
+					--study-folder="$StudyFolder" \
+					--subject="$Subject" \
+					--registration-name="$OutputRegName" \
+					--msm-all-templates="$MSMAllTemplates" \
+					--use-ind-mean="$UseIndMean" \
+					--low-res-mesh="$LowResMesh" \
+					--myelin-target-file="$MyelinTargetFile" \
+					--map="$Map"
+				# ----- End moved statements -----
+				# bias field is computed in the module MyelinMap_BC.sh
+				BiasFieldComputed=true
+			else
+				# bias field in native space is already generated
+				# BC the other types of given myelin maps
+				${Caret7_Command} -cifti-math "Var - Bias" ${NativeFolder}/${Subject}.${Map}_BC_${OutputRegName}.native.dscalar.nii -var Var ${NativeFolder}/${Subject}.${Map}.native.dscalar.nii -var Bias ${NativeFolder}/${Subject}.BiasField_${OutputRegName}.native.dscalar.nii
 			fi
-		done
+			Map="${Map}_BC"
+			log_Debug_Msg "Point 1.2"
+		fi
 
 		log_Debug_Msg "Point 2.0"
 

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -494,7 +494,7 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 
 		if [ ! ${Mesh} = ${HighResMesh} ] ; then
 			${Caret7_Command} -cifti-resample ${NativeFolder}/${Subject}.${NativeMap}.native.dscalar.nii COLUMN ${Folder}/${Subject}.MyelinMap_BC.${Mesh}k_fs_LR.dscalar.nii COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL ${Folder}/${Subject}.${Map}_${OutputRegName}.${Mesh}k_fs_LR.dscalar.nii -surface-postdilate 30 -left-spheres ${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii ${Folder}/${Subject}.L.sphere.${Mesh}k_fs_LR.surf.gii -left-area-surfs ${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii ${DownSampleT1wFolder}/${Subject}.L.midthickness_${OutputRegName}.${Mesh}k_fs_LR.surf.gii -right-spheres ${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii ${Folder}/${Subject}.R.sphere.${Mesh}k_fs_LR.surf.gii -right-area-surfs ${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii ${DownSampleT1wFolder}/${Subject}.R.midthickness_${OutputRegName}.${Mesh}k_fs_LR.surf.gii
-			for MapMap in ${Maps} ${MyelinMaps} ; do
+			for MapMap in ${Maps} ${MyelinMapsToUse} ; do
 				if [[ ${MapMap} = ${Map} ]] ; then
 					${Caret7_Command} -add-to-spec-file ${Folder}/${Subject}.${OutputRegName}.${Mesh}k_fs_LR.wb.spec INVALID ${Folder}/${Subject}.${Map}_${OutputRegName}.${Mesh}k_fs_LR.dscalar.nii
 					${Caret7_Command} -add-to-spec-file ${DownSampleT1wFolder}/${Subject}.${OutputRegName}.${Mesh}k_fs_LR.wb.spec INVALID ${Folder}/${Subject}.${Map}_${OutputRegName}.${Mesh}k_fs_LR.dscalar.nii
@@ -502,7 +502,7 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 			done
 		else
 			${Caret7_Command} -cifti-resample ${NativeFolder}/${Subject}.${NativeMap}.native.dscalar.nii COLUMN ${Folder}/${Subject}.MyelinMap_BC.${Mesh}k_fs_LR.dscalar.nii COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL ${Folder}/${Subject}.${Map}_${OutputRegName}.${Mesh}k_fs_LR.dscalar.nii -surface-postdilate 30 -left-spheres ${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii ${Folder}/${Subject}.L.sphere.${Mesh}k_fs_LR.surf.gii -left-area-surfs ${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii ${Folder}/${Subject}.L.midthickness_${OutputRegName}.${Mesh}k_fs_LR.surf.gii -right-spheres ${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii ${Folder}/${Subject}.R.sphere.${Mesh}k_fs_LR.surf.gii -right-area-surfs ${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii ${Folder}/${Subject}.R.midthickness_${OutputRegName}.${Mesh}k_fs_LR.surf.gii   
-			for MapMap in ${Maps} ${MyelinMaps} ; do
+			for MapMap in ${Maps} ${MyelinMapsToUse} ; do
 				if [[ ${MapMap} = ${Map} ]] ; then
 					${Caret7_Command} -add-to-spec-file ${Folder}/${Subject}.${OutputRegName}.${Mesh}k_fs_LR.wb.spec INVALID ${Folder}/${Subject}.${Map}_${OutputRegName}.${Mesh}k_fs_LR.dscalar.nii
 				fi

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -443,10 +443,6 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 	done
 	
 	log_Debug_Msg "Point 2.0"
-	if [ "$BiasFieldComputed" = false ]; then
-		MyelinMapsToUse=${MyelinMaps}
-	fi
-	
 	for Map in ${Maps} ${MyelinMapsToUse} SphericalDistortion ArealDistortion EdgeDistortion StrainJ StrainR ; do
 		log_Msg "Map: ${Map}"
 
@@ -474,7 +470,6 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 				fi
 			done
 		fi
-
 		log_Debug_Msg "Point 4.0"
 	done
 	log_Debug_Msg "Point 5.0"

--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -417,45 +417,11 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 	for MyelinMap in ${MyelinMaps} ; do
 		if [ "$BiasFieldComputed" = false ]; then
 			# ----- Begin moved statements -----
-
 			# Recompute Myelin Map Bias Field Based on Better Registration
 			log_Msg "Recompute Myelin Map Bias Field Based on Better Registration"
-
-			cifti_in=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
-			log_File_Must_Exist "${cifti_in}" # 1
-
-			cifti_template=${DownSampleFolder}/${Subject}.MyelinMap.${LowResMesh}k_fs_LR.dscalar.nii
-			log_File_Must_Exist "${cifti_template}" # 2
-
-			cifti_out=${DownSampleFolder}/${Subject}.MyelinMap_${OutputRegName}.${LowResMesh}k_fs_LR.dscalar.nii
-
-			left_spheres_current_sphere=${NativeFolder}/${Subject}.L.sphere.${OutputRegName}.native.surf.gii
-			log_File_Must_Exist "${left_spheres_current_sphere}" # 3
-
-			left_spheres_new_sphere=${DownSampleFolder}/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii
-			log_File_Must_Exist "${left_spheres_new_sphere}" # 4
-
-			left_area_surfs_current_area=${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii
-			log_File_Must_Exist "${left_area_surfs_current_area}" # 5
-
-			left_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.L.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
-			log_File_Must_Exist "${left_area_surfs_new_area}" # 6 - This is the one that doesn't exist
-
-			right_spheres_current_sphere=${NativeFolder}/${Subject}.R.sphere.${OutputRegName}.native.surf.gii
-			log_File_Must_Exist "${right_spheres_current_sphere}"
-
-			right_spheres_new_sphere=${DownSampleFolder}/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii
-			log_File_Must_Exist "${right_spheres_new_sphere}"
-
-			right_area_surfs_current_area=${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii
-			log_File_Must_Exist "${right_area_surfs_current_area}"
-
-			right_area_surfs_new_area=${DownSampleT1wFolder}/${Subject}.R.midthickness_${OutputRegName}.${LowResMesh}k_fs_LR.surf.gii
-			log_File_Must_Exist "${right_area_surfs_new_area}"
-
 			log_Debug_Msg "Point 1.1"
 			
-			# Myelin Map BC using 32k
+			# Myelin Map BC using low res
 			"$HCPPIPEDIR"/global/scripts/MyelinMap_BC.sh \
 				--study-folder="$StudyFolder" \
 				--subject="$Subject" \

--- a/Examples/Scripts/DeDriftAndResamplePipelineBatch.sh
+++ b/Examples/Scripts/DeDriftAndResamplePipelineBatch.sh
@@ -104,6 +104,8 @@ MatlabMode="0" #Mode=0 compiled Matlab, Mode=1 interpreted Matlab, Mode=2 octave
 #MotionRegression=TRUE
 #MatlabMode="0" #Mode=0 compiled Matlab, Mode=1 interpreted Matlab, Mode=2 octave
 
+MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
+
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
 fi
@@ -156,6 +158,7 @@ for Subject in "${Subjlist[@]}" ; do
         --smoothing-fwhm="$SmoothingFWHM" \
         --high-pass="$HighPass" \
         --matlab-run-mode="$MatlabMode" \
-        --motion-regression="$MotionRegression"
+        --motion-regression="$MotionRegression" \
+        --msm-all-templates="$MSMAllTemplates"
 done
 

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -96,25 +96,25 @@ log_Msg "RegNameStructString: $RegNameStructString"
 
 # check file exists
 NativeMyelinMap=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
-log_File_Must_Exist "${NativeMyelinMap}" # 1
+log_File_Must_Exist "${NativeMyelinMap}"
 LowResCiftiTemplate=${LowResFolder}/${Subject}.MyelinMap.${LowResMeshString}.dscalar.nii
-log_File_Must_Exist "${LowResCiftiTemplate}" # 2 
+log_File_Must_Exist "${LowResCiftiTemplate}"
 LeftSphereCurrentSphere=${NativeFolder}/${Subject}.L.sphere${RegNameStructString}.native.surf.gii
-log_File_Must_Exist "${LeftSphereCurrentSphere}" # 3
+log_File_Must_Exist "${LeftSphereCurrentSphere}"
 LeftSphereNewSphere=${LowResFolder}/${Subject}.L.sphere.${LowResMeshString}.surf.gii
-log_File_Must_Exist "${LeftSphereNewSphere}" # 4
+log_File_Must_Exist "${LeftSphereNewSphere}"
 LeftAreaSurfCurrentArea="${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii"
-log_File_Must_Exist "${LeftAreaSurfCurrentArea}" # 5
+log_File_Must_Exist "${LeftAreaSurfCurrentArea}"
 LeftAreaSurfNewArea=${LowResFolder}/${Subject}.L.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
-log_File_Must_Exist "${LeftAreaSurfNewArea}" # 6 - This is the one that doesn't exist
+log_File_Must_Exist "${LeftAreaSurfNewArea}"
 RightSphereCurrentSphere=${NativeFolder}/${Subject}.R.sphere${RegNameStructString}.native.surf.gii
-log_File_Must_Exist "${RightSphereCurrentSphere}" # 7
+log_File_Must_Exist "${RightSphereCurrentSphere}"
 RightSphereNewSphere=${LowResFolder}/${Subject}.R.sphere.${LowResMeshString}.surf.gii
-log_File_Must_Exist "${RightSphereNewSphere}" # 8
+log_File_Must_Exist "${RightSphereNewSphere}"
 RightAreaSurfCurrentArea="${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii"
-log_File_Must_Exist "${RightAreaSurfCurrentArea}" # 9
+log_File_Must_Exist "${RightAreaSurfCurrentArea}"
 RightAreaSurfNewArea=${LowResFolder}/${Subject}.R.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
-log_File_Must_Exist "${RightAreaSurfNewArea}" # 10 - This is the one that doesn't exist
+log_File_Must_Exist "${RightAreaSurfNewArea}"
 
 IndividualLowResMap=${LowResFolder}/${Subject}.MyelinMap${RegNameInOutputName}.${LowResMeshString}.dscalar.nii
 ${Caret7_Command} -cifti-resample ${NativeMyelinMap} \

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -157,12 +157,8 @@ ${Caret7_Command} -cifti-resample ${LowResBiasField} \
 log_Msg "Resampled BiasField in the native mesh space: ${NativeBiasField}"
 
 # generate bias corrected map in the output mesh space
-NativeBCMapToUse=${NativeFolder}/${Subject}.MyelinMap_BC${RegNameInOutputName}.native.dscalar.nii
-NativeMyelinMapToUse=${NativeMyelinMap}
-if [[ "$MapName" != "MyelinMap" ]]; then
-	NativeBCMapToUse=${NativeFolder}/${Subject}.${MapName}_BC${RegNameInOutputName}.native.dscalar.nii
-	NativeMyelinMapToUse=${NativeFolder}/${Subject}.${MapName}.native.dscalar.nii
-fi
+NativeBCMapToUse=${NativeFolder}/${Subject}.${MapName}_BC${RegNameInOutputName}.native.dscalar.nii
+NativeMyelinMapToUse=${NativeFolder}/${Subject}.${MapName}.native.dscalar.nii
 log_File_Must_Exist "${NativeMyelinMapToUse}"
 
 ${Caret7_Command} -cifti-math "Var - Bias" ${NativeBCMapToUse} \

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -94,19 +94,38 @@ log_Msg "RegNameInOutputName: $RegNameInOutputName"
 log_Msg "RegNameInT1wName: $RegNameInT1wName"
 log_Msg "RegNameStructString: $RegNameStructString"
 
+# check file exists
 NativeMyelinMap=${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii
-log_File_Must_Exist "${NativeMyelinMap}"
+log_File_Must_Exist "${NativeMyelinMap}" # 1
+LowResCiftiTemplate=${LowResFolder}/${Subject}.MyelinMap.${LowResMeshString}.dscalar.nii
+log_File_Must_Exist "${LowResCiftiTemplate}" # 2 
+LeftSphereCurrentSphere=${NativeFolder}/${Subject}.L.sphere${RegNameStructString}.native.surf.gii
+log_File_Must_Exist "${LeftSphereCurrentSphere}" # 3
+LeftSphereNewSphere=${LowResFolder}/${Subject}.L.sphere.${LowResMeshString}.surf.gii
+log_File_Must_Exist "${LeftSphereNewSphere}" # 4
+LeftAreaSurfCurrentArea="${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii"
+log_File_Must_Exist "${LeftAreaSurfCurrentArea}" # 5
+LeftAreaSurfNewArea=${LowResFolder}/${Subject}.L.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
+log_File_Must_Exist "${LeftAreaSurfNewArea}" # 6 - This is the one that doesn't exist
+RightSphereCurrentSphere=${NativeFolder}/${Subject}.R.sphere${RegNameStructString}.native.surf.gii
+log_File_Must_Exist "${RightSphereCurrentSphere}" # 7
+RightSphereNewSphere=${LowResFolder}/${Subject}.R.sphere.${LowResMeshString}.surf.gii
+log_File_Must_Exist "${RightSphereNewSphere}" # 8
+RightAreaSurfCurrentArea="${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii"
+log_File_Must_Exist "${RightAreaSurfCurrentArea}" # 9
+RightAreaSurfNewArea=${LowResFolder}/${Subject}.R.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
+log_File_Must_Exist "${RightAreaSurfNewArea}" # 10 - This is the one that doesn't exist
 
 IndividualLowResMap=${LowResFolder}/${Subject}.MyelinMap${RegNameInOutputName}.${LowResMeshString}.dscalar.nii
 ${Caret7_Command} -cifti-resample ${NativeMyelinMap} \
-	COLUMN ${LowResFolder}/${Subject}.MyelinMap.${LowResMeshString}.dscalar.nii \
+	COLUMN ${LowResCiftiTemplate} \
 	COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL \
 	${IndividualLowResMap} \
 	-surface-postdilate 40 \
-	-left-spheres ${NativeFolder}/${Subject}.L.sphere${RegNameStructString}.native.surf.gii ${LowResFolder}/${Subject}.L.sphere.${LowResMeshString}.surf.gii \
-	-left-area-surfs ${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii ${LowResFolder}/${Subject}.L.midthickness.${LowResMeshString}.surf.gii \
-	-right-spheres ${NativeFolder}/${Subject}.R.sphere${RegNameStructString}.native.surf.gii ${LowResFolder}/${Subject}.R.sphere.${LowResMeshString}.surf.gii \
-	-right-area-surfs ${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii ${LowResFolder}/${Subject}.R.midthickness.${LowResMeshString}.surf.gii
+	-left-spheres ${LeftSphereCurrentSphere} ${LeftSphereNewSphere} \
+	-left-area-surfs ${LeftAreaSurfCurrentArea} ${LeftAreaSurfNewArea} \
+	-right-spheres ${RightSphereCurrentSphere} ${RightSphereNewSphere} \
+	-right-area-surfs ${RightAreaSurfCurrentArea} ${RightAreaSurfNewArea}
 
 log_Msg "Resampled MyelinMap in the low res mesh space using registration: ${IndividualLowResMap}"
 


### PR DESCRIPTION
## Background
- The example script was not updated with the new mandatory argument "--msm-all-templates".
- MyelinMap_BC is only applied to MyelinMap and is not applied to a given map name, e.g. 'SmoothedMyelinMap'.

## Main change
- Add the template argument and the variable to the example script `Examples/Scripts/DeDriftAndResamplePipelineBatch.sh`.
- Fix MyelinMap_BC and the reference in `DeDriftAndResamplePipeline.sh`

## Evaluation
/media/myelin/alex/MSMAll_optimization/DeDriftAndResamplePipeline.sh.o3003663
/media/myelin/alex/MSMAll_optimization/DeDriftAndResamplePipeline.sh.e3003663
without error