### PR TITLE
replace the old _BC block with MyelinMap_BC

### DIFF
--- a/DeDriftAndResample/DeDriftAndResamplePipeline.sh
+++ b/DeDriftAndResample/DeDriftAndResamplePipeline.sh
@@ -53,7 +53,7 @@ opts_AddMandatory '--maps' 'Maps' 'non@myelin@maps' "@-delimited map name string
 opts_AddMandatory '--smoothing-fwhm' 'SmoothingFWHM' 'number' "Smoothing FWHM that matches what was used in the fMRISurface pipeline"
 opts_AddMandatory '--high-pass' 'HighPass' 'integer' 'the high pass value that was used when running FIX' '--melodic-high-pass' '--highpass'
 opts_AddMandatory '--motion-regression' 'MotionRegression' 'TRUE or FALSE' 'whether FIX should do motion regression'
-opts_AddMandatory '--msm-all-templates' 'MSMAllTemplates' 'path' "path to directory containing MSM All template files, e.g. 'YourFolder/global/templates/MSMAll'"
+opts_AddMandatory '--myelin-target-file' 'MyelinTarget' 'string' "myelin map target file, absolute folder, e.g. 'YourFolder/global/templates/MSMAll/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'"
 # optional inputs
 opts_AddOptional '--dedrift-reg-files' 'DeDriftRegFiles' 'string' "</Path/to/File/Left.sphere.surf.gii@/Path/to/File/Right.sphere.surf.gii>] Usually the spheres in global/templates/MSMAll/, defaults to ''." ''
 opts_AddOptional '--concat-reg-name' 'OutputRegName' 'MSMAll' "String corresponding to the output name for the dedrifted registration (referred to as the concatenated registration), usually MSMAll. Requires --dedrift-reg-files, defaults to ''." ''
@@ -66,7 +66,6 @@ opts_AddOptional '--multirun-fix-extract-extra-regnames' 'mrFIXExtractExtraRegNa
 opts_AddOptional '--multirun-fix-extract-volume' 'mrFIXExtractDoVol' 'TRUE or FALSE' "whether to also extract the specified MR FIX runs from the volume data, requires --multirun-fix-extract-concat-names to work, defaults to 'FALSE'." 'FALSE'
 opts_AddOptional '--fix-names' 'fixNames' 'ICA+FIXed@fMRI@Names' "@-delimited fMRIName strings corresponding to maps that will have single-run ICA+FIX reapplied to them (could be either rfMRI or tfMRI). Do not specify runs processed with MR FIX here. Previously known as --rfmri-names, defaults to ''." ''
 opts_AddOptional '--dont-fix-names' 'dontFixNames' 'not@ICA+FIXed@fMRI@Names' "@-delimited fMRIName strings corresponding to maps that will not have ICA+FIX reapplied to them (not recommended, MR FIX or at least single-run ICA+FIX is recommended for all fMRI data). Previously known as --tfmri-names, defaults to ''." ''
-opts_AddOptional '--myelin-target-file' 'MyelinTargetFile' 'string' "alternate myelin map target, relative to the --msm-all-templates folder." 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
 opts_AddOptional '--input-reg-name' 'InRegName' 'string' "A string to enable multiple fMRI resolutions, e.g. '_1.6mm', defaults to ''." ''
 opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the individual myelin map as the group reference map's mean" 'YES'
 opts_AddOptional '--matlab-run-mode' 'MatlabRunMode' '0, 1, or 2' "defaults to $g_matlab_default_mode
@@ -426,7 +425,6 @@ for Mesh in ${LowResMeshes} ${HighResMesh} ; do
 				--study-folder="$StudyFolder" \
 				--subject="$Subject" \
 				--registration-name="$OutputRegName" \
-				--msm-all-templates="$MSMAllTemplates" \
 				--use-ind-mean="$UseIndMean" \
 				--low-res-mesh="$LowResMesh" \
 				--myelin-target-file="$MyelinTargetFile" \

--- a/Examples/Scripts/DeDriftAndResamplePipelineBatch.sh
+++ b/Examples/Scripts/DeDriftAndResamplePipelineBatch.sh
@@ -105,6 +105,7 @@ MatlabMode="0" #Mode=0 compiled Matlab, Mode=1 interpreted Matlab, Mode=2 octave
 #MatlabMode="0" #Mode=0 compiled Matlab, Mode=1 interpreted Matlab, Mode=2 octave
 
 MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
+MyelinTargetFile="${MSMAllTemplates}/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii"
 
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
@@ -159,6 +160,6 @@ for Subject in "${Subjlist[@]}" ; do
         --high-pass="$HighPass" \
         --matlab-run-mode="$MatlabMode" \
         --motion-regression="$MotionRegression" \
-        --msm-all-templates="$MSMAllTemplates"
+        --myelin-target-file="$MyelinTargetFile"
 done
 

--- a/Examples/Scripts/MSMAllPipelineBatch.sh
+++ b/Examples/Scripts/MSMAllPipelineBatch.sh
@@ -96,6 +96,7 @@ HighPass="0"
 #Name to reflect high pass setting
 fMRIProcSTRING="_Atlas_hp0_clean"
 MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
+MyelinTargetFile="${MSMAllTemplates}/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii"
 RegName="MSMAll_InitalReg"
 HighResMesh="164"
 LowResMesh="32"
@@ -126,6 +127,7 @@ for Subject in $Subjlist ; do
         --high-pass="$HighPass" \
         --fmri-proc-string="$fMRIProcSTRING" \
         --msm-all-templates="$MSMAllTemplates" \
+        --myelin-target-file="$MyelinTargetFile" \
         --output-registration-name="$RegName" \
         --high-res-mesh="$HighResMesh" \
         --low-res-mesh="$LowResMesh" \

--- a/Examples/Scripts/PostFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PostFreeSurferPipelineBatch.sh
@@ -87,7 +87,8 @@ for Subject in $Subjlist ; do
     FreeSurferLabels="${HCPPIPEDIR_Config}/FreeSurferAllLut.txt"
     ReferenceMyelinMaps="${HCPPIPEDIR_Templates}/standard_mesh_atlases/Conte69.MyelinMap_BC.164k_fs_LR.dscalar.nii"
     RegName="MSMSulc" #MSMSulc is recommended, if binary is not available use FS (FreeSurfer)
-
+	MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
+	UseIndMean="YES"
     if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
         echo "About to locally run ${HCPPIPEDIR}/PostFreeSurfer/PostFreeSurferPipeline.sh"
         queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
@@ -107,7 +108,9 @@ for Subject in $Subjlist ; do
         --subcortgraylabels="$SubcorticalGrayLabels" \
         --freesurferlabels="$FreeSurferLabels" \
         --refmyelinmaps="$ReferenceMyelinMaps" \
-        --regname="$RegName"
+        --regname="$RegName" \
+        --msm-all-templates="$MSMAllTemplates" \
+        --use-ind-mean="$UseIndMean"
 
     # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
 
@@ -121,7 +124,9 @@ for Subject in $Subjlist ; do
         --subcortgraylabels=$SubcorticalGrayLabels \
         --freesurferlabels=$FreeSurferLabels \
         --refmyelinmaps=$ReferenceMyelinMaps \
-        --regname=$RegName"
+        --regname=$RegName \
+        --msm-all-templates="$MSMAllTemplates" \
+        --use-ind-mean="$UseIndMean""
 
     echo ". ${EnvironmentScript}"
 done

--- a/Examples/Scripts/PostFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PostFreeSurferPipelineBatch.sh
@@ -87,9 +87,9 @@ for Subject in $Subjlist ; do
     FreeSurferLabels="${HCPPIPEDIR_Config}/FreeSurferAllLut.txt"
     ReferenceMyelinMaps="${HCPPIPEDIR_Templates}/standard_mesh_atlases/Conte69.MyelinMap_BC.164k_fs_LR.dscalar.nii"
     RegName="MSMSulc" #MSMSulc is recommended, if binary is not available use FS (FreeSurfer)
-	MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
-	MyelinTargetFile="${MSMAllTemplates}/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii"
-	UseIndMean="YES"
+    MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
+    MyelinTargetFile="${MSMAllTemplates}/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii"
+    UseIndMean="YES"
     if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
         echo "About to locally run ${HCPPIPEDIR}/PostFreeSurfer/PostFreeSurferPipeline.sh"
         queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
@@ -110,7 +110,7 @@ for Subject in $Subjlist ; do
         --freesurferlabels="$FreeSurferLabels" \
         --refmyelinmaps="$ReferenceMyelinMaps" \
         --regname="$RegName" \
-		--myelin-target-file="$MyelinTargetFile" \
+        --myelin-target-file="$MyelinTargetFile" \
         --use-ind-mean="$UseIndMean"
 
     # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...

--- a/Examples/Scripts/PostFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PostFreeSurferPipelineBatch.sh
@@ -88,6 +88,7 @@ for Subject in $Subjlist ; do
     ReferenceMyelinMaps="${HCPPIPEDIR_Templates}/standard_mesh_atlases/Conte69.MyelinMap_BC.164k_fs_LR.dscalar.nii"
     RegName="MSMSulc" #MSMSulc is recommended, if binary is not available use FS (FreeSurfer)
 	MSMAllTemplates="${HCPPIPEDIR}/global/templates/MSMAll"
+	MyelinTargetFile="${MSMAllTemplates}/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii"
 	UseIndMean="YES"
     if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
         echo "About to locally run ${HCPPIPEDIR}/PostFreeSurfer/PostFreeSurferPipeline.sh"
@@ -109,7 +110,7 @@ for Subject in $Subjlist ; do
         --freesurferlabels="$FreeSurferLabels" \
         --refmyelinmaps="$ReferenceMyelinMaps" \
         --regname="$RegName" \
-        --msm-all-templates="$MSMAllTemplates" \
+		--myelin-target-file="$MyelinTargetFile" \
         --use-ind-mean="$UseIndMean"
 
     # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
@@ -125,7 +126,7 @@ for Subject in $Subjlist ; do
         --freesurferlabels=$FreeSurferLabels \
         --refmyelinmaps=$ReferenceMyelinMaps \
         --regname=$RegName \
-        --msm-all-templates="$MSMAllTemplates" \
+        --myelin-target-file="$MyelinTargetFile" \
         --use-ind-mean="$UseIndMean""
 
     echo ". ${EnvironmentScript}"

--- a/MSMAll/MSMAllPipeline.sh
+++ b/MSMAll/MSMAllPipeline.sh
@@ -63,6 +63,7 @@ opts_AddMandatory '--input-registration-name' 'InputRegName' 'MSMAll' "the regis
 opts_AddMandatory '--output-registration-name' 'OutputRegName' 'MSMAll' "the registration string corresponding to the output files, e.g. 'MSMAll_InitalReg'"
 opts_AddMandatory '--high-res-mesh' 'HighResMesh' 'meshnum' "high resolution mesh node count (in thousands), like '164' for 164k_fs_LR"
 opts_AddMandatory '--low-res-mesh' 'LowResMesh' 'meshnum' "low resolution mesh node count (in thousands), like '32' for 32k_fs_LR"
+opts_AddMandatory '--myelin-target-file' 'MyelinTarget' 'string' "myelin map target file, absolute folder, e.g. 'YourFolder/global/templates/MSMAll/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'"
 #MSMAll inputs
 opts_AddOptional '--module-name' 'ModuleName' 'string' "name of script or code used to run registration, defaults to 'MSMAll.sh'" 'MSMAll.sh'
 opts_AddOptional '--iteration-modes' 'IterationModes' 'string' "Specifieds what modalities:
@@ -82,7 +83,6 @@ opts_AddOptional '--vn' 'VN' 'YES/NO' "whether to perform variance normalization
 opts_AddOptional '--rerun-if-exists' 'ReRunIfExists' 'YES/NO' "whether to re-run even if output already exists, defaults to 'YES'" 'YES'
 opts_AddOptional '--registration-configure-path' 'RegConfPath' 'string' "it can be either the relative path where the registration configuration exists in 'MSMCONFIGDIR', or an absolute path" 'MSMAllStrainFinalconf1to1_1to3'
 opts_AddOptional '--registration-configure-override-variables' 'RegConfOverrideVars' 'string' "the registration configure variables to override instead of using the configuration file. Please use quotes, and space between parameters is not recommended. e.g. 'REGNUMBER=1,REGPOWER=3', defaults to 'NONE'" 'NONE'
-opts_AddOptional '--myelin-target-file' 'MyelinTarget' 'string' "alternate myelin map target, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
 opts_AddOptional '--rsn-template-file' 'RSNTemplates' 'string' "alternate rsn template file, relative to the --msm-all-templates folder" 'rfMRI_REST_Atlas_MSMAll_2_d41_WRN_DeDrift_hp2000_clean_PCA.ica_dREPLACEDIM_ROW_vn/melodic_oIC.dscalar.nii'
 opts_AddOptional '--rsn-weights-file' 'RSNWeights' 'string' "alternate rsn weights file, relative to the --msm-all-templates folder" 'rfMRI_REST_Atlas_MSMAll_2_d41_WRN_DeDrift_hp2000_clean_PCA.ica_dREPLACEDIM_ROW_vn/Weights.txt'
 opts_AddOptional '--topography-roi-file' 'TopographyROIs' 'string' "alternate topography roi file, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.atlas_Topographic_ROIs.32k_fs_LR.dscalar.nii'
@@ -124,7 +124,6 @@ then
 fi
 log_Msg "RegConfPath: ${RegConfPath}"
 # MSMAll templates defaults
-MyelinTarget="${MSMAllTemplates}/${MyelinTarget}"
 log_File_Must_Exist "${MyelinTarget}"
 RSNTemplates="${MSMAllTemplates}/${RSNTemplates}"
 log_Msg "RSNTemplates: ${RSNTemplates}"

--- a/MSMAll/scripts/MSMAll.sh
+++ b/MSMAll/scripts/MSMAll.sh
@@ -318,7 +318,7 @@ while [ ${i} -le ${NumIterations} ] ; do
 			--study-folder="$StudyFolder" \
 			--subject="$Subject" \
 			--registration-name="$InRegName" \
-			--msm-all-templates="$MSMAllTemplates" \
+			--myelin-target-file="$MyelinTargetFile" \
 			--use-ind-mean="$UseIndMean" \
 			--low-res-mesh="$LowResMesh"
 		${Caret7_Command} -cifti-separate-all ${DownSampleFolder}/${Subject}.BiasField_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii -left ${DownSampleFolder}/${Subject}.L.BiasField_${InRegName}.${LowResMesh}k_fs_LR.func.gii -right ${DownSampleFolder}/${Subject}.R.BiasField_${InRegName}.${LowResMesh}k_fs_LR.func.gii
@@ -721,7 +721,7 @@ rm ${NativeFolder}/${Subject}.SphericalDistortion.native.dtseries.nii
     --study-folder="$StudyFolder" \
     --subject="$Subject" \
     --registration-name="$RegName" \
-    --msm-all-templates="$MSMAllTemplates" \
+    --myelin-target-file="$MyelinTargetFile" \
     --use-ind-mean="$UseIndMean" \
     --low-res-mesh="$LowResMesh"
 

--- a/MSMAll/scripts/MSMAll.sh
+++ b/MSMAll/scripts/MSMAll.sh
@@ -313,11 +313,17 @@ while [ ${i} -le ${NumIterations} ] ; do
 
 	if [[ $(echo -n ${Modalities} | grep "A") ]] ; then
 		log_Msg "Modalities includes A"
-		${Caret7_Command} -cifti-resample ${NativeFolder}/${Subject}.MyelinMap.native.dscalar.nii COLUMN ${DownSampleFolder}/${Subject}.MyelinMap.${LowResMesh}k_fs_LR.dscalar.nii COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL ${DownSampleFolder}/${Subject}.MyelinMap_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii -surface-postdilate 40 -left-spheres ${NativeFolder}/${Subject}.L.sphere.${InRegName}.native.surf.gii ${DownSampleFolder}/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii -left-area-surfs ${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii ${DownSampleFolder}/${Subject}.L.midthickness.${LowResMesh}k_fs_LR.surf.gii -right-spheres ${NativeFolder}/${Subject}.R.sphere.${InRegName}.native.surf.gii ${DownSampleFolder}/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii -right-area-surfs ${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii ${DownSampleFolder}/${Subject}.R.midthickness.${LowResMesh}k_fs_LR.surf.gii
-		${Caret7_Command} -cifti-math "Individual - Reference" ${DownSampleFolder}/${Subject}.BiasField_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii -var Individual ${DownSampleFolder}/${Subject}.MyelinMap_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii -var Reference ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii
-		${Caret7_Command} -cifti-smoothing ${DownSampleFolder}/${Subject}.BiasField_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii ${CorrectionSigma} 0 COLUMN ${DownSampleFolder}/${Subject}.BiasField_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii -left-surface ${DownSampleFolder}/${Subject}.L.midthickness.${LowResMesh}k_fs_LR.surf.gii -right-surface ${DownSampleFolder}/${Subject}.R.midthickness.${LowResMesh}k_fs_LR.surf.gii
+		# Myelin Map BC using 32k
+		"$HCPPIPEDIR"/global/scripts/MyelinMap_BC.sh \
+			--study-folder="$StudyFolder" \
+			--subject="$Subject" \
+			--registration-name="$InRegName" \
+			--msm-all-templates="$MSMAllTemplates" \
+			--use-ind-mean="$UseIndMean" \
+			--low-res-mesh="$LowResMesh"
 		${Caret7_Command} -cifti-separate-all ${DownSampleFolder}/${Subject}.BiasField_${InRegName}.${LowResMesh}k_fs_LR.dscalar.nii -left ${DownSampleFolder}/${Subject}.L.BiasField_${InRegName}.${LowResMesh}k_fs_LR.func.gii -right ${DownSampleFolder}/${Subject}.R.BiasField_${InRegName}.${LowResMesh}k_fs_LR.func.gii
 		${Caret7_Command} -cifti-separate-all ${DownSampleFolder}/${Subject}.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.dscalar.nii -left ${DownSampleFolder}/${Subject}.L.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.func.gii -right ${DownSampleFolder}/${Subject}.R.atlas_MyelinMap_BC.${LowResMesh}k_fs_LR.func.gii
+		
 	fi
 
 	if [[ $(echo -n ${Modalities} | grep "T") ]] ; then

--- a/PostFreeSurfer/PostFreeSurferPipeline.sh
+++ b/PostFreeSurfer/PostFreeSurferPipeline.sh
@@ -226,7 +226,7 @@ if ((doProcessing)); then
     argList+=("$SubcorticalGrayLabels")     # ${21}
     argList+=("$RegName")                   # ${22}
     argList+=("$InflateExtraScale")         # ${23}
-    #"$PipelineScripts"/FreeSurfer2CaretConvertAndRegisterNonlinear.sh "${argList[@]}"
+    "$PipelineScripts"/FreeSurfer2CaretConvertAndRegisterNonlinear.sh "${argList[@]}"
 
     log_Msg "Create FreeSurfer ribbon file at full resolution"
 
@@ -238,7 +238,7 @@ if ((doProcessing)); then
     argList+=("$AtlasSpaceT1wImage")        # ${6}
     argList+=("$T1wRestoreImage")           # ${7}  Called T1wImage in CreateRibbon.sh
     argList+=("$FreeSurferLabels")          # ${8}
-    #"$PipelineScripts"/CreateRibbon.sh "${argList[@]}"
+    "$PipelineScripts"/CreateRibbon.sh "${argList[@]}"
 
     log_Msg "Myelin Mapping"
     log_Msg "RegName: ${RegName}"

--- a/PostFreeSurfer/PostFreeSurferPipeline.sh
+++ b/PostFreeSurfer/PostFreeSurferPipeline.sh
@@ -63,12 +63,15 @@ opts_AddMandatory '--lowresmesh' 'LowResMeshes' 'number' "usually '32', the stan
 opts_AddMandatory '--subcortgraylabels' 'SubcorticalGrayLabels' 'file' "location of FreeSurferSubcorticalLabelTableLut.txt"
 opts_AddMandatory '--freesurferlabels' 'FreeSurferLabels' 'file' "location of FreeSurferAllLut.txt"
 opts_AddMandatory '--refmyelinmaps' 'ReferenceMyelinMaps' 'file' "high-resolution group myelin map to use for bias correction"
+opts_AddMandatory '--msm-all-templates' 'MSMAllTemplates' 'path' "path to directory containing MSM All template files, e.g. 'YourFolder/global/templates/MSMAll'"
 
 opts_AddOptional '--mcsigma' 'CorrectionSigma' 'number' "myelin map bias correction sigma, default '$defaultSigma'" "$defaultSigma"
 opts_AddOptional '--regname' 'RegName' 'name' "surface registration to use, default 'MSMSulc'" 'MSMSulc'
 opts_AddOptional '--inflatescale' 'InflateExtraScale' 'number' "surface inflation scaling factor to deal with different resolutions, default '1'" '1'
 opts_AddOptional '--processing-mode' 'ProcessingMode' 'HCPStyleData|LegacyStyleData' "disable some HCP preprocessing requirements to allow processing of data that doesn't meet HCP acquisition guidelines - don't use this if you don't need to" 'HCPStyleData'
 opts_AddOptional '--structural-qc' 'QCMode' 'yes|no|only' "whether to run structural QC, default 'yes'" 'yes'
+opts_AddOptional '--myelin-target-file' 'MyelinTarget' 'string' "alternate myelin map target, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
+opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean , defaults to 'YES'" 'YES'
 
 opts_ParseArguments "$@"
 
@@ -223,7 +226,7 @@ if ((doProcessing)); then
     argList+=("$SubcorticalGrayLabels")     # ${21}
     argList+=("$RegName")                   # ${22}
     argList+=("$InflateExtraScale")         # ${23}
-    "$PipelineScripts"/FreeSurfer2CaretConvertAndRegisterNonlinear.sh "${argList[@]}"
+    #"$PipelineScripts"/FreeSurfer2CaretConvertAndRegisterNonlinear.sh "${argList[@]}"
 
     log_Msg "Create FreeSurfer ribbon file at full resolution"
 
@@ -235,7 +238,7 @@ if ((doProcessing)); then
     argList+=("$AtlasSpaceT1wImage")        # ${6}
     argList+=("$T1wRestoreImage")           # ${7}  Called T1wImage in CreateRibbon.sh
     argList+=("$FreeSurferLabels")          # ${8}
-    "$PipelineScripts"/CreateRibbon.sh "${argList[@]}"
+    #"$PipelineScripts"/CreateRibbon.sh "${argList[@]}"
 
     log_Msg "Myelin Mapping"
     log_Msg "RegName: ${RegName}"
@@ -279,6 +282,9 @@ if ((doProcessing)); then
     argList+=("$ReferenceMyelinMaps")
     argList+=("$CorrectionSigma")
     argList+=("$RegName")                                  # ${39}
+    argList+=("$MSMAllTemplates")
+    argList+=("$MyelinTarget")
+    argList+=("$UseIndMean")
     "$PipelineScripts"/CreateMyelinMaps.sh "${argList[@]}"
 fi
 

--- a/PostFreeSurfer/PostFreeSurferPipeline.sh
+++ b/PostFreeSurfer/PostFreeSurferPipeline.sh
@@ -70,7 +70,7 @@ opts_AddOptional '--regname' 'RegName' 'name' "surface registration to use, defa
 opts_AddOptional '--inflatescale' 'InflateExtraScale' 'number' "surface inflation scaling factor to deal with different resolutions, default '1'" '1'
 opts_AddOptional '--processing-mode' 'ProcessingMode' 'HCPStyleData|LegacyStyleData' "disable some HCP preprocessing requirements to allow processing of data that doesn't meet HCP acquisition guidelines - don't use this if you don't need to" 'HCPStyleData'
 opts_AddOptional '--structural-qc' 'QCMode' 'yes|no|only' "whether to run structural QC, default 'yes'" 'yes'
-opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean , defaults to 'YES'" 'YES'
+opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean, defaults to 'YES'" 'YES'
 
 opts_ParseArguments "$@"
 

--- a/PostFreeSurfer/PostFreeSurferPipeline.sh
+++ b/PostFreeSurfer/PostFreeSurferPipeline.sh
@@ -63,14 +63,13 @@ opts_AddMandatory '--lowresmesh' 'LowResMeshes' 'number' "usually '32', the stan
 opts_AddMandatory '--subcortgraylabels' 'SubcorticalGrayLabels' 'file' "location of FreeSurferSubcorticalLabelTableLut.txt"
 opts_AddMandatory '--freesurferlabels' 'FreeSurferLabels' 'file' "location of FreeSurferAllLut.txt"
 opts_AddMandatory '--refmyelinmaps' 'ReferenceMyelinMaps' 'file' "high-resolution group myelin map to use for bias correction"
-opts_AddMandatory '--msm-all-templates' 'MSMAllTemplates' 'path' "path to directory containing MSM All template files, e.g. 'YourFolder/global/templates/MSMAll'"
+opts_AddMandatory '--myelin-target-file' 'MyelinTarget' 'string' "myelin map target file, absolute folder, e.g. 'YourFolder/global/templates/MSMAll/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'"
 
 opts_AddOptional '--mcsigma' 'CorrectionSigma' 'number' "myelin map bias correction sigma, default '$defaultSigma'" "$defaultSigma"
 opts_AddOptional '--regname' 'RegName' 'name' "surface registration to use, default 'MSMSulc'" 'MSMSulc'
 opts_AddOptional '--inflatescale' 'InflateExtraScale' 'number' "surface inflation scaling factor to deal with different resolutions, default '1'" '1'
 opts_AddOptional '--processing-mode' 'ProcessingMode' 'HCPStyleData|LegacyStyleData' "disable some HCP preprocessing requirements to allow processing of data that doesn't meet HCP acquisition guidelines - don't use this if you don't need to" 'HCPStyleData'
 opts_AddOptional '--structural-qc' 'QCMode' 'yes|no|only' "whether to run structural QC, default 'yes'" 'yes'
-opts_AddOptional '--myelin-target-file' 'MyelinTarget' 'string' "alternate myelin map target, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
 opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean , defaults to 'YES'" 'YES'
 
 opts_ParseArguments "$@"
@@ -282,7 +281,6 @@ if ((doProcessing)); then
     argList+=("$ReferenceMyelinMaps")
     argList+=("$CorrectionSigma")
     argList+=("$RegName")                                  # ${39}
-    argList+=("$MSMAllTemplates")
     argList+=("$MyelinTarget")
     argList+=("$UseIndMean")
     "$PipelineScripts"/CreateMyelinMaps.sh "${argList[@]}"

--- a/PostFreeSurfer/scripts/CreateMyelinMaps.sh
+++ b/PostFreeSurfer/scripts/CreateMyelinMaps.sh
@@ -205,19 +205,6 @@ for Hemisphere in L R ; do
     ${CARET7DIR}/wb_command -volume-to-surface-mapping "$T1wFolder"/T1wDividedByT2w.nii.gz "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".MyelinMap.native.func.gii -myelin-style "$T1wFolder"/temp_ribbon.nii.gz "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".thickness.native.shape.gii "$MyelinMappingSigma"
     rm "$T1wFolder"/temp_ribbon.nii.gz
     ${CARET7DIR}/wb_command -metric-smoothing "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".MyelinMap.native.func.gii "$SurfaceSmoothingSigma" "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".SmoothedMyelinMap.native.func.gii -roi "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".roi.native.shape.gii  
-    ${CARET7DIR}/wb_command -metric-resample "$AtlasSpaceFolder"/"$Subject"."$Hemisphere".RefMyelinMap."$HighResMesh"k_fs_LR.func.gii "$AtlasSpaceFolder"/"$Subject"."$Hemisphere".sphere."$HighResMesh"k_fs_LR.surf.gii ${RegSphere} ADAP_BARY_AREA "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".RefMyelinMap.native.func.gii -area-surfs "$AtlasSpaceFolder"/"$Subject"."$Hemisphere".midthickness."$HighResMesh"k_fs_LR.surf.gii "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii -current-roi "$AtlasSpaceFolder"/"$Subject"."$Hemisphere".atlasroi."$HighResMesh"k_fs_LR.shape.gii
-    ${CARET7DIR}/wb_command -metric-dilate "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".RefMyelinMap.native.func.gii "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii 30 "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".RefMyelinMap.native.func.gii -nearest
-    ${CARET7DIR}/wb_command -metric-mask "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".RefMyelinMap.native.func.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".roi.native.shape.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".RefMyelinMap.native.func.gii
-
-    for Map in MyelinMap RefMyelinMap ; do
-      ${CARET7DIR}/wb_command -metric-resample "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere"."$Map".native.func.gii ${RegSphere} "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".sphere."$LowResMesh"k_fs_LR.surf.gii ADAP_BARY_AREA "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere"."$Map"."$LowResMesh"k_fs_LR.func.gii -area-surfs "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".midthickness."$LowResMesh"k_fs_LR.surf.gii -current-roi "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".roi.native.shape.gii
-      ${CARET7DIR}/wb_command -metric-smoothing "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".midthickness."$LowResMesh"k_fs_LR.surf.gii "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere"."$Map"."$LowResMesh"k_fs_LR.func.gii "$CorrectionSigma" "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma"."$LowResMesh"k_fs_LR.func.gii -roi "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".atlasroi."$LowResMesh"k_fs_LR.shape.gii
-      ${CARET7DIR}/wb_command -metric-resample "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma"."$LowResMesh"k_fs_LR.func.gii "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".sphere."$LowResMesh"k_fs_LR.surf.gii ${RegSphere} ADAP_BARY_AREA "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma".native.func.gii -area-surfs "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".midthickness."$LowResMesh"k_fs_LR.surf.gii "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii -current-roi "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere".atlasroi."$LowResMesh"k_fs_LR.shape.gii
-      ${CARET7DIR}/wb_command -metric-dilate "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma".native.func.gii "$T1wFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".midthickness.native.surf.gii 30 "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma".native.func.gii -nearest
-      ${CARET7DIR}/wb_command -metric-mask "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma".native.func.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".roi.native.shape.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma".native.func.gii
-      rm "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere"."$Map"."$LowResMesh"k_fs_LR.func.gii "$AtlasSpaceFolder"/fsaverage_LR"$LowResMesh"k/"$Subject"."$Hemisphere"."$Map"_s"$CorrectionSigma"."$LowResMesh"k_fs_LR.func.gii
-    done
-    rm "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".MyelinMap_s"$CorrectionSigma".native.func.gii "$AtlasSpaceFolder"/"$NativeFolder"/"$Subject"."$Hemisphere".RefMyelinMap_s"$CorrectionSigma".native.func.gii
   fi
 
   for STRING in $MapListFunc ; do
@@ -273,7 +260,8 @@ for MyelinMap in MyelinMap SmoothedMyelinMap ; do
 			--use-ind-mean="$UseIndMean" \
 			--low-res-mesh="$LowResMesh" \
 			--myelin-target-file="$MyelinTargetFile" \
-			--map="$MyelinMap"
+			--map="$MyelinMap" \
+			--gifti-output="YES"
 		# ----- End moved statements -----
 		# bias field is computed in the module MyelinMap_BC.sh
 		BiasFieldComputed=true

--- a/PostFreeSurfer/scripts/CreateMyelinMaps.sh
+++ b/PostFreeSurfer/scripts/CreateMyelinMaps.sh
@@ -260,16 +260,17 @@ for MyelinMap in MyelinMap SmoothedMyelinMap ; do
 			--use-ind-mean="$UseIndMean" \
 			--low-res-mesh="$LowResMesh" \
 			--myelin-target-file="$MyelinTargetFile" \
-			--map="$MyelinMap" \
-			--gifti-output="YES"
+			--map="$MyelinMap"
 		# ----- End moved statements -----
 		# bias field is computed in the module MyelinMap_BC.sh
 		BiasFieldComputed=true
+		${Caret7_Command} -cifti-separate-all ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.BiasField.native.dscalar.nii -left ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.BiasField.native.func.gii -right ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.BiasField.native.func.gii
 	else
 		# bias field in native space is already generated
 		# BC the other types of given myelin maps
 		${CARET7DIR}/wb_command -cifti-math "Var - Bias" ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii -var Var ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}.native.dscalar.nii -var Bias ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.BiasField.native.dscalar.nii
 	fi
+	${Caret7_Command} -cifti-separate-all ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii -left ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.${MapName}_BC.native.func.gii -right ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.${MapName}_BC.native.func.gii
 done
 
 #Add CIFTI Maps to Spec Files

--- a/PostFreeSurfer/scripts/CreateMyelinMaps.sh
+++ b/PostFreeSurfer/scripts/CreateMyelinMaps.sh
@@ -92,9 +92,8 @@ Jacobian="${36}"
 ReferenceMyelinMaps="${37}"
 CorrectionSigma="${38}"
 RegName="${39}"
-MSMAllTemplates="${40}"
-MyelinTargetFile="${41}"
-UseIndMean="${42}"
+MyelinTargetFile="${40}"
+UseIndMean="${41}"
 
 log_Msg "RegName: ${RegName}"
 
@@ -257,7 +256,6 @@ for MyelinMap in MyelinMap SmoothedMyelinMap ; do
 			--study-folder="$StudyFolder" \
 			--subject="$Subject" \
 			--registration-name="MSMSulc" \
-			--msm-all-templates="$MSMAllTemplates" \
 			--use-ind-mean="$UseIndMean" \
 			--low-res-mesh="$LowResMesh" \
 			--myelin-target-file="$MyelinTargetFile" \

--- a/PostFreeSurfer/scripts/CreateMyelinMaps.sh
+++ b/PostFreeSurfer/scripts/CreateMyelinMaps.sh
@@ -265,37 +265,34 @@ for MyelinMap in MyelinMap SmoothedMyelinMap ; do
 		# ----- End moved statements -----
 		# bias field is computed in the module MyelinMap_BC.sh
 		BiasFieldComputed=true
-		${Caret7_Command} -cifti-separate-all ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.BiasField.native.dscalar.nii -left ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.BiasField.native.func.gii -right ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.BiasField.native.func.gii
+		${CARET7DIR}/wb_command -cifti-separate-all ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.BiasField.native.dscalar.nii -left ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.BiasField.native.func.gii -right ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.BiasField.native.func.gii
 	else
 		# bias field in native space is already generated
 		# BC the other types of given myelin maps
 		${CARET7DIR}/wb_command -cifti-math "Var - Bias" ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii -var Var ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}.native.dscalar.nii -var Bias ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.BiasField.native.dscalar.nii
 	fi
-	${Caret7_Command} -cifti-separate-all ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii -left ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.${MyelinMap}_BC.native.func.gii -right ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.${MyelinMap}_BC.native.func.gii
+	${CARET7DIR}/wb_command -cifti-separate-all ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii -left ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.${MyelinMap}_BC.native.func.gii -right ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.${MyelinMap}_BC.native.func.gii
 done
 
-# create cifti and gift MyelinMap in the other low res mesh spaces
-if ((${#LowResMeshesArray[@]} > 0 )); then
-	# loop start from the 1st element in LowResMeshesArray (0-index)
-    for ((index = 1; index < ${#LowResMeshesArray[@]}; ++index))
-		LowResMesh="${LowResMeshesArray[index]}"
-		for MyelinMap in MyelinMap SmoothedMyelinMap ; do
-			${Caret7_Command} -cifti-resample ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii \
-				COLUMN ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.${MyelinMap}.${LowResMesh}k_fs_LR.dscalar.nii \
-				COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL \
-				${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.${MyelinMap}_BC.${LowResMesh}k_fs_LR.dscalar.nii \
-				-surface-postdilate 40 \
-				-left-spheres ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.sphere.MSMSulc.native.surf.gii ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii \
-				-left-area-surfs ${StudyFolder}/${Subject}/T1w/${NativeFolder}/${Subject}.L.midthickness.native.surf.gii ${StudyFolder}/${Subject}/T1w/fsaverage_LR${LowResMesh}k/${Subject}.L.midthickness.${LowResMesh}k_fs_LR.surf.gii \
-				-right-spheres ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.sphere.MSMSulc.native.surf.gii ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii \
-				-right-area-surfs ${StudyFolder}/${Subject}/T1w/${NativeFolder}/${Subject}.R.midthickness.native.surf.gii ${StudyFolder}/${Subject}/T1w/fsaverage_LR${LowResMesh}k/${Subject}.R.midthickness.${LowResMesh}k_fs_LR.surf.gii
-			# gifti files
-			${Caret7_Command} -cifti-separate-all ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.${MyelinMap}_BC.${LowResMesh}k_fs_LR.dscalar.nii \
-				-left ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.L.${MyelinMap}_BC.${LowResMesh}k_fs_LR.func.gii \
-				-right ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.R.${MyelinMap}_BC.${LowResMesh}k_fs_LR.func.gii
-		done
+# create cifti and gift MyelinMap in the low res mesh spaces
+for ((index = 0; index < ${#LowResMeshesArray[@]}; ++index)) ; do
+	LowResMesh="${LowResMeshesArray[index]}"
+	for MyelinMap in MyelinMap SmoothedMyelinMap ; do
+		${CARET7DIR}/wb_command -cifti-resample ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.${MyelinMap}_BC.native.dscalar.nii \
+			COLUMN ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.${MyelinMap}.${LowResMesh}k_fs_LR.dscalar.nii \
+			COLUMN ADAP_BARY_AREA ENCLOSING_VOXEL \
+			${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.${MyelinMap}_BC.${LowResMesh}k_fs_LR.dscalar.nii \
+			-surface-postdilate 40 \
+			-left-spheres ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.L.sphere.MSMSulc.native.surf.gii ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.L.sphere.${LowResMesh}k_fs_LR.surf.gii \
+			-left-area-surfs ${StudyFolder}/${Subject}/T1w/${NativeFolder}/${Subject}.L.midthickness.native.surf.gii ${StudyFolder}/${Subject}/T1w/fsaverage_LR${LowResMesh}k/${Subject}.L.midthickness.${LowResMesh}k_fs_LR.surf.gii \
+			-right-spheres ${AtlasSpaceFolder}/${NativeFolder}/${Subject}.R.sphere.MSMSulc.native.surf.gii ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.R.sphere.${LowResMesh}k_fs_LR.surf.gii \
+			-right-area-surfs ${StudyFolder}/${Subject}/T1w/${NativeFolder}/${Subject}.R.midthickness.native.surf.gii ${StudyFolder}/${Subject}/T1w/fsaverage_LR${LowResMesh}k/${Subject}.R.midthickness.${LowResMesh}k_fs_LR.surf.gii
+		# gifti files
+		${CARET7DIR}/wb_command -cifti-separate-all ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.${MyelinMap}_BC.${LowResMesh}k_fs_LR.dscalar.nii \
+			-left ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.L.${MyelinMap}_BC.${LowResMesh}k_fs_LR.func.gii \
+			-right ${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k/${Subject}.R.${MyelinMap}_BC.${LowResMesh}k_fs_LR.func.gii
 	done
-fi
+done
 
 #Add CIFTI Maps to Spec Files
 

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -105,7 +105,7 @@ LeftSphereNewSphere=${LowResFolder}/${Subject}.L.sphere.${LowResMeshString}.surf
 log_File_Must_Exist "${LeftSphereNewSphere}"
 LeftAreaSurfCurrentArea="${NativeT1wFolder}/${Subject}.L.midthickness.native.surf.gii"
 log_File_Must_Exist "${LeftAreaSurfCurrentArea}"
-LeftAreaSurfNewArea=${LowResFolder}/${Subject}.L.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
+LeftAreaSurfNewArea=${LowResT1wFolder}/${Subject}.L.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
 log_File_Must_Exist "${LeftAreaSurfNewArea}"
 RightSphereCurrentSphere=${NativeFolder}/${Subject}.R.sphere${RegNameStructString}.native.surf.gii
 log_File_Must_Exist "${RightSphereCurrentSphere}"
@@ -113,7 +113,7 @@ RightSphereNewSphere=${LowResFolder}/${Subject}.R.sphere.${LowResMeshString}.sur
 log_File_Must_Exist "${RightSphereNewSphere}"
 RightAreaSurfCurrentArea="${NativeT1wFolder}/${Subject}.R.midthickness.native.surf.gii"
 log_File_Must_Exist "${RightAreaSurfCurrentArea}"
-RightAreaSurfNewArea=${LowResFolder}/${Subject}.R.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
+RightAreaSurfNewArea=${LowResT1wFolder}/${Subject}.R.midthickness${RegNameInOutputName}.${LowResMeshString}.surf.gii
 log_File_Must_Exist "${RightAreaSurfNewArea}"
 
 IndividualLowResMap=${LowResFolder}/${Subject}.MyelinMap${RegNameInOutputName}.${LowResMeshString}.dscalar.nii

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -30,6 +30,7 @@ opts_AddOptional '--low-res-mesh' 'LowResMesh' 'meshnum' "low resolution mesh no
 opts_AddOptional '--mcsigma' 'CorrectionSigma' 'number' "myelin map bias correction sigma, this option is mainly intended for non-human-adult data, defaults to '$defaultSigma'" "$defaultSigma"
 opts_AddOptional '--myelin-target-file' 'MyelinTarget' 'string' "alternate myelin map target, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
 opts_AddOptional '--map' 'MapName' 'string' "map to applied the bias field correction, defaults to 'MyelinMap'" 'MyelinMap'
+opts_AddOptional '--gifti-output' 'GiftiOutput' 'YES or NO' "whether to generate the gifti outputs of Bias field and _BC cifti files in native mesh space, defaults to 'NO'" 'NO'
 opts_ParseArguments "$@"
 
 if ((pipedirguessed))
@@ -54,6 +55,7 @@ opts_ShowValues
 log_Msg "Starting main functionality"
 Caret7_Command=${CARET7DIR}/wb_command
 UseIndMeanBool=$(opts_StringToBool "$UseIndMean")
+GiftiOutputBool=$(opts_StringToBool "$GiftiOutput")
 # default folders
 SubjFolder=${StudyFolder}/${Subject}
 log_Msg "SubjFolder: $SubjFolder"
@@ -185,6 +187,9 @@ ${Caret7_Command} -cifti-math "Var - Bias" ${NativeBCMapToUse} \
 	-var Bias ${NativeBiasField}
 
 log_Msg "_BC Myelin map in the native mesh space: ${NativeBCMapToUse}"
-# TODO: add gifti generation according to one argument
-# -cifti-separate-all
+# gifti generation in native mesh space (BiasField and _BC files)
+if ((GiftiOutputBool)); then
+	${Caret7_Command} -cifti-separate-all ${NativeBiasField} -left ${NativeFolder}/${Subject}.L.BiasField${RegNameInOutputName}.native.dscalar.nii -right ${NativeFolder}/${Subject}.R.BiasField${RegNameInOutputName}.native.dscalar.nii
+	${Caret7_Command} -cifti-separate-all ${NativeBCMapToUse} -left ${NativeFolder}/${Subject}.L.${MapName}_BC${RegNameInOutputName}.native.dscalar.nii -right ${NativeFolder}/${Subject}.R.${MapName}_BC${RegNameInOutputName}.native.dscalar.nii
+fi
 log_Msg "Completing main functionality"

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -30,7 +30,6 @@ opts_AddOptional '--low-res-mesh' 'LowResMesh' 'meshnum' "low resolution mesh no
 opts_AddOptional '--mcsigma' 'CorrectionSigma' 'number' "myelin map bias correction sigma, this option is mainly intended for non-human-adult data, defaults to '$defaultSigma'" "$defaultSigma"
 opts_AddOptional '--myelin-target-file' 'MyelinTarget' 'string' "alternate myelin map target, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
 opts_AddOptional '--map' 'MapName' 'string' "map to applied the bias field correction, defaults to 'MyelinMap'" 'MyelinMap'
-opts_AddOptional '--gifti-output' 'GiftiOutput' 'YES or NO' "whether to generate the gifti outputs of Bias field and _BC cifti files in native mesh space, defaults to 'NO'" 'NO'
 opts_ParseArguments "$@"
 
 if ((pipedirguessed))
@@ -55,7 +54,6 @@ opts_ShowValues
 log_Msg "Starting main functionality"
 Caret7_Command=${CARET7DIR}/wb_command
 UseIndMeanBool=$(opts_StringToBool "$UseIndMean")
-GiftiOutputBool=$(opts_StringToBool "$GiftiOutput")
 # default folders
 SubjFolder=${StudyFolder}/${Subject}
 log_Msg "SubjFolder: $SubjFolder"
@@ -187,9 +185,4 @@ ${Caret7_Command} -cifti-math "Var - Bias" ${NativeBCMapToUse} \
 	-var Bias ${NativeBiasField}
 
 log_Msg "_BC Myelin map in the native mesh space: ${NativeBCMapToUse}"
-# gifti generation in native mesh space (BiasField and _BC files)
-if ((GiftiOutputBool)); then
-	${Caret7_Command} -cifti-separate-all ${NativeBiasField} -left ${NativeFolder}/${Subject}.L.BiasField${RegNameInOutputName}.native.dscalar.nii -right ${NativeFolder}/${Subject}.R.BiasField${RegNameInOutputName}.native.dscalar.nii
-	${Caret7_Command} -cifti-separate-all ${NativeBCMapToUse} -left ${NativeFolder}/${Subject}.L.${MapName}_BC${RegNameInOutputName}.native.dscalar.nii -right ${NativeFolder}/${Subject}.R.${MapName}_BC${RegNameInOutputName}.native.dscalar.nii
-fi
 log_Msg "Completing main functionality"

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -25,7 +25,7 @@ opts_AddMandatory '--subject' 'Subject' '100206' "one subject ID"
 opts_AddMandatory '--registration-name' 'RegName' 'MSMAll' "the registration string corresponding to the input files, e.g. 'MSMAll' or 'MSMSulc'"
 opts_AddMandatory '--myelin-target-file' 'MyelinTarget' 'string' "myelin map target file, absolute folder, e.g. 'YourFolder/global/templates/MSMAll/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'"
 #optional inputs
-opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean , defaults to 'YES'" 'YES'
+opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean, defaults to 'YES'" 'YES'
 opts_AddOptional '--low-res-mesh' 'LowResMesh' 'meshnum' "low resolution mesh node count (in thousands), defaults to '32' for 32k_fs_LR" '32'
 opts_AddOptional '--mcsigma' 'CorrectionSigma' 'number' "myelin map bias correction sigma, this option is mainly intended for non-human-adult data, defaults to '$defaultSigma'" "$defaultSigma"
 opts_AddOptional '--map' 'MapName' 'string' "map to applied the bias field correction, defaults to 'MyelinMap'" 'MyelinMap'

--- a/global/scripts/MyelinMap_BC.sh
+++ b/global/scripts/MyelinMap_BC.sh
@@ -23,12 +23,11 @@ opts_SetScriptDescription "corrects an individual native mesh myelin map for bia
 opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder that contains all subjects"
 opts_AddMandatory '--subject' 'Subject' '100206' "one subject ID"
 opts_AddMandatory '--registration-name' 'RegName' 'MSMAll' "the registration string corresponding to the input files, e.g. 'MSMAll' or 'MSMSulc'"
-opts_AddMandatory '--msm-all-templates' 'MSMAllTemplates' 'path' "path to directory containing MSM All template files, e.g. 'YourFolder/global/templates/MSMAll'"
+opts_AddMandatory '--myelin-target-file' 'MyelinTarget' 'string' "myelin map target file, absolute folder, e.g. 'YourFolder/global/templates/MSMAll/Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'"
 #optional inputs
 opts_AddOptional '--use-ind-mean' 'UseIndMean' 'YES or NO' "whether to use the mean of the subject's myelin map as reference map's myelin map mean , defaults to 'YES'" 'YES'
 opts_AddOptional '--low-res-mesh' 'LowResMesh' 'meshnum' "low resolution mesh node count (in thousands), defaults to '32' for 32k_fs_LR" '32'
 opts_AddOptional '--mcsigma' 'CorrectionSigma' 'number' "myelin map bias correction sigma, this option is mainly intended for non-human-adult data, defaults to '$defaultSigma'" "$defaultSigma"
-opts_AddOptional '--myelin-target-file' 'MyelinTarget' 'string' "alternate myelin map target, relative to the --msm-all-templates folder" 'Q1-Q6_RelatedParcellation210.MyelinMap_BC_MSMAll_2_d41_WRN_DeDrift.32k_fs_LR.dscalar.nii'
 opts_AddOptional '--map' 'MapName' 'string' "map to applied the bias field correction, defaults to 'MyelinMap'" 'MyelinMap'
 opts_ParseArguments "$@"
 
@@ -65,8 +64,6 @@ NativeFolder=${AtlasSpaceFolder}/Native
 log_Msg "NativeFolder: $NativeFolder"
 NativeT1wFolder=${T1wFolder}/Native
 log_Msg "NativeT1wFolder: $NativeT1wFolder"
-# MSMAll templates Myelin Target which is the group average MyelinMap_BC
-MyelinTarget="${MSMAllTemplates}/${MyelinTarget}"
 # low res setting
 LowResMeshString=${LowResMesh}k_fs_LR
 LowResFolder=${AtlasSpaceFolder}/fsaverage_LR${LowResMesh}k


### PR DESCRIPTION
## Background
There remain several legacy _BC code block that is not replaced by the module `MyelinMap_BC.sh`. 

## Main changes
- replace the old _BC code block in `MSMAll.sh` with `MyelinMap_BC.sh`
- `CreateMyelinMaps.sh` used gifti based _BC which is now replaced by the cifti-based `MyelinMap_BC.sh`, while the gifti files are kept
- add arguments to `PostFreeSurferPipeline.sh` to adapt the module `MyelinMap_BC.sh`
- update the example launch script `PostFreeSurferPipelineBatch.sh`
- change the argument `--myelin-target-file` as a single argument with absolute file path that doesn't depend on `--msm-all-templates`

## Evaluation
- MSMAllPipeline logs with no error: 
- `/media/myelin/alex/MSMAll_optimization/MSMAllPipeline.sh.e49165`
- `/media/myelin/alex/MSMAll_optimization/MSMAllPipeline.sh.o49165`

- PostFreeSurferPipeline logs with no error: 
- `/media/myelin/alex/MSMAll_optimization/PostFreeSurferPipeline.sh.e162416`
- `/media/myelin/alex/MSMAll_optimization/PostFreeSurferPipeline.sh.o162416`
