### PR TITLE
add inidividual-level ComputeGroupTICA; only in USE mode

### DIFF
--- a/tICA/scripts/ComputeGroupTICAInd.m
+++ b/tICA/scripts/ComputeGroupTICAInd.m
@@ -1,0 +1,145 @@
+function ComputeGroupTICAInd(StudyFolder, SubjListName, TCSListName, SpectraListName, fMRIListName, sICAdim, RunsXNumTimePoints, OutputFolder, OutString, RegName, LowResMesh, tICAmode, tICAMM, sICAtcsvarsFile)
+    
+    %if isdeployed()
+        %better solution for compiled matlab: *require* all arguments to be strings, so we don't have to build the argument list twice in the script
+    %end
+    sICAdim = str2double(sICAdim);
+    RunsXNumTimePoints = str2double(RunsXNumTimePoints);
+    
+    wbcommand = 'wb_command';
+    
+    %naming conventions inside OutputFolder, probably don't need to be changeable
+    tICAmixNamePart = 'melodic_mix';
+    tICAunmixNamePart = 'melodic_unmix';
+    statsNamePart = 'stats';
+    figsNamePart = 'Figure';
+    iqNamePart = 'iq';
+    sRNamePart = 'sR';
+    tICAtcsNamePart = 'tICA_TCS';
+    
+    RegString = '';
+    if ~isempty(RegName)
+        RegString = ['_' RegName];
+    end
+    
+    TCSList = myreadtext(TCSListName);
+    %MapList = myreadtext(MapListName);
+    %VolMapList = myreadtext(VolMapListName);
+    SpectraList = myreadtext(SpectraListName);
+    SubjectList = myreadtext(SubjListName);
+    fMRIList = myreadtext(fMRIListName);
+    
+    %TCSFullConcat = ciftiopen(TCSConcatName, wbcommand);
+	% pad the individual sICA timeseries to RunsXNumTimePoints
+    TCSSub=ciftiopen(TCSList{1}, wbcommand);
+    TCSPad = zeros(sICAdim, RunsXNumTimePoints, 'single');
+    TCSPad(1:size(TCSSub.cdata, 1), 1:size(TCSSub.cdata, 2)) = TCSSub.cdata;
+    TCSFullConcat=TCSSub;
+    TCSFullConcat.cdata=TCSPad;
+    
+    tICAMM=load(tICAMM);
+
+    numsubj = length(TCSList);
+    if length(SubjectList) ~= numsubj || length(SpectraList) ~= numsubj
+        error('input lists are not the same length');
+    end
+
+	if numsubj ~= 1
+		error('this file can only accept one subject at a time in a USE mode');
+	end
+
+    numfullsubj = 0;
+
+    %tica runwise normalization
+    TCSFullRunVars = single(zeros(sICAdim, RunsXNumTimePoints * numsubj));
+    for i = 1:numsubj
+        if exist(TCSList{i}, 'file')
+            subjBaseInd = (i - 1) * RunsXNumTimePoints + 1;
+            thisStart = subjBaseInd;
+            TCSRunVarSub = [];
+            SubjFolder = [StudyFolder '/' SubjectList{i} '/'];
+            for j = 1:length(fMRIList)
+                dtseriesName = [SubjFolder fMRIList{j}];
+                if exist(dtseriesName, 'file')
+                    [~, runLengthStr] = system(['wb_command -file-information -only-number-of-maps ' dtseriesName]);
+                    runLength = str2double(runLengthStr);
+                    nextStart = thisStart + runLength;
+                    TCSRunVarSub = [TCSRunVarSub repmat(std(TCSFullConcat.cdata(:, thisStart:(nextStart - 1)), [], 2), 1, runLength)];
+
+                    thisStart = nextStart;
+                end
+            end
+            if size(TCSRunVarSub, 2) == RunsXNumTimePoints
+                numfullsubj = numfullsubj + 1;
+            end
+            TCSFullRunVars(:, subjBaseInd - 1 + (1:size(TCSRunVarSub, 2))) = TCSRunVarSub;
+        end
+    end
+    %end tica runwise normalization
+
+    nlfunc = 'tanh';
+    iterations = 100;
+    tICAdim = sICAdim;
+
+    sICAtcsvars = load(sICAtcsvarsFile);
+    sICAtcsvars = sICAtcsvars.sICAtcsvars; 
+    TCSFullConcat.cdata = (TCSFullConcat.cdata ./ TCSFullRunVars) .* repmat(sICAtcsvars, 1, size(TCSFullRunVars, 2)); %Making all runs contribute equally improves tICA decompositions
+    TCSFullConcat.cdata(~isfinite(TCSFullConcat.cdata)) = 0;
+
+    %This loop produces more reproducible and better tICA decompositions
+    if strcmp(tICAmode,'USE')
+        A = tICAMM;
+        if size(tICAMM,1) ~= size(TCSFullConcat.cdata,1)
+            error('Mixing matrix to be used does not match dimensions of the sICA components');
+        end
+    else
+        error('tICAmode not recognized');
+    end
+    
+    %We do different types of icasso, etc in different modes/iterations, but we do things in between all iterations, and save out some files the same way each time
+    %So, rely on iteration number as a mode switch, even though it is ugly
+
+    IT = ['F'];
+    W = pinv(A);
+    normicasig = W * TCSFullConcat.cdata;
+
+    icasig = normicasig .* repmat(std(A ./ repmat(sICAtcsvars, 1, size(A, 2)))', 1, size(TCSFullConcat.cdata, 2)); %Unormalize the icasig assuming sICAtcs with std = 1 (approximately undo the original variance normalization)
+    
+    tICAtcs = TCSFullConcat;
+    tICAtcs.cdata = icasig'; %time X temporal ica
+	tICAtcs.cdata = tICAtcs.cdata';
+	%tICAtcs.cdata = single(tICAtcs.cdata);
+    tICAtcsAll = reshape(tICAtcs.cdata, tICAdim, RunsXNumTimePoints, numsubj);
+    
+    for i = 1:numsubj
+        if exist(TCSList{i}, 'file')
+            sICATCS = ciftiopen(TCSList{i}, 'wb_command');
+            sICASpectra = ciftiopen(SpectraList{i}, 'wb_command');
+            tICATCS = sICATCS;
+            %tICATCS.cdata = pinv(tICAmix) * sICATCS.cdata;
+            tICATCS.cdata = squeeze(tICAtcsAll(:, std(tICAtcsAll(:, :, i), [], 1) > 0, i));
+            tICASpectra = sICASpectra;
+            SubjFolder = [StudyFolder '/' SubjectList{i} '/'];
+            %FIXME: how to deal with subject ID in this filename without hardcoding conventions?
+            ciftisave(tICATCS, [SubjFolder 'MNINonLinear/fsaverage_LR' LowResMesh 'k/' SubjectList{i} '.' OutString '_tICA' RegString '_ts2.' LowResMesh 'k_fs_LR.sdseries.nii'], 'wb_command');
+            ts.Nnodes = size(tICATCS.cdata, 1);
+            ts.Nsubjects = 1;
+            ts.ts = tICATCS.cdata';
+            ts.NtimepointsPerSubject = size(tICATCS.cdata, 2);
+            tICASpectra.cdata = nets_spectra_sp(ts)';
+            %FIXME
+            ciftisave(tICASpectra, [SubjFolder '/MNINonLinear/fsaverage_LR' LowResMesh 'k/' SubjectList{i} '.' OutString '_tICA' RegString '_spectra2.' LowResMesh 'k_fs_LR.sdseries.nii'], 'wb_command');
+        end
+    end
+end
+
+function lines = myreadtext(filename)
+    fid = fopen(filename);
+    if fid < 0
+        error(['unable to open file ' filename]);
+    end
+    array = textscan(fid, '%s', 'Delimiter', {'\n'});
+    fclose(fid);
+    lines = array{1};
+end
+

--- a/tICA/scripts/ComputeGroupTICAInd.sh
+++ b/tICA/scripts/ComputeGroupTICAInd.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+set -eu
+
+pipedirguessed=0
+if [[ "${HCPPIPEDIR:-}" == "" ]]
+then
+    pipedirguessed=1
+    export HCPPIPEDIR="$(dirname -- "$0")/../.."
+fi
+
+source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
+source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
+source "$HCPPIPEDIR/global/scripts/tempfiles.shlib"
+g_matlab_default_mode=1
+
+#this function gets called by opts_ParseArguments when --help is specified
+function usage()
+{
+    #header text
+    echo "
+$log_ToolName: does stuff
+
+Usage: $log_ToolName PARAMETER...
+
+PARAMETERs are [ ] = optional; < > = user supplied value
+"
+    #automatic argument descriptions
+    opts_ShowArguments
+    
+    #do not use exit, the parsing code takes care of it
+}
+
+#arguments to opts_Add*: switch, variable to set, name for inside of <> in help text, description, [default value if AddOptional], [compatibility flag, ...]
+#help info for option gets printed like "--foo=<$3> - $4"
+opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder containing all subjects"
+opts_AddMandatory '--subject-list' 'SubjListRaw' '100206' 'only one subject'
+opts_AddMandatory '--fmri-list' 'fMRIListRaw' 'rfMRI_REST1_RL@rfMRI_REST1_LR...' 'list of runs used in sICA, in the SAME ORDER, separated by @s'
+#FIXME: when full script is ready, make calling script set the naming conventions for outputs
+opts_AddMandatory '--out-folder' 'OutGroupFolder' 'path' "group average folder"
+opts_AddMandatory '--fmri-concat-name' 'fMRIConcatName' 'string' "name for the concatenated data, like 'rfMRI_REST_7T'"
+opts_AddMandatory '--surf-reg-name' 'RegName' 'name' "the surface registration string"
+opts_AddMandatory '--ica-dim' 'sICAdim' 'integer' "number of ICA components"
+opts_AddMandatory '--subject-expected-timepoints' 'RunsXNumTimePoints' 'integer' "number of concatenated timepoints in a subject with full data"
+opts_AddMandatory '--low-res-mesh' 'LowResMesh' 'integer' "mesh resolution, like '32'"
+opts_AddMandatory '--sica-proc-string' 'sICAProcString' 'string' "name part to use for some outputs, like 'tfMRI_RET_7T_d73_WF5_WR'"
+opts_AddOptional '--matlab-run-mode' 'MatlabMode' '0, 1, or 2' "defaults to $g_matlab_default_mode
+
+0 = compiled MATLAB
+1 = interpreted MATLAB
+2 = Octave" "$g_matlab_default_mode"
+opts_AddOptional '--tICA-mode' 'tICAmode' 'USE' "defaults to USE
+USE simply applies a previously computed mixing matrix with matching sICA components" "USE"
+opts_AddOptional '--tICA-mixing-matrix' 'tICAMM' 'filename' "path to a previously computed tICA mixing matrix with matching sICA components"
+opts_ParseArguments "$@"
+
+if ((pipedirguessed))
+then
+    log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
+fi
+
+#display the parsed/default values
+opts_ShowValues
+
+#FIXME: hardcoded naming conventions, move these to high level script when ready
+OutputFolder="$OutGroupFolder/MNINonLinear/Results/$fMRIConcatName/tICA_d$sICAdim"
+
+RegString=""
+if [[ "$RegName" != "" ]]
+then
+    RegString="_$RegName"
+fi
+
+case "$MatlabMode" in
+    (0)
+        if [[ "${MATLAB_COMPILER_RUNTIME:-}" == "" ]]
+        then
+            log_Err_Abort "to use compiled matlab, you must set and export the variable MATLAB_COMPILER_RUNTIME"
+        fi
+        ;;
+    (1)
+        #NOTE: figure() is required by the spectra option, and -nojvm prevents using figure()
+        matlab_interpreter=(matlab -nodisplay -nosplash)
+        ;;
+    (2)
+        matlab_interpreter=(octave-cli -q --no-window-system)
+        ;;
+    (*)
+        log_Err_Abort "unrecognized matlab mode '$MatlabMode', use 0, 1, or 2"
+        ;;
+esac
+
+IFS='@' read -a SubjList <<<"$SubjListRaw"
+IFS='@' read -a fMRIList <<<"$fMRIListRaw"
+
+# this is the standard deviation of the raw group-concatenated sICA timeseries
+# the size of this std array is NumComp X 1
+sICAtcsvarsFile="$OutputFolder/sICAtcsvars.mat"
+
+TCSListName="$OutputFolder/TCSList.txt"
+SpectraListName="$OutputFolder/SpectraList.txt"
+SubjListName="$OutputFolder/SubjectList.txt"
+fMRIListName="$OutputFolder/fMRIList.txt"
+
+tempfiles_add "$TCSListName" "$SpectraListName" "$SubjListName" "$fMRIListName"
+
+rm -f -- "$TCSListName" "$SpectraListName" "$SubjListName" "$fMRIListName"
+
+for Subject in "${SubjList[@]}"
+do
+    FilePrefix="$StudyFolder/$Subject/MNINonLinear/fsaverage_LR${LowResMesh}k/$Subject.${sICAProcString}${RegString}"
+    echo "${FilePrefix}_ts.${LowResMesh}k_fs_LR.sdseries.nii" >> "$TCSListName"
+    echo "${FilePrefix}_spectra.${LowResMesh}k_fs_LR.sdseries.nii" >> "$SpectraListName"
+    echo "$Subject" >> "$SubjListName"
+done
+
+for fMRIName in "${fMRIList[@]}"
+do
+    echo "MNINonLinear/Results/$fMRIName/${fMRIName}_Atlas${RegString}.dtseries.nii" >> "$fMRIListName"
+done
+
+#shortcut in case the folder gets renamed
+this_script_dir=$(dirname "$0")
+
+#matlab function arguments have been changed to strings, to avoid having two copies of the argument list in the script
+matlab_argarray=("$StudyFolder" "$SubjListName" "$TCSListName" "$SpectraListName" "$fMRIListName" "$sICAdim" "$RunsXNumTimePoints" "$OutputFolder" "$sICAProcString" "$RegName" "$LowResMesh" "$tICAmode" "$tICAMM" "$sICAtcsvarsFile")
+
+case "$MatlabMode" in
+    (0)
+        matlab_cmd=("$this_script_dir/Compiled_ComputeGroupTICAInd/run_ComputeGroupTICAInd.sh" "$MATLAB_COMPILER_RUNTIME" "${matlab_argarray[@]}")
+        log_Msg "running compiled matlab command: ${matlab_cmd[*]}"
+        "${matlab_cmd[@]}"
+        ;;
+    (1 | 2)
+        #reformat argument array so matlab sees them as strings
+        matlab_args=""
+        for thisarg in "${matlab_argarray[@]}"
+        do
+            if [[ "$matlab_args" != "" ]]
+            then
+                matlab_args+=", "
+            fi
+            matlab_args+="'$thisarg'"
+        done
+        matlabcode="
+            addpath('$HCPPIPEDIR/global/matlab/icaDim');
+            addpath('$HCPPIPEDIR/global/matlab/nets_spectra');
+            addpath('$HCPPIPEDIR/global/matlab');
+            addpath('$this_script_dir/icasso122');
+            addpath('$this_script_dir/FastICA_25');
+            addpath('$this_script_dir');
+            addpath('$HCPCIFTIRWDIR');
+            ComputeGroupTICAInd($matlab_args);"
+
+        log_Msg "running matlab code: $matlabcode"
+        "${matlab_interpreter[@]}" <<<"$matlabcode"
+        echo
+        ;;
+esac
+


### PR DESCRIPTION
## Background
Running the raw ComputeGroupTICA on CHPC at individual level has issues regarding the missing files from ConcatGroupTICA. A workaround strategy is to make an individual-specific script to run ComputeGroupTICA on one subject.

## Main updates
- main matlab function `tICA/scripts/ComputeGroupTICAInd.m`
- bash script `tICA/scripts/ComputeGroupTICAInd.sh`

## Evaluation

**The launch script can be found here /media/myelin/alex/pipelines/pipeline4/HCPpipelines/compute_group_tica_ind.sh**

when `--fmri-list=fMRI_CONCAT_ALL`, this is to mimic the results on myelin
/media/myelin/alex/pipelines/pipeline4/HCPpipelines/ComputeGroupTICAInd.sh.e2850045
/media/myelin/alex/pipelines/pipeline4/HCPpipelines/ComputeGroupTICAInd.sh.o2850045

when `--fmri-list=${fMRINames}`, this is for the final launch on CHPC
/media/myelin/alex/pipelines/pipeline4/HCPpipelines/ComputeGroupTICAInd.sh.e2846459
/media/myelin/alex/pipelines/pipeline4/HCPpipelines/ComputeGroupTICAInd.sh.o2846459

The following is the evaluation on matlab to compare against the results on myelin. The new scripts can generate similar results with a maximum difference around 1.56e-05.
```
raw_tcs=ciftiopen('/media/myelin/brainmappers/Connectome_Project/HCP_Lifespan/HCA/HCA6010538_V1_MR/MNINonLinear/fsaverage_LR32k/HCA6010538_V1_MR.fMRI_CONCAT_ALL_d86_WF6_HCA1798_MSMAll_WR_tICA_MSMAll_ts.32k_fs_LR.sdseries.nii','wb_command'); % old result on myelin
new_tcs=ciftiopen('/media/myelin/brainmappers/Connectome_Project/HCP_Lifespan/HCA/HCA6010538_V1_MR/MNINonLinear/fsaverage_LR32k/HCA6010538_V1_MR.fMRI_CONCAT_ALL_d86_WF6_HCA1798_MSMAll_WR_tICA_MSMAll_ts_testAlexJun6.32k_fs_LR.sdseries.nii','wb_command'); % new script --fmri-list=${fMRINames}
new_tcs2=ciftiopen('/media/myelin/brainmappers/Connectome_Project/HCP_Lifespan/HCA/HCA6010538_V1_MR/MNINonLinear/fsaverage_LR32k/HCA6010538_V1_MR.fMRI_CONCAT_ALL_d86_WF6_HCA1798_MSMAll_WR_tICA_MSMAll_ts_testAlexJun6v2.32k_fs_LR.sdseries.nii','wb_command'); % new script --fmri-list="fMRI_CONCAT_ALL"

>> max(abs(raw_tcs.cdata-new_tcs2.cdata),[],'all')

ans =

  single

  1.5527e-05
```

## To be done
The compiled files are not generated and may need Tim's help to generate for Jure to set up a new container.