### PR TITLE
Wildcard search in Volume pipeline no longer finds directories.

### DIFF
--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -847,7 +847,7 @@ fi
 if [ "$fMRIReference" != "NONE" ]; then
     # --- copy over existing scout images
     log_Msg "Copying Scout from Reference fMRI"
-    ${FSLDIR}/bin/imcp ${fMRIReferencePath}/Scout* ${fMRIFolder}
+    find ${fMRIReferencePath} -maxdepth 1 -name "Scout*" -type f -exec ${FSLDIR}/bin/imcp {} ${fMRIFolder} \;
 
     for simage in SBRef_nonlin SBRef_nonlin_norm
     do


### PR DESCRIPTION
PR for issue https://github.com/Washington-University/HCPpipelines/issues/269

Previously the wildcard search could find directories along with files, the subsequent imcp for copying images/files would then crashed when a directory was provided as an input.

This fix now filters the wildcard search to files only.