### PR TITLE
add outlier functions to bypass matlab's isoutlier; adapt to r2017b

### DIFF
--- a/tICA/scripts/ComputeTICAFeatures.m
+++ b/tICA/scripts/ComputeTICAFeatures.m
@@ -92,33 +92,24 @@ tICAspectranorm=ciftiopen([OutputFolder '/tICA_Spectra_norm_' num2str(tICAdim) '
 % group norm surface map
 tICAMapsGroupNorm=tICAMaps;
 tICAMapsGroupNorm.cdata=(tICAMapsGroupNorm.cdata-mean(reshape(tICAMapsGroupNorm.cdata,[],1)))/std(reshape(tICAMapsGroupNorm.cdata,[],1));
-if ~isfile([OutputFolder '/tICA_Maps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii'])
-    ciftisave(tICAMapsGroupNorm,[OutputFolder '/tICA_Maps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii'],wbcommand);
-end
+ciftisave(tICAMapsGroupNorm,[OutputFolder '/tICA_Maps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii'],wbcommand);
+
 % group norm volume map
 tICAVolMapsGroupNorm=tICAVolMaps;
 tICAVolMapsGroupNorm.cdata=(tICAVolMapsGroupNorm.cdata-mean(reshape(tICAVolMapsGroupNorm.cdata,[],1)))/std(reshape(tICAVolMapsGroupNorm.cdata,[],1));
-if ~isfile([OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii'])
-    ciftisave(tICAVolMapsGroupNorm,[OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii'],wbcommand);
-end
+ciftisave(tICAVolMapsGroupNorm,[OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii'],wbcommand);
+
 % convert to nifti space
-if ~isfile([OutputFolder '/volmap.nii.gz'])
-    unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmap_tmp.nii.gz']);
-    unix(['wb_command -volume-resample ' OutputFolder '/volmap_tmp.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmap.nii.gz']);
-end
-if ~isfile([OutputFolder '/volmap_GroupNorm.nii.gz'])
-    unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmap_tmp2.nii.gz']);
-    unix(['wb_command -volume-resample ' OutputFolder '/volmap_tmp2.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmap_GroupNorm.nii.gz']);
-end
+unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmap_tmp.nii.gz']);
+unix(['wb_command -volume-resample ' OutputFolder '/volmap_tmp.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmap.nii.gz']);
+unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '_GroupNorm.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmap_tmp2.nii.gz']);
+unix(['wb_command -volume-resample ' OutputFolder '/volmap_tmp2.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmap_GroupNorm.nii.gz']);
+
 tICAVolNifti=niftiread([OutputFolder '/volmap.nii.gz']);
 tICAVolNiftiGroupNorm=niftiread([OutputFolder '/volmap_GroupNorm.nii.gz']);
+unix(['rm ' OutputFolder '/volmap_tmp.nii.gz'])
+unix(['rm ' OutputFolder '/volmap_tmp2.nii.gz'])
 
-if isfile([OutputFolder '/volmap_tmp.nii.gz'])
-    unix(['rm ' OutputFolder '/volmap_tmp.nii.gz'])
-end
-if isfile([OutputFolder '/volmap_tmp2.nii.gz'])
-    unix(['rm ' OutputFolder '/volmap_tmp2.nii.gz'])
-end
 % additional information
 Stats=load([OutputFolder '/stats_' num2str(tICAdim) '_' nonlinear '.wb_annsub.csv']);
 Mix=load([OutputFolder '/melodic_mix_' num2str(tICAdim) '_' nonlinear]);
@@ -317,88 +308,67 @@ tICAspectra_SS.cdata=tICAspectra.cdata*0;
 %Find strongest individual subjects for components
 [~, I]=max(TCSVARS);
 for i=1:size(TCSVARS,2)
-    if ~isfile([OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii']) && ~isfile([OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'])
-        %Subjlist{I(i)}
-        SubjFolderlist=[StudyFolder '/' Subjlist{I(i)}];
-        tICAMaps_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SR' RegString '.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');      
-        tICAVolMaps_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SR' RegString '_vol.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');
-        tICAMaps_SS.cdata(:,i)=tICAMaps_sub.cdata(:,i);
-        try
-            tICAVolMaps_SS.cdata(:,i)=tICAVolMaps_sub.cdata(:,i);
-        catch
-           [StudyFolder '/' Subjlist{I(i)}]
-           tICAFeaturesProcString
-        end
-        tICAMapsZ_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SRZ' RegString '.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');      
-        tICAVolMapsZ_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SRZ' RegString '_vol.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');
-        tICAMapsZ_SS.cdata(:,i)=tICAMapsZ_sub.cdata(:,i);
-        tICAVolMapsZ_SS.cdata(:,i)=tICAVolMapsZ_sub.cdata(:,i);
-        tICATCS_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString RegString '_ts.' LowResMesh 'k_fs_LR.sdseries.nii'],'wb_command');
-        tICASpectra_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString RegString '_spectra.' LowResMesh 'k_fs_LR.sdseries.nii'],'wb_command');
-        tICAtcs_SS.cdata(i,1:length(tICATCS_sub.cdata(i,:)))=tICATCS_sub.cdata(i,:);
-        tICAspectra_SS.cdata(i,1:length(tICASpectra_sub.cdata(i,:)))=tICASpectra_sub.cdata(i,:);
-
-        tICASingleComponentSpaceXTime=zeros(size(CorticalROIs,2),length(tICATCS_sub.cdata),size(tICATCS_sub.cdata,1),'single');
-        for j=1:size(tICAMaps.cdata,2)
-            tICASingleComponentSpaceXTime(:,:,j)=CorticalROIs'*(tICAMaps_sub.cdata(:,j)*tICATCS_sub.cdata(j,:));
-        end
-        rtICASingleComponentSpaceXTime=[];
-
-        for k=1:size(tICAMaps.cdata,2)%tICA_dim
-        c=1;
-        for j=ParcelReorder
-            rtICASingleComponentSpaceXTime(c:c-1+round((a(j)/min(a))),:,k)=repmat(tICASingleComponentSpaceXTime(j,:,k),round((a(j)/min(a))),1);
-            c=c+round((a(j)/min(a)));
-        end
-        end
-
-        temp=tICAtcs_SS;
-        temp.cdata=zeros(size(rtICASingleComponentSpaceXTime,1),size(tICAtcs_SS.cdata,2),'single');
-        temp.cdata(:,1:size(rtICASingleComponentSpaceXTime,2))=squeeze(rtICASingleComponentSpaceXTime(:,:,i))./repmat(std(sum(rtICASingleComponentSpaceXTime,3),[],2),1,size(rtICASingleComponentSpaceXTime,2));
-        ciftisavereset(temp,[OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
-        temp.cdata(:,1:size(rtICASingleComponentSpaceXTime,2))=squeeze(sum(rtICASingleComponentSpaceXTime(:,:,:),3))./repmat(std(sum(rtICASingleComponentSpaceXTime,3),[],2),1,size(rtICASingleComponentSpaceXTime,2));
-        ciftisavereset(temp,[OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
+    %Subjlist{I(i)}
+    SubjFolderlist=[StudyFolder '/' Subjlist{I(i)}];
+    tICAMaps_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SR' RegString '.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');      
+    tICAVolMaps_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SR' RegString '_vol.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');
+    tICAMaps_SS.cdata(:,i)=tICAMaps_sub.cdata(:,i);
+    try
+        tICAVolMaps_SS.cdata(:,i)=tICAVolMaps_sub.cdata(:,i);
+    catch
+       [StudyFolder '/' Subjlist{I(i)}]
+       tICAFeaturesProcString
     end
+    tICAMapsZ_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SRZ' RegString '.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');      
+    tICAVolMapsZ_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SRZ' RegString '_vol.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');
+    tICAMapsZ_SS.cdata(:,i)=tICAMapsZ_sub.cdata(:,i);
+    tICAVolMapsZ_SS.cdata(:,i)=tICAVolMapsZ_sub.cdata(:,i);
+    tICATCS_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString RegString '_ts.' LowResMesh 'k_fs_LR.sdseries.nii'],'wb_command');
+    tICASpectra_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString RegString '_spectra.' LowResMesh 'k_fs_LR.sdseries.nii'],'wb_command');
+    tICAtcs_SS.cdata(i,1:length(tICATCS_sub.cdata(i,:)))=tICATCS_sub.cdata(i,:);
+    tICAspectra_SS.cdata(i,1:length(tICASpectra_sub.cdata(i,:)))=tICASpectra_sub.cdata(i,:);
+
+    tICASingleComponentSpaceXTime=zeros(size(CorticalROIs,2),length(tICATCS_sub.cdata),size(tICATCS_sub.cdata,1),'single');
+    for j=1:size(tICAMaps.cdata,2)
+        tICASingleComponentSpaceXTime(:,:,j)=CorticalROIs'*(tICAMaps_sub.cdata(:,j)*tICATCS_sub.cdata(j,:));
+    end
+    rtICASingleComponentSpaceXTime=[];
+
+    for k=1:size(tICAMaps.cdata,2)%tICA_dim
+    c=1;
+    for j=ParcelReorder
+        rtICASingleComponentSpaceXTime(c:c-1+round((a(j)/min(a))),:,k)=repmat(tICASingleComponentSpaceXTime(j,:,k),round((a(j)/min(a))),1);
+        c=c+round((a(j)/min(a)));
+    end
+    end
+
+    temp=tICAtcs_SS;
+    temp.cdata=zeros(size(rtICASingleComponentSpaceXTime,1),size(tICAtcs_SS.cdata,2),'single');
+    temp.cdata(:,1:size(rtICASingleComponentSpaceXTime,2))=squeeze(rtICASingleComponentSpaceXTime(:,:,i))./repmat(std(sum(rtICASingleComponentSpaceXTime,3),[],2),1,size(rtICASingleComponentSpaceXTime,2));
+    ciftisavereset(temp,[OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
+    temp.cdata(:,1:size(rtICASingleComponentSpaceXTime,2))=squeeze(sum(rtICASingleComponentSpaceXTime(:,:,:),3))./repmat(std(sum(rtICASingleComponentSpaceXTime,3),[],2),1,size(rtICASingleComponentSpaceXTime,2));
+    ciftisavereset(temp,[OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
 end
-if ~isfile([OutputFolder '/tICA_Maps_' num2str(tICAdim) '_' nonlinear '_SS.dscalar.nii'])
-    ciftisave(tICAMaps_SS,[OutputFolder '/tICA_Maps_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
-end
-if ~isfile([OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_' nonlinear '_SS.dscalar.nii'])
-    ciftisave(tICAVolMaps_SS,[OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
-end
-if ~isfile([OutputFolder '/tICA_MapsZ_' num2str(tICAdim) '_' nonlinear '_SS.dscalar.nii'])
-    ciftisave(tICAMapsZ_SS,[OutputFolder '/tICA_MapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
-end
-if ~isfile([OutputFolder '/tICA_VolMapsZ_' num2str(tICAdim) '_' nonlinear '_SS.dscalar.nii'])
+ciftisave(tICAMaps_SS,[OutputFolder '/tICA_Maps_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
+ciftisave(tICAVolMaps_SS,[OutputFolder '/tICA_VolMaps_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
+ciftisave(tICAMapsZ_SS,[OutputFolder '/tICA_MapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
 ciftisave(tICAVolMapsZ_SS,[OutputFolder '/tICA_VolMapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);
 unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMapsZ_' num2str(tICAdim) '_' nonlinear '_SS.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmapZ_tmp.nii.gz']);
 unix(['wb_command -volume-resample ' OutputFolder '/volmapZ_tmp.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmapZ_ss.nii.gz']);
-end
-if isfile([OutputFolder '/volmapZ_tmp.nii.gz'])
-    unix(['rm ' OutputFolder '/volmapZ_tmp.nii.gz'])
-end
-if ~isfile([OutputFolder '/tICA_TCS_' num2str(tICAdim) '_' nonlinear '_SS.sdseries.nii'])
-    ciftisave(tICAtcs_SS,[OutputFolder '/tICA_TCS_' num2str(tICAdim) '_' nonlinear '_SS.sdseries.nii'],wbcommand);
-end
-if ~isfile([OutputFolder '/tICA_Spectra_' num2str(tICAdim) '_' nonlinear '_SS.sdseries.nii'])
-    ciftisave(tICAspectra_SS,[OutputFolder '/tICA_Spectra_' num2str(tICAdim) '_' nonlinear '_SS.sdseries.nii'],wbcommand);
-end
+unix(['rm ' OutputFolder '/volmapZ_tmp.nii.gz'])
+ciftisave(tICAtcs_SS,[OutputFolder '/tICA_TCS_' num2str(tICAdim) '_' nonlinear '_SS.sdseries.nii'],wbcommand);
+ciftisave(tICAspectra_SS,[OutputFolder '/tICA_Spectra_' num2str(tICAdim) '_' nonlinear '_SS.sdseries.nii'],wbcommand);
 
 tICAMapsZ_SS=ciftiopen([OutputFolder '/tICA_MapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'], wbcommand);
 tICAVolMapsZ_SS=ciftiopen([OutputFolder '/tICA_VolMapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'], wbcommand);
 
 % convert to nifti space
-if ~isfile([OutputFolder '/volmapZ.nii.gz'])
-    unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmapZ_tmp.nii.gz']);
-    unix(['wb_command -volume-resample ' OutputFolder '/volmapZ_tmp.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmapZ.nii.gz']);
-end
+unix(['wb_command -cifti-separate ' OutputFolder '/tICA_VolMapsZ_' num2str(tICAdim) '_tanhF_SS.dscalar.nii COLUMN -volume-all ' OutputFolder '/volmapZ_tmp.nii.gz']);
+unix(['wb_command -volume-resample ' OutputFolder '/volmapZ_tmp.nii.gz ' NiftiTemplateFile ' CUBIC ' OutputFolder '/volmapZ.nii.gz']);
 
 tICAVolSSZNiftiOrig=niftiread([OutputFolder '/volmapZ.nii.gz']);
 tICAVolSSZNifti=reshape(tICAVolSSZNiftiOrig,[],size(tICAVolSSZNiftiOrig,4));
-
-if isfile([OutputFolder '/volmapZ_tmp.nii.gz'])
-    unix(['rm ' OutputFolder '/volmapZ_tmp.nii.gz'])
-end
+unix(['rm ' OutputFolder '/volmapZ_tmp.nii.gz'])
 
 disp('generateing features...')
 num_space_metrics=4;
@@ -702,16 +672,8 @@ other_features.GSCOVS=GSCOVS;
 
 if strcmp(ToSave, 'YES')
     disp('saving features...')
-    c=clock;
-    clock_string=[];
-    for i=1:5 % to minute only (5)
-        clock_string=[clock_string '_' num2str(c(i))];
-    end
-    writetable(features, [OutputFolder '/features' clock_string '.csv'], 'WriteRowNames',true);
-    % overwrite the current feature files
-    unix(['cp ' OutputFolder '/features' clock_string '.csv ' OutputFolder '/features.csv']);
-    save([OutputFolder '/other_features' clock_string '.mat'], 'other_features', '-v7.3');
-    unix(['cp ' OutputFolder '/other_features' clock_string '.mat ' OutputFolder '/other_features.mat']);
+    writetable(features, [OutputFolder '/features.csv'], 'WriteRowNames',true);
+    save([OutputFolder '/other_features.mat'], 'other_features', '-v7.3');
 end
 disp('done!')
 end

--- a/tICA/scripts/ComputeTICAFeatures.m
+++ b/tICA/scripts/ComputeTICAFeatures.m
@@ -317,7 +317,7 @@ tICAspectra_SS.cdata=tICAspectra.cdata*0;
 %Find strongest individual subjects for components
 [~, I]=max(TCSVARS);
 for i=1:size(TCSVARS,2)
-    %if ~isfile([OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii']) && ~isfile([OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'])
+    if ~isfile([OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii']) && ~isfile([OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'])
         %Subjlist{I(i)}
         SubjFolderlist=[StudyFolder '/' Subjlist{I(i)}];
         tICAMaps_sub=ciftiopen([SubjFolderlist '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' Subjlist{I(i)} '.' tICAFeaturesProcString '_SR' RegString '.' LowResMesh 'k_fs_LR.dscalar.nii'],'wb_command');      
@@ -355,14 +355,10 @@ for i=1:size(TCSVARS,2)
         temp=tICAtcs_SS;
         temp.cdata=zeros(size(rtICASingleComponentSpaceXTime,1),size(tICAtcs_SS.cdata,2),'single');
         temp.cdata(:,1:size(rtICASingleComponentSpaceXTime,2))=squeeze(rtICASingleComponentSpaceXTime(:,:,i))./repmat(std(sum(rtICASingleComponentSpaceXTime,3),[],2),1,size(rtICASingleComponentSpaceXTime,2));
-        if ~isfile([OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii'])
-            ciftisavereset(temp,[OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
-        end
+        ciftisavereset(temp,[OutputFolder '/tICA' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
         temp.cdata(:,1:size(rtICASingleComponentSpaceXTime,2))=squeeze(sum(rtICASingleComponentSpaceXTime(:,:,:),3))./repmat(std(sum(rtICASingleComponentSpaceXTime,3),[],2),1,size(rtICASingleComponentSpaceXTime,2));
-        if ~isfile([OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'])
-            ciftisavereset(temp,[OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
-        end
-    %end
+        ciftisavereset(temp,[OutputFolder '/All' num2str(i,'%02.f') '_SS.sdseries.nii'],'wb_command');
+    end
 end
 if ~isfile([OutputFolder '/tICA_Maps_' num2str(tICAdim) '_' nonlinear '_SS.dscalar.nii'])
     ciftisave(tICAMaps_SS,[OutputFolder '/tICA_Maps_' num2str(tICAdim) '_tanhF_SS.dscalar.nii'],wbcommand);

--- a/tICA/scripts/feature_helpers/ComputeDVARSandGS.m
+++ b/tICA/scripts/feature_helpers/ComputeDVARSandGS.m
@@ -32,92 +32,87 @@ for i=1:length(Subjlist)
         RunStarts=[1];
     end
     for j=1:length(fMRINames)
-        % check if file exists, if any of them not exists, generate them
-        if ~isfile([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_GS.sdseries.nii']) || ...
-            ~isfile([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_DVARS.sdseries.nii']) || ...
-            ~isfile([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_DVARS_Medians.txt'])
-            if exist([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/Signal.txt'],'file')
-                sICA=load([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/filtered_func_data.ica/melodic_mix']);
-                %sICA_table=readtable([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/filtered_func_data.ica/melodic_mix']);
-                %sICA=sICA_table{:,:};
-                %sICA(find(isnan(sICA)))=0;
-                if rclean==1
-                    Signal=load([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/ReCleanSignal.txt']);
-                else
-                    Signal=load([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/Signal.txt']);
-                end
-                file_name=[SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '.dtseries.nii'];
-                CIFTIDenseTimeSeries=ciftiopen(file_name,wbcommand);
-                TR = CIFTIDenseTimeSeries.diminfo{2}.seriesStep;
-                CIFTIDenseTimeSeries.cdata=demean(CIFTIDenseTimeSeries.cdata,2);
-                BetaICA=pinv(normalise(sICA(:,Signal)))*CIFTIDenseTimeSeries.cdata';
-                CIFTIDenseTimeSeriesSignalsICA=(sICA(:,Signal)*BetaICA)';
-                CIFTIDenseTimeseriesUnstructuredNoise=CIFTIDenseTimeSeries.cdata-CIFTIDenseTimeSeriesSignalsICA;
-
-                GS=mean(CIFTIDenseTimeSeries.cdata)';
-                GSsICA=mean(CIFTIDenseTimeSeriesSignalsICA)';
-                GSUnstruct=mean(CIFTIDenseTimeseriesUnstructuredNoise)';
-
-                DVARS=[0;rms(diff(transpose(CIFTIDenseTimeSeries.cdata)),2)]; 
-                DVARSsICA=[0;rms(diff(transpose(CIFTIDenseTimeSeriesSignalsICA)),2)]; 
-                DVARSUnstruct=[0;rms(diff(transpose(CIFTIDenseTimeseriesUnstructuredNoise)),2)]; 
-
-                cDVARS=[0;rms(diff(transpose(CIFTIDenseTimeSeries.cdata(1:59412,:))),2)]; 
-                cDVARSsICA=[0;rms(diff(transpose(CIFTIDenseTimeSeriesSignalsICA(1:59412,:))),2)]; 
-                cDVARSUnstruct=[0;rms(diff(transpose(CIFTIDenseTimeseriesUnstructuredNoise(1:59412,:))),2)]; 
-
-                if ~strcmp(MRFixConcatName,'')
-                    MedianDV=[0 0 0 0 0 0];
-                    for k=1:length(RunStarts)
-                        MedianDV(1)=MedianDV(1) + median(DVARS(RunStarts(k):RunEnds(k)));
-                        MedianDV(2)=MedianDV(2) + median(DVARSsICA(RunStarts(k):RunEnds(k)));
-                        MedianDV(3)=MedianDV(3) + median(DVARSUnstruct(RunStarts(k):RunEnds(k)));
-                        MedianDV(4)=MedianDV(4) + median(cDVARS(RunStarts(k):RunEnds(k)));
-                        MedianDV(5)=MedianDV(5) + median(cDVARSsICA(RunStarts(k):RunEnds(k)));
-                        MedianDV(6)=MedianDV(6) + median(cDVARSUnstruct(RunStarts(k):RunEnds(k)));
-                        DVARS(RunStarts(k):RunEnds(k))=DVARS(RunStarts(k):RunEnds(k))-median(DVARS(RunStarts(k):RunEnds(k)));
-                        DVARSsICA(RunStarts(k):RunEnds(k))=DVARSsICA(RunStarts(k):RunEnds(k))-median(DVARSsICA(RunStarts(k):RunEnds(k)));
-                        DVARSUnstruct(RunStarts(k):RunEnds(k))=DVARSUnstruct(RunStarts(k):RunEnds(k))-median(DVARSUnstruct(RunStarts(k):RunEnds(k)));
-                        cDVARS(RunStarts(k):RunEnds(k))=cDVARS(RunStarts(k):RunEnds(k))-median(cDVARS(RunStarts(k):RunEnds(k)));
-                        cDVARSsICA(RunStarts(k):RunEnds(k))=cDVARSsICA(RunStarts(k):RunEnds(k))-median(cDVARSsICA(RunStarts(k):RunEnds(k)));
-                        cDVARSUnstruct(RunStarts(k):RunEnds(k))=cDVARSUnstruct(RunStarts(k):RunEnds(k))-median(cDVARSUnstruct(RunStarts(k):RunEnds(k)));
-                    end
-                    MedianDV=MedianDV./length(RunStarts);
-                else
-                    MedianDV(1)=median(DVARS);
-                    MedianDV(2)=median(DVARSsICA);
-                    MedianDV(3)=median(DVARSUnstruct);
-                    MedianDV(4)=median(cDVARS);
-                    MedianDV(5)=median(cDVARSsICA);
-                    MedianDV(6)=median(cDVARSUnstruct);
-                    DVARS=DVARS-median(DVARS);
-                    DVARSsICA=DVARSsICA-median(DVARSsICA);
-                    DVARSUnstruct=DVARSUnstruct-median(DVARSUnstruct);
-                    cDVARS=cDVARS-median(cDVARS);
-                    cDVARSsICA=cDVARSsICA-median(cDVARSsICA);
-                    cDVARSUnstruct=cDVARSUnstruct-median(cDVARSUnstruct);
-                end
-
-                DVARS(RunStarts)=0;
-                DVARSsICA(RunStarts)=0;
-                DVARSUnstruct(RunStarts)=0;
-                cDVARS(RunStarts)=0;
-                cDVARSsICA(RunStarts)=0;
-                cDVARSUnstruct(RunStarts)=0;
-
-                CIFTIGS=cifti_struct_create_sdseries([GS GSsICA GSUnstruct]','step',TR,'namelist',{'GS';'GSsICA';'GSUnstruct'});
-                CIFTIDVARS=cifti_struct_create_sdseries([DVARS DVARSsICA DVARSUnstruct cDVARS cDVARSsICA cDVARSUnstruct]','step',TR,'namelist',{'DVARS';'DVARSsICA';'DVARSUnstruct';'CorticalDVARS';'CorticalDVARSsICA';'CorticalDVARSUnstruct'});
-                %CIFTIGS=cifti_struct_create_sdseries([GS(1:size(a,2)) GSsICA(1:size(a,2)) GSUnstruct(1:size(a,2))]','step',TR,'namelist',{'GS';'GSsICA';'GSUnstruct'});
-                %CIFTIDVARS=cifti_struct_create_sdseries([DVARS(1:size(a,2)) DVARSsICA(1:size(a,2)) DVARSUnstruct(1:size(a,2)) cDVARS(1:size(a,2)) cDVARSsICA(1:size(a,2)) cDVARSUnstruct(1:size(a,2))]','step',TR,'namelist',{'DVARS';'DVARSsICA';'DVARSUnstruct';'CorticalDVARS';'CorticalDVARSsICA';'CorticalDVARSUnstruct'});
-
-                ciftisave(CIFTIGS,[SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_GS.sdseries.nii'],'wb_command');
-                ciftisave(CIFTIDVARS,[SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_DVARS.sdseries.nii'],'wb_command');
-
-                dlmwrite([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_DVARS_Medians.txt'],MedianDV,'\t');
-
-                %unix(['rm ' SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas_hp' hp '_clean_rclean_GS.sdseries.nii']);
-                %unix(['rm ' SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas_hp' hp '_clean_rclean_DVARS.sdseries.nii']);
+        if exist([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/Signal.txt'],'file')
+            sICA=load([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/filtered_func_data.ica/melodic_mix']);
+            %sICA_table=readtable([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/filtered_func_data.ica/melodic_mix']);
+            %sICA=sICA_table{:,:};
+            %sICA(find(isnan(sICA)))=0;
+            if rclean==1
+                Signal=load([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/ReCleanSignal.txt']);
+            else
+                Signal=load([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_hp' hp '.ica/Signal.txt']);
             end
+            file_name=[SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '.dtseries.nii'];
+            CIFTIDenseTimeSeries=ciftiopen(file_name,wbcommand);
+            TR = CIFTIDenseTimeSeries.diminfo{2}.seriesStep;
+            CIFTIDenseTimeSeries.cdata=demean(CIFTIDenseTimeSeries.cdata,2);
+            BetaICA=pinv(normalise(sICA(:,Signal)))*CIFTIDenseTimeSeries.cdata';
+            CIFTIDenseTimeSeriesSignalsICA=(sICA(:,Signal)*BetaICA)';
+            CIFTIDenseTimeseriesUnstructuredNoise=CIFTIDenseTimeSeries.cdata-CIFTIDenseTimeSeriesSignalsICA;
+
+            GS=mean(CIFTIDenseTimeSeries.cdata)';
+            GSsICA=mean(CIFTIDenseTimeSeriesSignalsICA)';
+            GSUnstruct=mean(CIFTIDenseTimeseriesUnstructuredNoise)';
+
+            DVARS=[0;rms(diff(transpose(CIFTIDenseTimeSeries.cdata)),2)]; 
+            DVARSsICA=[0;rms(diff(transpose(CIFTIDenseTimeSeriesSignalsICA)),2)]; 
+            DVARSUnstruct=[0;rms(diff(transpose(CIFTIDenseTimeseriesUnstructuredNoise)),2)]; 
+
+            cDVARS=[0;rms(diff(transpose(CIFTIDenseTimeSeries.cdata(1:59412,:))),2)]; 
+            cDVARSsICA=[0;rms(diff(transpose(CIFTIDenseTimeSeriesSignalsICA(1:59412,:))),2)]; 
+            cDVARSUnstruct=[0;rms(diff(transpose(CIFTIDenseTimeseriesUnstructuredNoise(1:59412,:))),2)]; 
+
+            if ~strcmp(MRFixConcatName,'')
+                MedianDV=[0 0 0 0 0 0];
+                for k=1:length(RunStarts)
+                    MedianDV(1)=MedianDV(1) + median(DVARS(RunStarts(k):RunEnds(k)));
+                    MedianDV(2)=MedianDV(2) + median(DVARSsICA(RunStarts(k):RunEnds(k)));
+                    MedianDV(3)=MedianDV(3) + median(DVARSUnstruct(RunStarts(k):RunEnds(k)));
+                    MedianDV(4)=MedianDV(4) + median(cDVARS(RunStarts(k):RunEnds(k)));
+                    MedianDV(5)=MedianDV(5) + median(cDVARSsICA(RunStarts(k):RunEnds(k)));
+                    MedianDV(6)=MedianDV(6) + median(cDVARSUnstruct(RunStarts(k):RunEnds(k)));
+                    DVARS(RunStarts(k):RunEnds(k))=DVARS(RunStarts(k):RunEnds(k))-median(DVARS(RunStarts(k):RunEnds(k)));
+                    DVARSsICA(RunStarts(k):RunEnds(k))=DVARSsICA(RunStarts(k):RunEnds(k))-median(DVARSsICA(RunStarts(k):RunEnds(k)));
+                    DVARSUnstruct(RunStarts(k):RunEnds(k))=DVARSUnstruct(RunStarts(k):RunEnds(k))-median(DVARSUnstruct(RunStarts(k):RunEnds(k)));
+                    cDVARS(RunStarts(k):RunEnds(k))=cDVARS(RunStarts(k):RunEnds(k))-median(cDVARS(RunStarts(k):RunEnds(k)));
+                    cDVARSsICA(RunStarts(k):RunEnds(k))=cDVARSsICA(RunStarts(k):RunEnds(k))-median(cDVARSsICA(RunStarts(k):RunEnds(k)));
+                    cDVARSUnstruct(RunStarts(k):RunEnds(k))=cDVARSUnstruct(RunStarts(k):RunEnds(k))-median(cDVARSUnstruct(RunStarts(k):RunEnds(k)));
+                end
+                MedianDV=MedianDV./length(RunStarts);
+            else
+                MedianDV(1)=median(DVARS);
+                MedianDV(2)=median(DVARSsICA);
+                MedianDV(3)=median(DVARSUnstruct);
+                MedianDV(4)=median(cDVARS);
+                MedianDV(5)=median(cDVARSsICA);
+                MedianDV(6)=median(cDVARSUnstruct);
+                DVARS=DVARS-median(DVARS);
+                DVARSsICA=DVARSsICA-median(DVARSsICA);
+                DVARSUnstruct=DVARSUnstruct-median(DVARSUnstruct);
+                cDVARS=cDVARS-median(cDVARS);
+                cDVARSsICA=cDVARSsICA-median(cDVARSsICA);
+                cDVARSUnstruct=cDVARSUnstruct-median(cDVARSUnstruct);
+            end
+
+            DVARS(RunStarts)=0;
+            DVARSsICA(RunStarts)=0;
+            DVARSUnstruct(RunStarts)=0;
+            cDVARS(RunStarts)=0;
+            cDVARSsICA(RunStarts)=0;
+            cDVARSUnstruct(RunStarts)=0;
+
+            CIFTIGS=cifti_struct_create_sdseries([GS GSsICA GSUnstruct]','step',TR,'namelist',{'GS';'GSsICA';'GSUnstruct'});
+            CIFTIDVARS=cifti_struct_create_sdseries([DVARS DVARSsICA DVARSUnstruct cDVARS cDVARSsICA cDVARSUnstruct]','step',TR,'namelist',{'DVARS';'DVARSsICA';'DVARSUnstruct';'CorticalDVARS';'CorticalDVARSsICA';'CorticalDVARSUnstruct'});
+            %CIFTIGS=cifti_struct_create_sdseries([GS(1:size(a,2)) GSsICA(1:size(a,2)) GSUnstruct(1:size(a,2))]','step',TR,'namelist',{'GS';'GSsICA';'GSUnstruct'});
+            %CIFTIDVARS=cifti_struct_create_sdseries([DVARS(1:size(a,2)) DVARSsICA(1:size(a,2)) DVARSUnstruct(1:size(a,2)) cDVARS(1:size(a,2)) cDVARSsICA(1:size(a,2)) cDVARSUnstruct(1:size(a,2))]','step',TR,'namelist',{'DVARS';'DVARSsICA';'DVARSUnstruct';'CorticalDVARS';'CorticalDVARSsICA';'CorticalDVARSUnstruct'});
+
+            ciftisave(CIFTIGS,[SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_GS.sdseries.nii'],'wb_command');
+            ciftisave(CIFTIDVARS,[SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_DVARS.sdseries.nii'],'wb_command');
+
+            dlmwrite([SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas' RegString ProcString '_DVARS_Medians.txt'],MedianDV,'\t');
+
+            %unix(['rm ' SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas_hp' hp '_clean_rclean_GS.sdseries.nii']);
+            %unix(['rm ' SubjFolder '/MNINonLinear/Results/' fMRINames{j} '/' fMRINames{j} '_Atlas_hp' hp '_clean_rclean_DVARS.sdseries.nii']);
         end
     end
     if ~strcmp(MRFixConcatName,'')

--- a/tICA/scripts/feature_helpers/findFivePercentageOutliers.m
+++ b/tICA/scripts/feature_helpers/findFivePercentageOutliers.m
@@ -1,0 +1,12 @@
+function ret = findFivePercentageOutliers(flatdata)
+    %isoutlier(..., 'percentiles', [5 95]) written to treat all values at once
+    numelems = numel(flatdata);
+    ret = false(size(flatdata));
+    if numelems < 1
+        return
+    end
+    numexclude = floor((numelems + 9) / 20); %in R2021a, isoutlier excludes 0 for 10, 2 for 11...
+    [~, perm] = sort(flatdata(:));
+    ret([1:numexclude (end - numexclude + 1):end]) = true;
+    ret(perm) = ret; %un-sort the exclusion mask
+end

--- a/tICA/scripts/feature_helpers/findOutliers.m
+++ b/tICA/scripts/feature_helpers/findOutliers.m
@@ -1,0 +1,6 @@
+function isOutliers = findOutliers(data)
+% must be 1d array
+madOutliers=findScaledMADOutliers(data);
+perOutliers=findFivePercentageOutliers(data);
+isOutliers=and(madOutliers, perOutliers);
+end

--- a/tICA/scripts/feature_helpers/findOutliers.m
+++ b/tICA/scripts/feature_helpers/findOutliers.m
@@ -1,6 +1,6 @@
-function isOutliers = findOutliers(data)
+function ret = findOutliers(data)
 % must be 1d array
 madOutliers=findScaledMADOutliers(data);
 perOutliers=findFivePercentageOutliers(data);
-isOutliers=and(madOutliers, perOutliers);
+ret=and(madOutliers, perOutliers);
 end

--- a/tICA/scripts/feature_helpers/findOutliers.m
+++ b/tICA/scripts/feature_helpers/findOutliers.m
@@ -1,5 +1,6 @@
 function ret = findOutliers(data)
 % must be 1d array
+% outlier detection: identify data that do not pass the MAD-based test, while ensuring that it never detects more than 5% of the highest or lowest values.
 madOutliers=findScaledMADOutliers(data);
 perOutliers=findFivePercentageOutliers(data);
 ret=and(madOutliers, perOutliers);

--- a/tICA/scripts/feature_helpers/findScaledMADOutliers.m
+++ b/tICA/scripts/feature_helpers/findScaledMADOutliers.m
@@ -1,7 +1,6 @@
 function isOutlier = findScaledMADOutliers(data)
 % Determine if an array contains values that are outside of three scaled MAD
     numElems = numel(data);
-    isOutlier = false(size(data));
     if numElems < 1
         return
     end

--- a/tICA/scripts/feature_helpers/findScaledMADOutliers.m
+++ b/tICA/scripts/feature_helpers/findScaledMADOutliers.m
@@ -1,0 +1,16 @@
+function isOutlier = findScaledMADOutliers(data)
+% Determine if an array contains values that are outside of three scaled MAD
+    numElems = numel(data);
+    isOutlier = false(size(data));
+    if numElems < 1
+        return
+    end
+    deviations = data - median(data);
+    absDeviations = abs(deviations);
+    mad = median(absDeviations);
+    % Scale the MAD by -1/(sqrt(2)*erfcinv(3/2))
+    % from https://www.mathworks.com/help/matlab/ref/isoutlier.html#bvolffm
+    scaledMAD = 1.4826 * mad;
+    threshold = 3 * scaledMAD;
+    isOutlier = absDeviations > threshold;
+end

--- a/tICA/scripts/feature_helpers/findScaledMADOutliers.m
+++ b/tICA/scripts/feature_helpers/findScaledMADOutliers.m
@@ -1,4 +1,4 @@
-function isOutlier = findScaledMADOutliers(data)
+function ret = findScaledMADOutliers(data)
 % Determine if an array contains values that are outside of three scaled MAD
     numElems = numel(data);
     if numElems < 1
@@ -11,5 +11,5 @@ function isOutlier = findScaledMADOutliers(data)
     % from https://www.mathworks.com/help/matlab/ref/isoutlier.html#bvolffm
     scaledMAD = 1.4826 * mad;
     threshold = 3 * scaledMAD;
-    isOutlier = absDeviations > threshold;
+    ret = absDeviations > threshold;
 end

--- a/tICA/scripts/feature_helpers/std_outlier.m
+++ b/tICA/scripts/feature_helpers/std_outlier.m
@@ -7,7 +7,7 @@ function outlier_stat = std_outlier(data)
     if any(isnan(data_reshape))
         error('found NaN in std_outlier');
     end
-    isoutlier_stat = myoutliers(data_reshape); %TODO: test me
+    isoutlier_stat = findOutliers(data_reshape); %TODO: test me
     if isempty(isoutlier_stat)
         %outlier_stat=1; %original
         outlier_stat=0;
@@ -18,17 +18,3 @@ function outlier_stat = std_outlier(data)
         outlier_stat=1-std_exclude_outlier/std_all;
     end
 end
-
-%isoutlier(..., 'percentiles', [5 95]) written to treat all values at once
-function ret = myoutliers(flatdata)
-    numelems = numel(flatdata);
-    ret = false(size(flatdata));
-    if numelems < 1
-        return
-    end
-    numexclude = floor((numelems + 9) / 20); %in R2021a, isoutlier excludes 0 for 10, 2 for 11...
-    [~, perm] = sort(flatdata(:));
-    ret([1:numexclude (end - numexclude + 1):end]) = true;
-    ret(perm) = ret; %un-sort the exclusion mask
-end
-

--- a/tICA/scripts/feature_helpers/sum_outlier.m
+++ b/tICA/scripts/feature_helpers/sum_outlier.m
@@ -1,8 +1,9 @@
 function output = sum_outlier(T)
 %Afill = filloutliers(T,'spline');
 %Afill = filloutliers(T,'next');
-Afill = filloutliers(T,'spline','percentiles', [5,95]);
+outliers=findOutliers(T);
 
+Afill = filloutliers(T,'spline','OutlierLocations', outliers);
 Afill(find(isnan(Afill)))=T(find(isnan(Afill)));
 % original
 output = sqrt(sum((T-Afill).^2));


### PR DESCRIPTION
## Background
Matlab's `isoutlier` function has new option `percentile` that wasn't introduced in r2017b but in the latest versions. Because of this, the compiled version of Matlab always throws errors for scripts written in r2022 which use commands such as `isoutlier(a, 'percentile', [5,95])`. 

## Main changes
- `isoutlier` and `filloutlier` are removed from the tICA feature generation step
- two custom outlier detection functions are involved, 
  - `findFivePercentageOutliers` to find outliers outside 5% to 95% range
  - `findScaledMADOutliers` to find outliers three scaled MAD away from the median
- the final outlier is determined by the intersection (AND) between the outliers obtained from the above criteria

## Evaluation
In r2022b (raw version),

```
A = [57 59 60 100 59 58 57 58 300 61 62 60 62 58 57];
res=isoutlier(A,'percentile',[5,95])

res =

  1×15 logical array

   0   0   0   0   0   0   0   0   1   0   0   0   0   0   0
```
 
in r2022b & r2017b (current commit),

```
A = [57 59 60 100 59 58 57 58 300 61 62 60 62 58 57];
res=findOutliers(A)

res =

  1×15 logical array

   0   0   0   0   0   0   0   0   1   0   0   0   0   0   0
```