### PR TITLE
update rsn regression with the tICA regression

### DIFF
--- a/global/scripts/RSNregression.m
+++ b/global/scripts/RSNregression.m
@@ -181,10 +181,6 @@ function RSNregression(InputFile, InputVNFile, Method, ParamsFile, OutputBeta, v
             
             if strcmp(Method, "tICA_weighted") % based on tICA/scripts/ComputeGroupTICA.m but for one subject as a group
                 NODEts=NODEts';
-                disp(['NODEts'])
-                size(NODEts)
-                SpectraArray = textscan(optional.SpectraParams, '%s', 'Delimiter', {'@'});
-                nTPsForSpectra =str2double(SpectraArray{1}{1});
                 thisStart = 1;
                 TCSRunVarSub = [];
                 for i = 1:size(inputArray, 1)

--- a/global/scripts/RSNregression.m
+++ b/global/scripts/RSNregression.m
@@ -213,9 +213,9 @@ function RSNregression(InputFile, InputVNFile, Method, ParamsFile, OutputBeta, v
                 % normicasig has stdev = 1 (more or less), just like the fastica/icasso output, we want to multiply the (approximate) amplitudes from A into it
                 % but, we also want to pretend that the input to tICA was normalized, so:
                 % tICAinput = A * normicasig
-                % pretendtICAinput = diag(1 / stdev(tICAinput)) * A * normicasig
+                % pretendtICAinput = diag(1 / std(tICAinput)) * A * normicasig
                 % ...assume normicasig doesn't change...
-                % pretendA = diag(1 / stdev(tICAinput)) * A = A ./ repmat(stdev(tICAinput), ...)
+                % pretendA = diag(1 / std(tICAinput)) * A = A ./ repmat(std(tICAinput), ...)
                 % then use std() to extract the approximate amplitudes from pretendA...sqrt(mean(x .^ 2)) might be better, but this was how we did it in tICA, so...
                 icasig = normicasig .* repmat(std(A ./ repmat(sICAtcsvars, 1, size(A, 2)))', 1, size(NODEts, 2)); %Un-normalize the icasig assuming sICAtcs with std = 1 (approximately undo the original variance normalization)
 

--- a/global/scripts/RSNregression.m
+++ b/global/scripts/RSNregression.m
@@ -190,7 +190,7 @@ function RSNregression(InputFile, InputVNFile, Method, ParamsFile, OutputBeta, v
                 for i = 1:size(inputArray, 1)
                     dtseriesName=[inputArray{i}];
                     if exist(dtseriesName, 'file')
-                        [~, runLengthStr] = my_system(['wb_command -file-information -only-number-of-maps ' dtseriesName]);
+                        runLengthStr = my_system(['wb_command -file-information -only-number-of-maps ' dtseriesName]);
                         disp(['runLengthStr ' runLengthStr])
                         runLength = str2double(runLengthStr);
                         nextStart = thisStart + runLength;
@@ -230,7 +230,7 @@ function RSNregression(InputFile, InputVNFile, Method, ParamsFile, OutputBeta, v
             NODEts=NODEts.cdata';
             betaICA = ((pinv(normalise(NODEts)) * demean(inputConcat')))';
         otherwise
-            error(['unrecognized method: "' Method '", use "weighted", "dual", or "single"']);
+            error(['unrecognized method: "' Method '", use "weighted", "tICA_weighted", "dual", or "single"']);
     end
     
     NODEtsnorm = normalise(NODEts);
@@ -348,7 +348,7 @@ function outstruct = open_vol_as_cifti(volName, ciftiTemplate, wbcommand)
 end
 
 %like call_fsl, but without sourcing fslconf
-function [exitStatus, stdout]=my_system(command)
+function stdout=my_system(command)
     if ismac()
         ldsave = getenv('DYLD_LIBRARY_PATH');
     else
@@ -369,7 +369,7 @@ function [exitStatus, stdout]=my_system(command)
         setenv('LD_LIBRARY_PATH');
     end
 
-    [exitStatus, stdout] = system(command, '-echo');
+    [exitStatus, stdout] = system(command);
 
     if exitStatus ~= 0
         error(['command failed: ' command]);

--- a/global/scripts/RSNregression.m
+++ b/global/scripts/RSNregression.m
@@ -209,10 +209,17 @@ function RSNregression(InputFile, InputVNFile, Method, ParamsFile, OutputBeta, v
                 % unmix the sICA timeseries
                 W = pinv(A);
                 normicasig = W * NODEts;
-                icasig = normicasig .* repmat(std(A ./ repmat(sICAtcsvars, 1, size(A, 2)))', 1, size(NODEts, 2)); %Unormalize the icasig assuming sICAtcs with std = 1 (approximately undo the original variance normalization)
                 
-                tICAtcs = single(icasig);
+                % normicasig has stdev = 1 (more or less), just like the fastica/icasso output, we want to multiply the (approximate) amplitudes from A into it
+                % but, we also want to pretend that the input to tICA was normalized, so:
+                % tICAinput = A * normicasig
+                % pretendtICAinput = diag(1 / stdev(tICAinput)) * A * normicasig
+                % ...assume normicasig doesn't change...
+                % pretendA = diag(1 / stdev(tICAinput)) * A = A ./ repmat(stdev(tICAinput), ...)
+                % then use std() to extract the approximate amplitudes from pretendA...sqrt(mean(x .^ 2)) might be better, but this was how we did it in tICA, so...
+                icasig = normicasig .* repmat(std(A ./ repmat(sICAtcsvars, 1, size(A, 2)))', 1, size(NODEts, 2)); %Un-normalize the icasig assuming sICAtcs with std = 1 (approximately undo the original variance normalization)
 
+                tICAtcs = single(icasig);
                 % single regression
                 NODEts = tICAtcs';
                 betaICA = ((pinv(normalise(NODEts)) * demean(inputConcat')))';

--- a/tICA/scripts/ComputeGroupTICA.m
+++ b/tICA/scripts/ComputeGroupTICA.m
@@ -127,6 +127,13 @@ function ComputeGroupTICA(StudyFolder, SubjListName, TCSListName, SpectraListNam
             [iq, A, W, normicasig, sR] = icasso('bootstrap', TCSFullConcat.cdata, iterations, 'initGuess', A, 'approach', 'symm', 'g', nlfunc, 'lastEig', sICAdim, 'numOfIC', tICAdim, 'maxNumIterations', 1000); %x4
         end
 
+        % normicasig has stdev = 1, we want to multiply the (approximate) amplitudes from A into it
+        % but, we also want to pretend that the input to tICA was normalized, so:
+        % tICAinput = A * normicasig
+        % pretendtICAinput = diag(1 / std(tICAinput)) * A * normicasig
+        % ...assume normicasig doesn't change...
+        % pretendA = diag(1 / std(tICAinput)) * A = A ./ repmat(std(tICAinput), ...)
+        % then use std() to extract the approximate amplitudes from pretendA...sqrt(mean(x .^ 2)) might be better, but this was how we did it originally, so...
         icasig = normicasig .* repmat(std(A ./ repmat(sICAtcsvars, 1, size(A, 2)))', 1, size(TCSFullConcat.cdata, 2)); %Unormalize the icasig assuming sICAtcs with std = 1 (approximately undo the original variance normalization)
         
 


### PR DESCRIPTION
Introduce a `tICA_weighted` mode which performs the following steps in one mode:

-  weighted spatial regression given a group sICA spatial map;
- tICA unmix given a group tICA mixing matrix;
- single regression to generate individual tICA spatial maps.