### PR TITLE
Support for GE HealthCare (GEHC) B0 Fieldmap processing.

### DIFF
--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
@@ -277,7 +277,7 @@ for Subject in $Subjlist ; do
             --SEPhasePos="$SpinEchoPhaseEncodePositive" \
             --fmapmag="$MagnitudeInputName" \
             --fmapphase="$PhaseInputName" \
-            --fmapgelegacy="$GEB0InputName" \
+            --fmapcombined="$GEB0InputName" \
             --echospacing="$EchoSpacing" \
             --echodiff="$DeltaTE" \
             --unwarpdir="$UnwarpDir" \
@@ -299,7 +299,7 @@ for Subject in $Subjlist ; do
             --SEPhasePos=$SpinEchoPhaseEncodePositive \
             --fmapmag=$MagnitudeInputName \
             --fmapphase=$PhaseInputName \
-            --fmapgelegacy=$GEB0InputName \
+            --fmapcombined=$GEB0InputName \
             --echospacing=$EchoSpacing \
             --echodiff=$DeltaTE \
             --unwarpdir=$UnwarpDir \

--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
@@ -230,7 +230,7 @@ for Subject in $Subjlist ; do
         # or set the following inputs if using regular FIELDMAP (i.e. SiemensFieldMap GEHealthCareFieldMap PhilipsFieldMap)
         MagnitudeInputName="NONE" #Expects 4D Magnitude volume with two 3D volumes (differing echo times) - or a single 3D Volume
         PhaseInputName="NONE" #Expects a 3D Phase difference volume (Siemen's style) -or Fieldmap in Hertz for GE Healthcare
-        DeltaTE="NONE" #2.46ms for 3T, 1.02ms for 7T - for GE Healthcare at 3.0T, *usually* 2.304ms for 2D-B0MAP and 2.272 ms 3D B0MAP.
+        DeltaTE="NONE" #For Siemens, typically 2.46ms for 3T, 1.02ms for 7T; For GE Healthcare at 3T, *usually* 2.304ms for 2D-B0MAP and 2.272ms for 3D-B0MAP
         # For GE HealthCare, see related notes in PreFreeSurferPipelineBatch.sh and FieldMapProcessingAll.sh
 
         # Path to GE HEalthCare Legacy style B0 fieldmap with two volumes

--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
@@ -277,7 +277,7 @@ for Subject in $Subjlist ; do
             --SEPhasePos="$SpinEchoPhaseEncodePositive" \
             --fmapmag="$MagnitudeInputName" \
             --fmapphase="$PhaseInputName" \
-            --fmap="$GEB0InputName" \
+            --fmapgelegacy="$GEB0InputName" \
             --echospacing="$EchoSpacing" \
             --echodiff="$DeltaTE" \
             --unwarpdir="$UnwarpDir" \
@@ -299,7 +299,7 @@ for Subject in $Subjlist ; do
             --SEPhasePos=$SpinEchoPhaseEncodePositive \
             --fmapmag=$MagnitudeInputName \
             --fmapphase=$PhaseInputName \
-            --fmap=$GEB0InputName \
+            --fmapgelegacy=$GEB0InputName \
             --echospacing=$EchoSpacing \
             --echodiff=$DeltaTE \
             --unwarpdir=$UnwarpDir \

--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
@@ -233,7 +233,7 @@ for Subject in $Subjlist ; do
         DeltaTE="NONE" #For Siemens, typically 2.46ms for 3T, 1.02ms for 7T; For GE Healthcare at 3T, *usually* 2.304ms for 2D-B0MAP and 2.272ms for 3D-B0MAP
         # For GE HealthCare, see related notes in PreFreeSurferPipelineBatch.sh and FieldMapProcessingAll.sh
 
-        # Path to GE HEalthCare Legacy style B0 fieldmap with two volumes
+        # Path to GE HealthCare Legacy style B0 fieldmap with two volumes
         #   1. field map in hertz
         #   2. magnitude
         # Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable

--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
@@ -277,7 +277,7 @@ for Subject in $Subjlist ; do
             --SEPhasePos="$SpinEchoPhaseEncodePositive" \
             --fmapmag="$MagnitudeInputName" \
             --fmapphase="$PhaseInputName" \
-            --fmapgeneralelectric="$GEB0InputName" \
+            --fmap="$GEB0InputName" \
             --echospacing="$EchoSpacing" \
             --echodiff="$DeltaTE" \
             --unwarpdir="$UnwarpDir" \
@@ -299,7 +299,7 @@ for Subject in $Subjlist ; do
             --SEPhasePos=$SpinEchoPhaseEncodePositive \
             --fmapmag=$MagnitudeInputName \
             --fmapphase=$PhaseInputName \
-            --fmapgeneralelectric=$GEB0InputName \
+            --fmap=$GEB0InputName \
             --echospacing=$EchoSpacing \
             --echodiff=$DeltaTE \
             --unwarpdir=$UnwarpDir \

--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
@@ -235,7 +235,7 @@ for Subject in $Subjlist ; do
 
         # Path to GE HealthCare Legacy style B0 fieldmap with two volumes
         #   1. field map in hertz
-        #   2. magnitude
+        #   2. magnitude image
         # Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable
         #
         # Example Value: 

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -19,62 +19,62 @@ DEFAULT_ENVIRONMENT_SCRIPT="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCP
 #
 get_batch_options()
 {
-	local arguments=("$@")
+    local arguments=("$@")
 
-	# Output global variables
-	unset StudyFolder
-	unset Subjlist
-	unset RunLocal
-	unset EnvironmentScript
+    # Output global variables
+    unset StudyFolder
+    unset Subjlist
+    unset RunLocal
+    unset EnvironmentScript
 
-	# Default values
+    # Default values
 
-	# Location of subject folders (named by subject ID)
-	StudyFolder="${DEFAULT_STUDY_FOLDER}"
+    # Location of subject folders (named by subject ID)
+    StudyFolder="${DEFAULT_STUDY_FOLDER}"
 
-	# Space delimited list of subject IDs
-	Subjlist="${DEFAULT_SUBJ_LIST}"
+    # Space delimited list of subject IDs
+    Subjlist="${DEFAULT_SUBJ_LIST}"
 
-	# Whether or not to run locally instead of submitting to a queue
-	RunLocal="${DEFAULT_RUN_LOCAL}"
+    # Whether or not to run locally instead of submitting to a queue
+    RunLocal="${DEFAULT_RUN_LOCAL}"
 
-	# Pipeline environment script
-	EnvironmentScript="${DEFAULT_ENVIRONMENT_SCRIPT}"
+    # Pipeline environment script
+    EnvironmentScript="${DEFAULT_ENVIRONMENT_SCRIPT}"
 
-	# Parse command line options
-	local index=0
-	local numArgs=${#arguments[@]}
-	local argument
+    # Parse command line options
+    local index=0
+    local numArgs=${#arguments[@]}
+    local argument
 
-	while [ ${index} -lt ${numArgs} ]
-	do
-		argument=${arguments[index]}
-		
-		case ${argument} in
-			--StudyFolder=*)
-				StudyFolder=${argument#*=}
-				index=$(( index + 1 ))
-				;;
-			--Subject=*)
-				Subjlist=${argument#*=}
-				index=$(( index + 1 ))
-				;;
-			--runlocal | --RunLocal)
-				RunLocal="TRUE"
-				index=$(( index + 1 ))
-				;;
-			--EnvironmentScript=*)
-				EnvironmentScript=${argument#*=}
-				index=$(( index + 1 ))
-				;;
-			*)
-				echo ""
-				echo "ERROR: Unrecognized Option: ${argument}"
-				echo ""
-				exit 1
-				;;
-		esac
-	done
+    while [ ${index} -lt ${numArgs} ]
+    do
+        argument=${arguments[index]}
+        
+        case ${argument} in
+            --StudyFolder=*)
+                StudyFolder=${argument#*=}
+                index=$(( index + 1 ))
+                ;;
+            --Subject=*)
+                Subjlist=${argument#*=}
+                index=$(( index + 1 ))
+                ;;
+            --runlocal | --RunLocal)
+                RunLocal="TRUE"
+                index=$(( index + 1 ))
+                ;;
+            --EnvironmentScript=*)
+                EnvironmentScript=${argument#*=}
+                index=$(( index + 1 ))
+                ;;
+            *)
+                echo ""
+                echo "ERROR: Unrecognized Option: ${argument}"
+                echo ""
+                exit 1
+                ;;
+        esac
+    done
 }
 
 # Get command line batch options
@@ -129,152 +129,152 @@ TaskList+=(tfMRI_RETEXP_AP)
 
 for Subject in $Subjlist
 do
-	
-	echo "${SCRIPT_NAME}: Processing Subject: ${Subject}"
-	
-	for fMRIName in "${TaskList[@]}"
-	do
-		echo "  ${SCRIPT_NAME}: Processing Scan: ${fMRIName}"
+    
+    echo "${SCRIPT_NAME}: Processing Subject: ${Subject}"
+    
+    for fMRIName in "${TaskList[@]}"
+    do
+        echo "  ${SCRIPT_NAME}: Processing Scan: ${fMRIName}"
 
-		TaskName=`echo ${fMRIName} | sed 's/_[APLR]\+$//'`
-		echo "  ${SCRIPT_NAME}: TaskName: ${TaskName}"
-		
-		len=${#fMRIName}
-		echo "  ${SCRIPT_NAME}: len: $len"
-		start=$(( len - 2 ))
-		
-		PhaseEncodingDir=${fMRIName:start:2}
-		echo "  ${SCRIPT_NAME}: PhaseEncodingDir: ${PhaseEncodingDir}"
-		
-		case ${PhaseEncodingDir} in
-			"PA")
-				UnwarpDir="y"
-				;;
-			"AP")
-				UnwarpDir="y-"
-				;;
-			"RL")
-				UnwarpDir="x"
-				;;
-			"LR")
-				UnwarpDir="x-"
-				;;
-			*)
-				echo "${SCRIPT_NAME}: Unrecognized Phase Encoding Direction: ${PhaseEncodingDir}"
-				exit 1
-				;;
-		esac
-		
-		echo "  ${SCRIPT_NAME}: UnwarpDir: ${UnwarpDir}"
-		
-		SubjectUnprocessedRootDir="${StudyFolder}/${Subject}/unprocessed/7T/${fMRIName}"
-		
-		fMRITimeSeries="${SubjectUnprocessedRootDir}/${Subject}_7T_${fMRIName}.nii.gz"
+        TaskName=`echo ${fMRIName} | sed 's/_[APLR]\+$//'`
+        echo "  ${SCRIPT_NAME}: TaskName: ${TaskName}"
+        
+        len=${#fMRIName}
+        echo "  ${SCRIPT_NAME}: len: $len"
+        start=$(( len - 2 ))
+        
+        PhaseEncodingDir=${fMRIName:start:2}
+        echo "  ${SCRIPT_NAME}: PhaseEncodingDir: ${PhaseEncodingDir}"
+        
+        case ${PhaseEncodingDir} in
+            "PA")
+                UnwarpDir="y"
+                ;;
+            "AP")
+                UnwarpDir="y-"
+                ;;
+            "RL")
+                UnwarpDir="x"
+                ;;
+            "LR")
+                UnwarpDir="x-"
+                ;;
+            *)
+                echo "${SCRIPT_NAME}: Unrecognized Phase Encoding Direction: ${PhaseEncodingDir}"
+                exit 1
+                ;;
+        esac
+        
+        echo "  ${SCRIPT_NAME}: UnwarpDir: ${UnwarpDir}"
+        
+        SubjectUnprocessedRootDir="${StudyFolder}/${Subject}/unprocessed/7T/${fMRIName}"
+        
+        fMRITimeSeries="${SubjectUnprocessedRootDir}/${Subject}_7T_${fMRIName}.nii.gz"
 
-		# A single band reference image (SBRef) is recommended if available
-		# Set to NONE if you want to use the first volume of the timeseries for motion correction
-		fMRISBRef="NONE"
-		
-		# "Effective" Echo Spacing of fMRI image (specified in *sec* for the fMRI processing)
-		# EchoSpacing = 1/(BWPPPE * ReconMatrixPE)
-		#   where BWPPPE is the "BandwidthPerPixelPhaseEncode" = DICOM field (0019,1028) for Siemens, and
-		#   ReconMatrixPE = size of the reconstructed image in the PE dimension
-		# In-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
-		# all potentially need to be accounted for (which they are in Siemen's reported BWPPPE)
-		EchoSpacing="0.00032"
+        # A single band reference image (SBRef) is recommended if available
+        # Set to NONE if you want to use the first volume of the timeseries for motion correction
+        fMRISBRef="NONE"
+        
+        # "Effective" Echo Spacing of fMRI image (specified in *sec* for the fMRI processing)
+        # EchoSpacing = 1/(BWPPPE * ReconMatrixPE)
+        #   where BWPPPE is the "BandwidthPerPixelPhaseEncode" = DICOM field (0019,1028) for Siemens, and
+        #   ReconMatrixPE = size of the reconstructed image in the PE dimension
+        # In-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
+        # all potentially need to be accounted for (which they are in Siemen's reported BWPPPE)
+        EchoSpacing="0.00032"
 
-		# Susceptibility distortion correction method (required for accurate processing)
-		# Values: TOPUP, SiemensFieldMap (same as FIELDMAP), GEHealthCareLegacyFieldMap, GEHealthCareFieldMap, PhilipsFieldMap
-		DistortionCorrection="TOPUP"
-		
-		# Receive coil bias field correction method
-		# Values: NONE, LEGACY, or SEBASED
-		#   SEBASED calculates bias field from spin echo images (which requires TOPUP distortion correction)
-		#   LEGACY uses the T1w bias field (method used for 3T HCP-YA data, but non-optimal; not recommended).
-		BiasCorrection="SEBASED"
+        # Susceptibility distortion correction method (required for accurate processing)
+        # Values: TOPUP, SiemensFieldMap (same as FIELDMAP), GEHealthCareLegacyFieldMap, GEHealthCareFieldMap, PhilipsFieldMap
+        DistortionCorrection="TOPUP"
+        
+        # Receive coil bias field correction method
+        # Values: NONE, LEGACY, or SEBASED
+        #   SEBASED calculates bias field from spin echo images (which requires TOPUP distortion correction)
+        #   LEGACY uses the T1w bias field (method used for 3T HCP-YA data, but non-optimal; not recommended).
+        BiasCorrection="SEBASED"
 
-		# For the spin echo field map volume with a 'negative' phase encoding direction
-		# (LR in HCP-YA data; AP in 7T HCP-YA and HCP-D/A data)
-		# Set to NONE if using regular FIELDMAP
-		SpinEchoPhaseEncodeNegative="${SubjectUnprocessedRootDir}/${Subject}_7T_SpinEchoFieldMap_AP.nii.gz"
-		
-		# For the spin echo field map volume with a 'positive' phase encoding direction
-		# (RL in HCP-YA data; PA in 7T HCP-YA and HCP-D/A data)
-		# Set to NONE if using regular FIELDMAP
-		SpinEchoPhaseEncodePositive="${SubjectUnprocessedRootDir}/${Subject}_7T_SpinEchoFieldMap_PA.nii.gz"
-		
-		# Topup configuration file (if using TOPUP)
-		# Set to NONE if using regular FIELDMAP
-		TopUpConfig="${HCPPIPEDIR_Config}/b02b0.cnf"
-		
-		# Not using Siemens Gradient Echo Field Maps for susceptibility distortion correction
-		# Set following to NONE if using TOPUP
-		# or set the following inputs if using regular FIELDMAP (i.e. SiemensFieldMap GEHealthCareFieldMap PhilipsFieldMap)
-		MagnitudeInputName="NONE" #Expects 4D Magnitude volume with two 3D volumes (differing echo times) - or a single 3D Volume
-		PhaseInputName="NONE" #Expects a 3D Phase difference volume (Siemen's style) -or Fieldmap in Hertz for GE Healthcare
-		DeltaTE="NONE" #For Siemens, typically 2.46ms for 3T, 1.02ms for 7T; For GE Healthcare at 3T, *usually* 2.304ms for 2D-B0MAP and 2.272ms for 3D-B0MAP
+        # For the spin echo field map volume with a 'negative' phase encoding direction
+        # (LR in HCP-YA data; AP in 7T HCP-YA and HCP-D/A data)
+        # Set to NONE if using regular FIELDMAP
+        SpinEchoPhaseEncodeNegative="${SubjectUnprocessedRootDir}/${Subject}_7T_SpinEchoFieldMap_AP.nii.gz"
+        
+        # For the spin echo field map volume with a 'positive' phase encoding direction
+        # (RL in HCP-YA data; PA in 7T HCP-YA and HCP-D/A data)
+        # Set to NONE if using regular FIELDMAP
+        SpinEchoPhaseEncodePositive="${SubjectUnprocessedRootDir}/${Subject}_7T_SpinEchoFieldMap_PA.nii.gz"
+        
+        # Topup configuration file (if using TOPUP)
+        # Set to NONE if using regular FIELDMAP
+        TopUpConfig="${HCPPIPEDIR_Config}/b02b0.cnf"
+        
+        # Not using Siemens Gradient Echo Field Maps for susceptibility distortion correction
+        # Set following to NONE if using TOPUP
+        # or set the following inputs if using regular FIELDMAP (i.e. SiemensFieldMap GEHealthCareFieldMap PhilipsFieldMap)
+        MagnitudeInputName="NONE" #Expects 4D Magnitude volume with two 3D volumes (differing echo times) - or a single 3D Volume
+        PhaseInputName="NONE" #Expects a 3D Phase difference volume (Siemen's style) -or Fieldmap in Hertz for GE Healthcare
+        DeltaTE="NONE" #For Siemens, typically 2.46ms for 3T, 1.02ms for 7T; For GE Healthcare at 3T, *usually* 2.304ms for 2D-B0MAP and 2.272ms for 3D-B0MAP
         # For GE HealthCare, see related notes in PreFreeSurferPipelineBatch.sh and FieldMapProcessingAll.sh
 
-		# Path to GE HealthCare Legacy style B0 fieldmap with two volumes
-		#   1. field map in hertz
-		#   2. magnitude image
-		# Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable
-		#
-		 # Example Value: 
-		#  GEB0InputName="${StudyFolder}/${Subject}/unprocessed/3T/${fMRIName}/${Subject}_3T_GradientEchoFieldMap.nii.gz" 
-		#  DeltaTE=2.272 # ms 
-		GEB0InputName="NONE"
-		
-		# Target final resolution of fMRI data
+        # Path to GE HealthCare Legacy style B0 fieldmap with two volumes
+        #   1. field map in hertz
+        #   2. magnitude image
+        # Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable
+        #
+         # Example Value: 
+        #  GEB0InputName="${StudyFolder}/${Subject}/unprocessed/3T/${fMRIName}/${Subject}_3T_GradientEchoFieldMap.nii.gz" 
+        #  DeltaTE=2.272 # ms 
+        GEB0InputName="NONE"
+        
+        # Target final resolution of fMRI data
         # 2mm is recommended for 3T HCP data, 1.6mm for 7T HCP data (i.e. should match acquisition resolution)
-		FinalFMRIResolution="1.60"
-		dof_epi2t1=12
-		
-		# Gradient distortion correction
-		# Set to NONE to skip gradient distortion correction
-		# (These files are considered proprietary and therefore not provided as part of the HCP Pipelines -- contact Siemens to obtain)
-		# GradientDistortionCoeffs="${HCPPIPEDIR_Config}/coeff_SC72C_Skyra.grad"
-		GradientDistortionCoeffs="NONE"
-		
-		# Use mcflirt motion correction
-		# Values: MCFLIRT (default), FLIRT
-		# (3T HCP-YA processing used 'FLIRT', but 'MCFLIRT' now recommended)
-		MCType="MCFLIRT"
-		
-		# Determine output name for the fMRI
-		output_fMRIName="${TaskName}_7T_${PhaseEncodingDir}"
-		echo "  ${SCRIPT_NAME}: output_fMRIName: ${output_fMRIName}"
-		
-		if [[ "$RunLocal" == "TRUE" || "$QUEUE" == "" ]]
-		then
-			echo "  ${SCRIPT_NAME}: About to locally run ${HCPPIPEDIR}/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh"
-			queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
-		else
-			echo "  ${SCRIPT_NAME}: About to use fsl_sub to queue ${HCPPIPEDIR}/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh"
-			queuing_command=("${FSLDIR}/bin/fsl_sub" -q "$QUEUE")
-		fi
-		
-		"${queuing_command[@]}" "$HCPPIPEDIR"/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh \
-			--path="$StudyFolder" \
-			--subject="$Subject" \
-			--fmriname="$output_fMRIName" \
-			--fmritcs="$fMRITimeSeries" \
-			--fmriscout="$fMRISBRef" \
-			--SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
-			--SEPhasePos="$SpinEchoPhaseEncodePositive" \
-			--fmapmag="$MagnitudeInputName" \
-			--fmapphase="$PhaseInputName" \
-			--fmapcombined="$GEB0InputName" \
-			--echospacing="$EchoSpacing" \
-			--echodiff="$DeltaTE" \
-			--unwarpdir="$UnwarpDir" \
-			--fmrires="$FinalFMRIResolution" \
-			--dcmethod="$DistortionCorrection" \
-			--gdcoeffs="$GradientDistortionCoeffs" \
-			--topupconfig="$TopUpConfig" \
-			--dof="$dof_epi2t1" \
-			--biascorrection=$BiasCorrection \
-			--mctype="$MCType"
-	done
-	
+        FinalFMRIResolution="1.60"
+        dof_epi2t1=12
+        
+        # Gradient distortion correction
+        # Set to NONE to skip gradient distortion correction
+        # (These files are considered proprietary and therefore not provided as part of the HCP Pipelines -- contact Siemens to obtain)
+        # GradientDistortionCoeffs="${HCPPIPEDIR_Config}/coeff_SC72C_Skyra.grad"
+        GradientDistortionCoeffs="NONE"
+        
+        # Use mcflirt motion correction
+        # Values: MCFLIRT (default), FLIRT
+        # (3T HCP-YA processing used 'FLIRT', but 'MCFLIRT' now recommended)
+        MCType="MCFLIRT"
+        
+        # Determine output name for the fMRI
+        output_fMRIName="${TaskName}_7T_${PhaseEncodingDir}"
+        echo "  ${SCRIPT_NAME}: output_fMRIName: ${output_fMRIName}"
+        
+        if [[ "$RunLocal" == "TRUE" || "$QUEUE" == "" ]]
+        then
+            echo "  ${SCRIPT_NAME}: About to locally run ${HCPPIPEDIR}/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh"
+            queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
+        else
+            echo "  ${SCRIPT_NAME}: About to use fsl_sub to queue ${HCPPIPEDIR}/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh"
+            queuing_command=("${FSLDIR}/bin/fsl_sub" -q "$QUEUE")
+        fi
+        
+        "${queuing_command[@]}" "$HCPPIPEDIR"/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh \
+            --path="$StudyFolder" \
+            --subject="$Subject" \
+            --fmriname="$output_fMRIName" \
+            --fmritcs="$fMRITimeSeries" \
+            --fmriscout="$fMRISBRef" \
+            --SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
+            --SEPhasePos="$SpinEchoPhaseEncodePositive" \
+            --fmapmag="$MagnitudeInputName" \
+            --fmapphase="$PhaseInputName" \
+            --fmapcombined="$GEB0InputName" \
+            --echospacing="$EchoSpacing" \
+            --echodiff="$DeltaTE" \
+            --unwarpdir="$UnwarpDir" \
+            --fmrires="$FinalFMRIResolution" \
+            --dcmethod="$DistortionCorrection" \
+            --gdcoeffs="$GradientDistortionCoeffs" \
+            --topupconfig="$TopUpConfig" \
+            --dof="$dof_epi2t1" \
+            --biascorrection=$BiasCorrection \
+            --mctype="$MCType"
+    done
+    
 done

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -238,7 +238,7 @@ do
 		
 		# Use mcflirt motion correction
 		# Values: MCFLIRT (default), FLIRT
-        # (3T HCP-YA processing used 'FLIRT', but 'MCFLIRT' now recommended)
+		# (3T HCP-YA processing used 'FLIRT', but 'MCFLIRT' now recommended)
 		MCType="MCFLIRT"
 		
 		# Determine output name for the fMRI

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -264,7 +264,7 @@ do
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
-			--fmapgelegacy="$GEB0InputName" \
+			--fmapcombined="$GEB0InputName" \
 			--echospacing="$EchoSpacing" \
 			--echodiff="$DeltaTE" \
 			--unwarpdir="$UnwarpDir" \

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -256,7 +256,7 @@ do
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
-			--fmapgeneralelectric="$GEB0InputName" \
+			--fmap="$GEB0InputName" \
 			--echospacing="$EchoSpacing" \
 			--echodiff="$DeltaTE" \
 			--unwarpdir="$UnwarpDir" \

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -215,13 +215,13 @@ do
 		# For GE HealthCare, see related notes in PreFreeSurferPipelineBatch.sh and FieldMapProcessingAll.sh
 
 		# Path to GE HEalthCare Legacy style B0 fieldmap with two volumes
-        #   1. field map in hertz
-        #   2. magnitude
-        # Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable
-        #
-        # Example Value: 
-        #  GEB0InputName="${StudyFolder}/${Subject}/unprocessed/3T/${fMRIName}/${Subject}_3T_GradientEchoFieldMap.nii.gz" 
-        #  DeltaTE=2.272 # ms 
+		#   1. field map in hertz
+		#   2. magnitude
+		# Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable
+		#
+		 # Example Value: 
+		#  GEB0InputName="${StudyFolder}/${Subject}/unprocessed/3T/${fMRIName}/${Subject}_3T_GradientEchoFieldMap.nii.gz" 
+		#  DeltaTE=2.272 # ms 
 		GEB0InputName="NONE"
 		
 		FinalFMRIResolution="1.60"

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -264,7 +264,7 @@ do
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
-			--fmap="$GEB0InputName" \
+			--fmapgelegacy="$GEB0InputName" \
 			--echospacing="$EchoSpacing" \
 			--echodiff="$DeltaTE" \
 			--unwarpdir="$UnwarpDir" \

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -231,9 +231,9 @@ do
 		dof_epi2t1=12
 		
 		# Gradient distortion correction
-        # Set to NONE to skip gradient distortion correction
-        # (These files are considered proprietary and therefore not provided as part of the HCP Pipelines -- contact Siemens to obtain)
-        # GradientDistortionCoeffs="${HCPPIPEDIR_Config}/coeff_SC72C_Skyra.grad"
+		# Set to NONE to skip gradient distortion correction
+		# (These files are considered proprietary and therefore not provided as part of the HCP Pipelines -- contact Siemens to obtain)
+		# GradientDistortionCoeffs="${HCPPIPEDIR_Config}/coeff_SC72C_Skyra.grad"
 		GradientDistortionCoeffs="NONE"
 		
 		# Use mcflirt motion correction

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -162,6 +162,7 @@ do
 			*)
 				echo "${SCRIPT_NAME}: Unrecognized Phase Encoding Direction: ${PhaseEncodingDir}"
 				exit 1
+				;;
 		esac
 		
 		echo "  ${SCRIPT_NAME}: UnwarpDir: ${UnwarpDir}"
@@ -211,12 +212,12 @@ do
 		# or set the following inputs if using regular FIELDMAP (i.e. SiemensFieldMap GEHealthCareFieldMap PhilipsFieldMap)
 		MagnitudeInputName="NONE" #Expects 4D Magnitude volume with two 3D volumes (differing echo times) - or a single 3D Volume
 		PhaseInputName="NONE" #Expects a 3D Phase difference volume (Siemen's style) -or Fieldmap in Hertz for GE Healthcare
-		DeltaTE="NONE" #2.46ms for 3T, 1.02ms for 7T - for GE Healthcare at 3.0T, *usually* 2.304ms for 2D-B0MAP and 2.272 ms 3D B0MAP.
-		# For GE HealthCare, see related notes in PreFreeSurferPipelineBatch.sh and FieldMapProcessingAll.sh
+		DeltaTE="NONE" #For Siemens, typically 2.46ms for 3T, 1.02ms for 7T; For GE Healthcare at 3T, *usually* 2.304ms for 2D-B0MAP and 2.272ms for 3D-B0MAP
+        # For GE HealthCare, see related notes in PreFreeSurferPipelineBatch.sh and FieldMapProcessingAll.sh
 
-		# Path to GE HEalthCare Legacy style B0 fieldmap with two volumes
+		# Path to GE HealthCare Legacy style B0 fieldmap with two volumes
 		#   1. field map in hertz
-		#   2. magnitude
+		#   2. magnitude image
 		# Set to "NONE" if not using "GEHealthCareLegacyFieldMap" as the value for the DistortionCorrection variable
 		#
 		 # Example Value: 
@@ -224,13 +225,20 @@ do
 		#  DeltaTE=2.272 # ms 
 		GEB0InputName="NONE"
 		
+		# Target final resolution of fMRI data
+        # 2mm is recommended for 3T HCP data, 1.6mm for 7T HCP data (i.e. should match acquisition resolution)
 		FinalFMRIResolution="1.60"
 		dof_epi2t1=12
 		
-		# Skipping Gradient Distortion Correction
+		# Gradient distortion correction
+        # Set to NONE to skip gradient distortion correction
+        # (These files are considered proprietary and therefore not provided as part of the HCP Pipelines -- contact Siemens to obtain)
+        # GradientDistortionCoeffs="${HCPPIPEDIR_Config}/coeff_SC72C_Skyra.grad"
 		GradientDistortionCoeffs="NONE"
 		
 		# Use mcflirt motion correction
+		# Values: MCFLIRT (default), FLIRT
+        # (3T HCP-YA processing used 'FLIRT', but 'MCFLIRT' now recommended)
 		MCType="MCFLIRT"
 		
 		# Determine output name for the fMRI

--- a/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
+++ b/Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
@@ -184,7 +184,7 @@ do
 		EchoSpacing="0.00032"
 
 		# Susceptibility distortion correction method (required for accurate processing)
-        # Values: TOPUP, SiemensFieldMap (same as FIELDMAP), GEHealthCareLegacyFieldMap, GEHealthCareFieldMap, PhilipsFieldMap
+		# Values: TOPUP, SiemensFieldMap (same as FIELDMAP), GEHealthCareLegacyFieldMap, GEHealthCareFieldMap, PhilipsFieldMap
 		DistortionCorrection="TOPUP"
 		
 		# Receive coil bias field correction method

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -187,7 +187,7 @@ main()
 	# The HCP Pipeline Scripts currently support the use of gradient echo field
 	# maps or spin echo field maps as they are produced by the Siemens Connectom
 	# Scanner. They also support the use of gradient echo field maps as generated
-	# by General Electric scanners.
+	# by GE HealthCare scanners.
 	#
 	# Change either the gradient echo field map or spin echo field map scan
 	# settings to match your data. This script is setup to use gradient echo
@@ -257,13 +257,13 @@ main()
 		#     Echo Field Map for readout distortion correction. 
 		#	  The Legacy fieldmap is a two volume file: 1. field map in Hz and 2. magnitude image.
 		# 	  Use "GEB0InputName" variable to specify the 2-Volume file. 
-		#	  Set "TE" variable to the EchoTime difference (TE2-TE1). 
+		#	  Set "DeltaTE" variable to the EchoTime difference (TE2-TE1). 
 		#	 
 		#	"GEHealthCareFieldMap" 
 		#	  Average any repeats and use GE HealthCare specific Gradient Echo
 		#     Field Maps for readout distortion correction
-		#	  This uses separate NIfTI files for the fieldmap in Hz and the magnitude image
-		#	  Use variables "MagnitudeInputName", "PhaseInputName" and "TE"
+		#	  This uses two separate NIfTI files for the fieldmap in Hz and the magnitude image
+		#	  Use variables "MagnitudeInputName", "PhaseInputName" and "DeltaTE"
 		#
 		#   "SiemensFieldMap"
 		#     Average any repeats and use Siemens specific Gradient Echo
@@ -272,7 +272,7 @@ main()
 		# Current Setup is for Siemens specific Gradient Echo Field Maps
 		#
 		#   The following settings for AvgrdcSTRING, MagnitudeInputName,
-		#   PhaseInputName, and TE are for using the Siemens specific
+		#   PhaseInputName, and DeltaTE are for using the Siemens specific
 		#   Gradient Echo Field Maps that are collected and used in the
 		#   standard HCP-YA protocol.
 		#
@@ -294,7 +294,7 @@ main()
 
 		# The DeltaTE (echo time difference) of the fieldmap.  For HCP Young Adult data, this variable would typically be 2.46ms for 3T scans, 1.02ms for 7T
 		# scans, or "NONE" if not using readout distortion correction
-		TE="2.46"
+		DeltaTE="2.46"
 
 		# ----------------------------------------------------------------------
 		# Variables related to using Spin Echo Field Maps
@@ -373,12 +373,12 @@ main()
 		#  
 		# For Example:
 		#   GEB0InputName="${StudyFolder}/${Subject}/unprocessed/3T/T1w_MPR1/${Subject}_3T_GradientEchoFieldMap.nii.gz"
-		#	TE=2.304 
-		#   Here TE refers to the DeltaTE in ms
+		#	DeltaTE=2.304 
+		#   Here DeltaTE refers to the DeltaTE in ms
 		#   NOTE: At 3T, the DeltaTE is *usually* 2.304ms for 2D-B0MAP and 2.272ms 3D-B0MAP.
 		#   NOTE: The Delta can be found in json files (if data converted with recent dcm2niix)
 		#   NOTE: Then DeltaTE = (EchoTime2-EchoTime1)*1000
-		#	NOTE: In the DICOM, DeltaTE = round(abs(1e6/( 2*pi*(0019,10E2) )))
+		#	NOTE: In the DICOM, DeltaTE in ms = round(abs(1e6/( 2*pi*(0019,10E2) )))*1e-3 
 		GEB0InputName="NONE"
 
 		# ---------------------------------------------------------------
@@ -391,12 +391,12 @@ main()
 		# AvgrdcSTRING="GEHealthCareFieldMap"). 
 
 		# Example: set MagnitudeInputName to magnitude image, set PhaseInputName 
-		# to the input fieldmap in Hertz and TE (a.k.a DeltaTE)
+		# to the input fieldmap in Hertz and DeltaTE 
 		# (for DeltaTE see NOTE above)
 		#
 		# MagnitudeInputName="${StudyFolder}/${Subject}/unprocessed/3T/T1w_MPR1/${Subject}_3T_BOMap_Magnitude.nii.gz"
 		# PhaseInputName="${StudyFolder}/${Subject}/unprocessed/3T/T1w_MPR1/${Subject}_3T_B0Map_fieldmaphz.nii.gz"
-		# TE="2.272"
+		# DeltaTE="2.272"
 
 		# ---------------------------------------------------------------
 
@@ -498,7 +498,7 @@ main()
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
 			--fmapgeneralelectric="$GEB0InputName" \
-			--echodiff="$TE" \
+			--echodiff="$DeltaTE" \
 			--SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \
 			--seechospacing="$SEEchoSpacing" \

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -255,7 +255,7 @@ main()
 		#   "GEHealthCareLegacyFieldMap"
 		#     Average any repeats and use GE HeathCare Legacy specific Gradient
 		#     Echo Field Map for readout distortion correction. 
-		#	  The Legacy fieldmap is a two volume file: 1. field map in Hz and 2. magnitude.
+		#	  The Legacy fieldmap is a two volume file: 1. field map in Hz and 2. magnitude image.
 		# 	  Use "GEB0InputName" variable to specify the 2-Volume file. 
 		#	  Set "TE" variable to the EchoTime difference (TE2-TE1). 
 		#	 

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -497,7 +497,7 @@ main()
 			--fnirtconfig="$FNIRTConfig" \
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
-			--fmap="$GEB0InputName" \
+			--fmapgelegacy="$GEB0InputName" \
 			--echodiff="$DeltaTE" \
 			--SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -497,7 +497,7 @@ main()
 			--fnirtconfig="$FNIRTConfig" \
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
-			--fmapgelegacy="$GEB0InputName" \
+			--fmapcombined="$GEB0InputName" \
 			--echodiff="$DeltaTE" \
 			--SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -262,7 +262,7 @@ main()
 		#	"GEHealthCareFieldMap" 
 		#	  Average any repeats and use GE HealthCare specific Gradient Echo
 		#     Field Maps for readout distortion correction
-		#	  This uses two separate NIfTI file for the fieldmap in Hz and the magnitude
+		#	  This uses separate NIfTI files for the fieldmap in Hz and the magnitude image
 		#	  Use variables "MagnitudeInputName", "PhaseInputName" and "TE"
 		#
 		#   "SiemensFieldMap"

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -368,7 +368,7 @@ main()
 		# GEB0InputName should be a GE HealthCare Legacy style B0 fieldmap with two
 		# volumes
 		#   1) fieldmap in hertz and
-		#   2) magnitude,
+		#   2) magnitude image,
 		# set to NONE if using TOPUP or FIELDMAP/SiemensFieldMap or GEHealthCareFieldMap
 		#  
 		# For Example:

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -292,7 +292,7 @@ main()
 		# volume or "NONE" if not used
 		PhaseInputName="${StudyFolder}/${Subject}/unprocessed/3T/T1w_MPR1/${Subject}_3T_FieldMap_Phase.nii.gz"
 
-		# The DeltaTE (echo time difference) of the fieldmap.  For HCP Young Adult data, this variable should be set to 2.46ms for 3T scans, 1.02ms for 7T
+		# The DeltaTE (echo time difference) of the fieldmap.  For HCP Young Adult data, this variable would typically be 2.46ms for 3T scans, 1.02ms for 7T
 		# scans, or "NONE" if not using readout distortion correction
 		TE="2.46"
 

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -497,7 +497,7 @@ main()
 			--fnirtconfig="$FNIRTConfig" \
 			--fmapmag="$MagnitudeInputName" \
 			--fmapphase="$PhaseInputName" \
-			--fmapgeneralelectric="$GEB0InputName" \
+			--fmap="$GEB0InputName" \
 			--echodiff="$DeltaTE" \
 			--SEPhaseNeg="$SpinEchoPhaseEncodeNegative" \
 			--SEPhasePos="$SpinEchoPhaseEncodePositive" \

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -375,7 +375,7 @@ main()
 		#   GEB0InputName="${StudyFolder}/${Subject}/unprocessed/3T/T1w_MPR1/${Subject}_3T_GradientEchoFieldMap.nii.gz"
 		#	TE=2.304 
 		#   Here TE refers to the DeltaTE in ms
-		#   NOTE: At 3.0T, the DeltaTE is *usually* 2.304ms for 2D-B0MAP and 2.272 ms 3D B0MAP.
+		#   NOTE: At 3T, the DeltaTE is *usually* 2.304ms for 2D-B0MAP and 2.272ms 3D-B0MAP.
 		#   NOTE: The Delta can be found in json files (if data converted with recent dcm2niix)
 		#   NOTE: Then DeltaTE = (EchoTime2-EchoTime1)*1000
 		#	NOTE: In the DICOM DeltaTE = round(abs(1e6/( 2*pi*(0019,10E2) )))

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -292,8 +292,8 @@ main()
 		# volume or "NONE" if not used
 		PhaseInputName="${StudyFolder}/${Subject}/unprocessed/3T/T1w_MPR1/${Subject}_3T_FieldMap_Phase.nii.gz"
 
-		# The DeltaTE (echo time difference) variable should be set to 2.46ms for 3T scanner, 1.02ms for 7T
-		# scanner or "NONE" if not using
+		# The DeltaTE (echo time difference) of the fieldmap.  For HCP Young Adult data, this variable should be set to 2.46ms for 3T scans, 1.02ms for 7T
+		# scans, or "NONE" if not using readout distortion correction
 		TE="2.46"
 
 		# ----------------------------------------------------------------------

--- a/Examples/Scripts/PreFreeSurferPipelineBatch.sh
+++ b/Examples/Scripts/PreFreeSurferPipelineBatch.sh
@@ -378,7 +378,7 @@ main()
 		#   NOTE: At 3T, the DeltaTE is *usually* 2.304ms for 2D-B0MAP and 2.272ms 3D-B0MAP.
 		#   NOTE: The Delta can be found in json files (if data converted with recent dcm2niix)
 		#   NOTE: Then DeltaTE = (EchoTime2-EchoTime1)*1000
-		#	NOTE: In the DICOM DeltaTE = round(abs(1e6/( 2*pi*(0019,10E2) )))
+		#	NOTE: In the DICOM, DeltaTE = round(abs(1e6/( 2*pi*(0019,10E2) )))
 		GEB0InputName="NONE"
 
 		# ---------------------------------------------------------------

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -215,7 +215,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file_path' "Siemens/Philips/G
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'file_path' "Siemens/Philips Gradient Echo Fieldmap phase file or GE HealthCare Fieldmap in Hertz"
 
-opts_AddOptional '--fmap' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image"
+opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image"
 
 opts_AddOptional '--echodiff' 'TE' 'delta_TE' "Delta TE in ms for field map or 'NONE' if  not used"
 
@@ -248,7 +248,7 @@ opts_AddMandatory '--avgrdcmethod' 'AvgrdcSTRING' 'avgrdcmethod' "Averaging and 
       Field Maps for readout distortion correction
 
   '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmap argument).
+      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgelegacy argument).
       This option is maintained for backward compatibility.
 
   '${GE_HEALTHCARE_METHOD_OPT}'
@@ -553,7 +553,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --t2brain=${T2wFolder_T2wImageWithPath_acpc_brain} \
         --fmapmag=${MagnitudeInputName} \
         --fmapphase=${PhaseInputName} \
-        --fmap=${GEB0InputName} \
+        --fmapgelegacy=${GEB0InputName} \
         --echodiff=${TE} \
         --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
         --SEPhasePos=${SpinEchoPhaseEncodePositive} \

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -154,7 +154,7 @@ SIEMENS_METHOD_OPT="SiemensFieldMap"
 SPIN_ECHO_METHOD_OPT="TOPUP"
 # For GE HealthCare Fieldmap Distortion Correction methods 
 # see explanations in global/scripts/FieldMapPreprocessingAll.sh
-GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap" 
+GE_HEALTHCARE_LEGACY_METHOD_OPT="GEHealthCareLegacyFieldMap" 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 
@@ -247,7 +247,7 @@ opts_AddMandatory '--avgrdcmethod' 'AvgrdcSTRING' 'avgrdcmethod' "Averaging and 
       average any repeats and use Philips specific Gradient Echo
       Field Maps for readout distortion correction
 
-  '${GENERAL_ELECTRIC_METHOD_OPT}'
+  '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
       use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
       This option is maintained for backward compatibility.
 
@@ -531,7 +531,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
 
   case $AvgrdcSTRING in
 
-    ${FIELDMAP_METHOD_OPT} | ${SPIN_ECHO_METHOD_OPT} | ${GENERAL_ELECTRIC_METHOD_OPT} | ${GE_HEALTHCARE_METHOD_OPT} | ${SIEMENS_METHOD_OPT} | ${PHILIPS_METHOD_OPT})
+    ${FIELDMAP_METHOD_OPT} | ${SPIN_ECHO_METHOD_OPT} | ${GE_HEALTHCARE_LEGACY_METHOD_OPT} | ${GE_HEALTHCARE_METHOD_OPT} | ${SIEMENS_METHOD_OPT} | ${PHILIPS_METHOD_OPT})
 
       log_Msg "Performing ${AvgrdcSTRING} Readout Distortion Correction"
       wdir=${T2wFolder}/T2wToT1wDistortionCorrectAndReg

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -215,7 +215,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file_path' "Siemens/Philips/G
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'file_path' "Siemens/Philips Gradient Echo Fieldmap phase file or GE HealthCare Fieldmap in Hertz"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image"
+opts_AddOptional '--fmap' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image"
 
 opts_AddOptional '--echodiff' 'TE' 'delta_TE' "Delta TE in ms for field map or 'NONE' if  not used"
 
@@ -248,7 +248,7 @@ opts_AddMandatory '--avgrdcmethod' 'AvgrdcSTRING' 'avgrdcmethod' "Averaging and 
       Field Maps for readout distortion correction
 
   '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
+      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmap argument).
       This option is maintained for backward compatibility.
 
   '${GE_HEALTHCARE_METHOD_OPT}'
@@ -553,7 +553,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --t2brain=${T2wFolder_T2wImageWithPath_acpc_brain} \
         --fmapmag=${MagnitudeInputName} \
         --fmapphase=${PhaseInputName} \
-        --fmapgeneralelectric=${GEB0InputName} \
+        --fmap=${GEB0InputName} \
         --echodiff=${TE} \
         --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
         --SEPhasePos=${SpinEchoPhaseEncodePositive} \

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -215,7 +215,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file_path' "Siemens/Philips/G
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'file_path' "Siemens/Philips Gradient Echo Fieldmap phase file or GE HealthCare Fieldmap in Hertz"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map file. Two volumes in one file  1. field map in hertz  2. magnitude"
+opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image"
 
 opts_AddOptional '--echodiff' 'TE' 'delta_TE' "Delta TE in ms for field map or 'NONE' if  not used"
 

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -252,7 +252,7 @@ opts_AddMandatory '--avgrdcmethod' 'AvgrdcSTRING' 'avgrdcmethod' "Averaging and 
       This option is maintained for backward compatibility.
 
   '${GE_HEALTHCARE_METHOD_OPT}'
-      use GE HealthCare specific Gradient Echo Field Maps for SDC (fieldmap in Hz and magnitude in two separate NIfTI files via --fmapphase and --fmapmag).
+      use GE HealthCare specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in two separate NIfTI files, via --fmapphase and --fmapmag).
     
   '${SIEMENS_METHOD_OPT}' 
       average any repeats and use Siemens specific Gradient Echo

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -215,7 +215,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file_path' "Siemens/Philips/G
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'file_path' "Siemens/Philips Gradient Echo Fieldmap phase file or GE HealthCare Fieldmap in Hertz"
 
-opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image"
+opts_AddOptional '--fmapcombined' 'GEB0InputName' 'file_path' "GE HealthCare Legacy Gradient Echo Field Map approach, which contains two volumes in one file: 1. field map in hertz; 2. magnitude image" '' '--fmap'
 
 opts_AddOptional '--echodiff' 'TE' 'delta_TE' "Delta TE in ms for field map or 'NONE' if  not used"
 
@@ -248,7 +248,7 @@ opts_AddMandatory '--avgrdcmethod' 'AvgrdcSTRING' 'avgrdcmethod' "Averaging and 
       Field Maps for readout distortion correction
 
   '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgelegacy argument).
+      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapcombined argument).
       This option is maintained for backward compatibility.
 
   '${GE_HEALTHCARE_METHOD_OPT}'
@@ -553,7 +553,7 @@ if [ "$CustomBrain" = "NONE" ] ; then
         --t2brain=${T2wFolder_T2wImageWithPath_acpc_brain} \
         --fmapmag=${MagnitudeInputName} \
         --fmapphase=${PhaseInputName} \
-        --fmapgelegacy=${GEB0InputName} \
+        --fmapcombined=${GEB0InputName} \
         --echodiff=${TE} \
         --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
         --SEPhasePos=${SpinEchoPhaseEncodePositive} \

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -248,7 +248,7 @@ opts_AddMandatory '--avgrdcmethod' 'AvgrdcSTRING' 'avgrdcmethod' "Averaging and 
       Field Maps for readout distortion correction
 
   '${GENERAL_ELECTRIC_METHOD_OPT}'
-      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in a single NIfTI file via --fmapgeneralelectric argument).
+      use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
       This option is maintained for backward compatibility.
 
   '${GE_HEALTHCARE_METHOD_OPT}'

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -12,7 +12,7 @@ SIEMENS_METHOD_OPT="SiemensFieldMap"
 SPIN_ECHO_METHOD_OPT="TOPUP"
 # For GE HealthCare Fieldmap Distortion Correction methods 
 # see explanations in global/scripts/FieldMapPreprocessingAll.sh
-GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap" 
+GE_HEALTHCARE_LEGACY_METHOD_OPT="GEHealthCareLegacyFieldMap" 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 FIELDMAP_METHOD_OPT="FIELDMAP"
@@ -68,7 +68,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method used for re
         '${PHILIPS_METHOD_OPT}'
            use Philips specific Gradient Echo Field Maps for readout distortion correction
         
-        '${GENERAL_ELECTRIC_METHOD_OPT}'
+        '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
            use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
            This option is maintained for backward compatibility.
 
@@ -231,7 +231,7 @@ case $DistortionCorrection in
 
         ;;
 
-    ${GENERAL_ELECTRIC_METHOD_OPT})
+    ${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 
         # ---------------------------------------------------
         # -- GE HealthCare Legacy Gradient Echo Field Maps --
@@ -392,7 +392,7 @@ for TXw in $Modalities ; do
 
     case $DistortionCorrection in
 
-        ${FIELDMAP_METHOD_OPT} | ${SIEMENS_METHOD_OPT} | ${GENERAL_ELECTRIC_METHOD_OPT} | ${GE_HEALTHCARE_METHOD_OPT} | ${PHILIPS_METHOD_OPT})
+        ${FIELDMAP_METHOD_OPT} | ${SIEMENS_METHOD_OPT} | ${GE_HEALTHCARE_LEGACY_METHOD_OPT} | ${GE_HEALTHCARE_METHOD_OPT} | ${PHILIPS_METHOD_OPT})
             ${FSLDIR}/bin/applywarp --rel --interp=spline -i ${WD}/Magnitude -r ${WD}/Magnitude -w ${WD}/FieldMap_Warp${TXw}.nii.gz -o ${WD}/Magnitude_warpped${TXw}
             ${FSLDIR}/bin/flirt -interp spline -dof 6 -in ${WD}/Magnitude_warpped${TXw} -ref ${TXwImage} -out ${WD}/Magnitude_warpped${TXw}2${TXwImageBasename} -omat ${WD}/Fieldmap2${TXwImageBasename}.mat -searchrx -30 30 -searchry -30 30 -searchrz -30 30
             ;;

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -90,7 +90,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input fieldmap magnit
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz or  2. magnitude)"
+opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
 opts_AddOptional '--echodiff' 'TE' 'value (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -69,7 +69,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method used for re
            use Philips specific Gradient Echo Field Maps for readout distortion correction
         
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgelegacy argument).
+           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapcombined argument).
            This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -90,7 +90,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input fieldmap magnit
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
-opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
+opts_AddOptional '--fmapcombined' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)" '' '--fmap'
 
 opts_AddOptional '--echodiff' 'DeltaTE' 'value (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
@@ -172,7 +172,7 @@ verbose_echo "                     T2wImage                  (t2): $T2wImage"
 verbose_echo "                T2wImageBrain             (t2brain): $T2wImageBrain"
 verbose_echo "           MagnitudeInputName             (fmapmag): $MagnitudeInputName"
 verbose_echo "               PhaseInputName           (fmapphase): $PhaseInputName"
-verbose_echo "                GEB0InputName (fmapgeneralelectric): $GEB0InputName"
+verbose_echo "                GEB0InputName        (fmapcombined): $GEB0InputName"
 verbose_echo "                      DeltaTE            (echodiff): $DeltaTE"
 verbose_echo "  SpinEchoPhaseEncodeNegative          (SEPhaseNeg): $SpinEchoPhaseEncodeNegative"
 verbose_echo "  SpinEchoPhaseEncodePositive          (SEPhasePos): $SpinEchoPhaseEncodePositive"
@@ -245,7 +245,7 @@ case $DistortionCorrection in
         ${HCPPIPEDIR_Global}/FieldMapPreprocessingAll.sh \
             --workingdir=${WD}/FieldMap \
             --method="GEHealthCareLegacyFieldMap" \
-            --fmapgelegacy=${GEB0InputName} \
+            --fmapcombined=${GEB0InputName} \
             --echodiff=${DeltaTE} \
             --ofmapmag=${WD}/Magnitude \
             --ofmapmagbrain=${WD}/Magnitude_brain \

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -73,7 +73,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method used for re
            This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
-           use GE HealthCare specific Gradient Echo Field Maps for SDC (fieldmap in Hz and magnitude in two separate NIfTI files via --fmapphase and --fmapmag).
+           use GE HealthCare specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in two separate NIfTI files, via --fmapphase and --fmapmag).
 
         '${SIEMENS_METHOD_OPT}'
            use Siemens specific Gradient Echo Field Maps for readout distortion correction

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -69,7 +69,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method used for re
            use Philips specific Gradient Echo Field Maps for readout distortion correction
         
         '${GENERAL_ELECTRIC_METHOD_OPT}'
-           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in a single NIfTI file via --fmapgeneralelectric argument).
+           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
            This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -88,7 +88,7 @@ opts_AddOptional '--workingdir' 'WD' 'path' "working directory" "."
 
 opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input fieldmap magnitude image"
 
-opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in hertz (GE HealthCare)"
+opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
 opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz or  2. magnitude)"
 

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -92,7 +92,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase im
 
 opts_AddOptional '--fmap' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
-opts_AddOptional '--echodiff' 'TE' 'value (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
+opts_AddOptional '--echodiff' 'DeltaTE' 'value (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
 opts_AddOptional '--SEPhaseNeg' 'SpinEchoPhaseEncodeNegative' 'image' "input spin echo negative phase encoding image"
 
@@ -173,7 +173,7 @@ verbose_echo "                T2wImageBrain             (t2brain): $T2wImageBrai
 verbose_echo "           MagnitudeInputName             (fmapmag): $MagnitudeInputName"
 verbose_echo "               PhaseInputName           (fmapphase): $PhaseInputName"
 verbose_echo "                GEB0InputName (fmapgeneralelectric): $GEB0InputName"
-verbose_echo "                           TE            (echodiff): $TE"
+verbose_echo "                      DeltaTE            (echodiff): $DeltaTE"
 verbose_echo "  SpinEchoPhaseEncodeNegative          (SEPhaseNeg): $SpinEchoPhaseEncodeNegative"
 verbose_echo "  SpinEchoPhaseEncodePositive          (SEPhasePos): $SpinEchoPhaseEncodePositive"
 verbose_echo "               SEEchoSpacing        (seechospacing): $SEEchoSpacing"
@@ -223,7 +223,7 @@ case $DistortionCorrection in
             --method="SiemensFieldMap" \
             --fmapmag=${MagnitudeInputName} \
             --fmapphase=${PhaseInputName} \
-            --echodiff=${TE} \
+            --echodiff=${DeltaTE} \
             --ofmapmag=${WD}/Magnitude \
             --ofmapmagbrain=${WD}/Magnitude_brain \
             --ofmap=${WD}/FieldMap \
@@ -246,7 +246,7 @@ case $DistortionCorrection in
             --workingdir=${WD}/FieldMap \
             --method="GEHealthCareLegacyFieldMap" \
             --fmap=${GEB0InputName} \
-            --echodiff=${TE} \
+            --echodiff=${DeltaTE} \
             --ofmapmag=${WD}/Magnitude \
             --ofmapmagbrain=${WD}/Magnitude_brain \
             --ofmap=${WD}/FieldMap \
@@ -270,7 +270,7 @@ case $DistortionCorrection in
             --method="GEHealthCareFieldMap" \
             --fmapmag=${MagnitudeInputName} \
             --fmapphase=${PhaseInputName} \
-            --echodiff=${TE} \
+            --echodiff=${DeltaTE} \
             --ofmapmag=${WD}/Magnitude \
             --ofmapmagbrain=${WD}/Magnitude_brain \
             --ofmap=${WD}/FieldMap \
@@ -294,7 +294,7 @@ case $DistortionCorrection in
             --method="PhilipsFieldMap" \
             --fmapmag=${MagnitudeInputName} \
             --fmapphase=${PhaseInputName} \
-            --echodiff=${TE} \
+            --echodiff=${DeltaTE} \
             --ofmapmag=${WD}/Magnitude \
             --ofmapmagbrain=${WD}/Magnitude_brain \
             --ofmap=${WD}/FieldMap \

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -69,7 +69,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method used for re
            use Philips specific Gradient Echo Field Maps for readout distortion correction
         
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmap argument).
+           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgelegacy argument).
            This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -90,7 +90,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input fieldmap magnit
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
-opts_AddOptional '--fmap' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
+opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
 opts_AddOptional '--echodiff' 'DeltaTE' 'value (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
@@ -245,7 +245,7 @@ case $DistortionCorrection in
         ${HCPPIPEDIR_Global}/FieldMapPreprocessingAll.sh \
             --workingdir=${WD}/FieldMap \
             --method="GEHealthCareLegacyFieldMap" \
-            --fmap=${GEB0InputName} \
+            --fmapgelegacy=${GEB0InputName} \
             --echodiff=${DeltaTE} \
             --ofmapmag=${WD}/Magnitude \
             --ofmapmagbrain=${WD}/Magnitude_brain \

--- a/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
+++ b/PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
@@ -69,7 +69,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method used for re
            use Philips specific Gradient Echo Field Maps for readout distortion correction
         
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
+           use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (i.e., field map in Hz and magnitude image in a single NIfTI file, via --fmap argument).
            This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -90,7 +90,7 @@ opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input fieldmap magnit
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
+opts_AddOptional '--fmap' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
 opts_AddOptional '--echodiff' 'TE' 'value (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -40,9 +40,6 @@ PHILIPS_METHOD_OPT="PhilipsFieldMap"
 SPIN_ECHO_METHOD_OPT="TOPUP"
 NONE_METHOD_OPT="NONE"
 
-# Minimum required FSL version for GE_HEALTHCARE_LEGACY_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
-GEHEALTHCARE_MINIMUM_FSL_VERSION="6.0.7.1"
-
 # --------------------------------------------------------------------------------
 #  Usage Description Function
 # --------------------------------------------------------------------------------
@@ -304,6 +301,7 @@ case "$DistortionCorrection" in
     # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
     # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
     # The intention is to catch the error as early as possible. 
+    # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
     fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
       "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. " 
 		;;
@@ -321,6 +319,7 @@ case "$DistortionCorrection" in
     # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
     # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
     # The intention is to catch the error as early as possible. 
+    # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
     fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
       "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. "
 		;;

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -34,13 +34,13 @@ FIELDMAP_METHOD_OPT="FIELDMAP"
 SIEMENS_METHOD_OPT="SiemensFieldMap"
 # For GE HealthCare Fieldmap Distortion Correction methods 
 # see explanations in global/scripts/FieldMapPreprocessingAll.sh
-GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap" 
+GE_HEALTHCARE_LEGACY_METHOD_OPT="GEHealthCareLegacyFieldMap" 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 SPIN_ECHO_METHOD_OPT="TOPUP"
 NONE_METHOD_OPT="NONE"
 
-# Minimum required FSL version for GENERAL_ELECTRIC_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
+# Minimum required FSL version for GE_HEALTHCARE_LEGACY_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
 GEHEALTHCARE_MINIMUM_FSL_VERSION="6.0.7.1"
 
 # --------------------------------------------------------------------------------
@@ -84,7 +84,7 @@ opts_AddMandatory '--dcmethod' 'DistortionCorrection' 'method' "Which method to 
              use a pair of Spin Echo EPI images ('Spin Echo Field Maps') acquired with
              opposing polarity for SDC
 
-        '${GENERAL_ELECTRIC_METHOD_OPT}'
+        '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
              use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmapgeneralelectric argument).
              This option is maintained for backward compatibility.
 
@@ -294,7 +294,7 @@ case "$DistortionCorrection" in
 		fi
 		;;
 
-	${GENERAL_ELECTRIC_METHOD_OPT})
+	${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 		if [ -z ${GEB0InputName} ]; then
 			log_Err_Abort "--fmapgeneralelectric must be specified with --dcmethod=${DistortionCorrection}"
 		fi

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--dcmethod' 'DistortionCorrection' 'method' "Which method to 
              opposing polarity for SDC
 
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmapgeneralelectric argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmap argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -114,7 +114,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "fieldmap phase images in
 
 opts_AddOptional '--echodiff' 'deltaTE' 'milliseconds' "Difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
+opts_AddOptional '--fmap' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
 # OTHER OPTIONS:
 
@@ -296,7 +296,7 @@ case "$DistortionCorrection" in
 
 	${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 		if [ -z ${GEB0InputName} ]; then
-			log_Err_Abort "--fmapgeneralelectric must be specified with --dcmethod=${DistortionCorrection}"
+			log_Err_Abort "--fmap must be specified with --dcmethod=${DistortionCorrection}"
 		fi
     if [ -z ${deltaTE} ]; then
       log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
@@ -751,7 +751,7 @@ if [ $fMRIReference = "NONE" ] ; then
          --t1brain=${T1wFolder}/${T1wRestoreImageBrain} \
          --fmapmag=${MagnitudeInputName} \
          --fmapphase=${PhaseInputName} \
-         --fmapgeneralelectric=${GEB0InputName} \
+         --fmap=${GEB0InputName} \
          --echodiff=${deltaTE} \
          --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
          --SEPhasePos=${SpinEchoPhaseEncodePositive} \

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -108,7 +108,7 @@ opts_AddOptional '--SEPhasePos' 'SpinEchoPhaseEncodePositive' 'file' "positive p
 
 opts_AddOptional '--topupconfig' 'TopupConfig' 'file' "Which topup config file to use"
 
-opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file' "input field map magnitude image"
+opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file' "field map magnitude image"
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "input fieldmap phase images in radians (Siemens/Philips) or in hertz (GE HealthCare)"
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--dcmethod' 'DistortionCorrection' 'method' "Which method to 
              opposing polarity for SDC
 
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmap argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmapgelegacy argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -114,7 +114,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "fieldmap phase images in
 
 opts_AddOptional '--echodiff' 'deltaTE' 'milliseconds' "Difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmap' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
+opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
 # OTHER OPTIONS:
 
@@ -296,7 +296,7 @@ case "$DistortionCorrection" in
 
 	${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 		if [ -z ${GEB0InputName} ]; then
-			log_Err_Abort "--fmap must be specified with --dcmethod=${DistortionCorrection}"
+			log_Err_Abort "--fmapgelegacy must be specified with --dcmethod=${DistortionCorrection}"
 		fi
     if [ -z ${deltaTE} ]; then
       log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
@@ -751,7 +751,7 @@ if [ $fMRIReference = "NONE" ] ; then
          --t1brain=${T1wFolder}/${T1wRestoreImageBrain} \
          --fmapmag=${MagnitudeInputName} \
          --fmapphase=${PhaseInputName} \
-         --fmap=${GEB0InputName} \
+         --fmapgelegacy=${GEB0InputName} \
          --echodiff=${deltaTE} \
          --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
          --SEPhasePos=${SpinEchoPhaseEncodePositive} \

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -302,6 +302,8 @@ case "$DistortionCorrection" in
       log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
     fi
     # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
+    # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
+    # The intention is to catch the error as early as possible. 
     fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
       "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. " 
 		;;
@@ -317,6 +319,8 @@ case "$DistortionCorrection" in
 			log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
 		fi
     # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
+    # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
+    # The intention is to catch the error as early as possible. 
     fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
       "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. "
 		;;

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -114,7 +114,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "fieldmap phase images in
 
 opts_AddOptional '--echodiff' 'deltaTE' 'milliseconds' "Difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'file' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz or  2. magnitude)"
+opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
 
 # OTHER OPTIONS:
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--dcmethod' 'DistortionCorrection' 'method' "Which method to 
              opposing polarity for SDC
 
         '${GENERAL_ELECTRIC_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in a single NIfTI file via --fmapgeneralelectric argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmapgeneralelectric argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -303,7 +303,7 @@ case "$DistortionCorrection" in
     fi
     # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
     fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
-      "For ${DistortionCorrection} method the minimun required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. " 
+      "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. " 
 		;;
   
   ${GE_HEALTHCARE_METHOD_OPT})

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -89,7 +89,7 @@ opts_AddMandatory '--dcmethod' 'DistortionCorrection' 'method' "Which method to 
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
-             use GE HealthCare specific Gradient Echo Field Maps for SDC (fieldmap in Hz and magnitude in two separate NIfTI files via --fmapphase and --fmapmag).
+             use GE HealthCare specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in two separate NIfTI files, via --fmapphase and --fmapmag).
 
         '${PHILIPS_METHOD_OPT}'
              use Philips specific Gradient Echo Field Maps for SDC

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -110,7 +110,7 @@ opts_AddOptional '--topupconfig' 'TopupConfig' 'file' "Which topup config file t
 
 opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'file' "field map magnitude image"
 
-opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "input fieldmap phase images in radians (Siemens/Philips) or in hertz (GE HealthCare)"
+opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
 opts_AddOptional '--echodiff' 'deltaTE' 'milliseconds' "Difference of echo times for fieldmap, in milliseconds"
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--dcmethod' 'DistortionCorrection' 'method' "Which method to 
              opposing polarity for SDC
 
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmapgelegacy argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude iimage n a single NIfTI file via, --fmapcombined argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -114,7 +114,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'file' "fieldmap phase images in
 
 opts_AddOptional '--echodiff' 'deltaTE' 'milliseconds' "Difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)"
+opts_AddOptional '--fmapcombined' 'GEB0InputName' 'file' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz and 2. magnitude image)" '' '--fmap'
 
 # OTHER OPTIONS:
 
@@ -296,7 +296,7 @@ case "$DistortionCorrection" in
 
 	${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 		if [ -z ${GEB0InputName} ]; then
-			log_Err_Abort "--fmapgelegacy must be specified with --dcmethod=${DistortionCorrection}"
+			log_Err_Abort "--fmapcombined must be specified with --dcmethod=${DistortionCorrection}"
 		fi
     if [ -z ${deltaTE} ]; then
       log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
@@ -755,7 +755,7 @@ if [ $fMRIReference = "NONE" ] ; then
          --t1brain=${T1wFolder}/${T1wRestoreImageBrain} \
          --fmapmag=${MagnitudeInputName} \
          --fmapphase=${PhaseInputName} \
-         --fmapgelegacy=${GEB0InputName} \
+         --fmapcombined=${GEB0InputName} \
          --echodiff=${deltaTE} \
          --SEPhaseNeg=${SpinEchoPhaseEncodeNegative} \
          --SEPhasePos=${SpinEchoPhaseEncodePositive} \

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -267,92 +267,92 @@ fsl_minimum_required_version_check "6.0.1" "FSL version 6.0.0 is unsupported. Pl
 ## Case checking for which distortion correction was used ## 
 
 case "$DistortionCorrection" in
-	${SPIN_ECHO_METHOD_OPT})
-		if [ -z ${SpinEchoPhaseEncodeNegative} ]; then
-			log_Err_Abort "--SEPhaseNeg must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		if [ -z ${SpinEchoPhaseEncodePositive} ]; then
-			log_Err_Abort "--SEPhasePos must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		if [ -z ${TopupConfig} ]; then
-			log_Err_Abort "--topupconfig must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		;;
+    ${SPIN_ECHO_METHOD_OPT})
+        if [ -z ${SpinEchoPhaseEncodeNegative} ]; then
+            log_Err_Abort "--SEPhaseNeg must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${SpinEchoPhaseEncodePositive} ]; then
+            log_Err_Abort "--SEPhasePos must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${TopupConfig} ]; then
+            log_Err_Abort "--topupconfig must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        ;;
 
-	${FIELDMAP_METHOD_OPT}|${SIEMENS_METHOD_OPT})
-		if [ -z ${MagnitudeInputName} ]; then
-			log_Err_Abort "--fmapmag must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		if [ -z ${PhaseInputName} ]; then
-			log_Err_Abort "--fmapphase must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		if [ -z ${deltaTE} ]; then
-			log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		;;
+    ${FIELDMAP_METHOD_OPT}|${SIEMENS_METHOD_OPT})
+        if [ -z ${MagnitudeInputName} ]; then
+            log_Err_Abort "--fmapmag must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${PhaseInputName} ]; then
+            log_Err_Abort "--fmapphase must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${deltaTE} ]; then
+            log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        ;;
 
-	${GE_HEALTHCARE_LEGACY_METHOD_OPT})
-		if [ -z ${GEB0InputName} ]; then
-			log_Err_Abort "--fmapcombined must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-    if [ -z ${deltaTE} ]; then
-      log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
-    fi
-    # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
-    # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
-    # The intention is to catch the error as early as possible. 
-    # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
-    fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
-      "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. " 
-		;;
+    ${GE_HEALTHCARE_LEGACY_METHOD_OPT})
+        if [ -z ${GEB0InputName} ]; then
+            log_Err_Abort "--fmapcombined must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${deltaTE} ]; then
+            log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
+        # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
+        # The intention is to catch the error as early as possible. 
+        # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
+        fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
+            "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. " 
+        ;;
   
   ${GE_HEALTHCARE_METHOD_OPT})
-		if [ -z ${MagnitudeInputName} ]; then
-			log_Err_Abort "--fmapmag must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		if [ -z ${PhaseInputName} ]; then
-			log_Err_Abort "--fmapphase must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-		if [ -z ${deltaTE} ]; then
-			log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
-		fi
-    # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
-    # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
-    # The intention is to catch the error as early as possible. 
-    # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
-    fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
-      "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. "
-		;;
+        if [ -z ${MagnitudeInputName} ]; then
+            log_Err_Abort "--fmapmag must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${PhaseInputName} ]; then
+            log_Err_Abort "--fmapphase must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${deltaTE} ]; then
+            log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
+        # This FSL version check is duplicated in global/scripts/FieldMapPreprocessingAll.sh
+        # The intention is to catch the error as early as possible. 
+        # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
+        fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
+            "For ${DistortionCorrection} method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}. "
+        ;;
 
-  ${PHILIPS_METHOD_OPT})
-    if [ -z ${MagnitudeInputName} ]; then
-      log_Err_Abort "--fmapmag must be specified with --dcmethod=${DistortionCorrection}"
-    fi
-    if [ -z ${PhaseInputName} ]; then
-      log_Err_Abort "--fmapphase must be specified with --dcmethod=${DistortionCorrection}"
-    fi
-    if [ -z ${deltaTE} ]; then
-      log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
-    fi
-    ;;
+    ${PHILIPS_METHOD_OPT})
+        if [ -z ${MagnitudeInputName} ]; then
+            log_Err_Abort "--fmapmag must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${PhaseInputName} ]; then
+            log_Err_Abort "--fmapphase must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        if [ -z ${deltaTE} ]; then
+            log_Err_Abort "--echodiff must be specified with --dcmethod=${DistortionCorrection}"
+        fi
+        ;;
 
-	${NONE_METHOD_OPT})
-		# Do nothing
-		;;
+    ${NONE_METHOD_OPT})
+        # Do nothing
+        ;;
 
-	*)
-		log_Err_Abort "unrecognized value for --dcmethod (${DistortionCorrection})"
-		;;
+    *)
+        log_Err_Abort "unrecognized value for --dcmethod (${DistortionCorrection})"
+        ;;
 
 esac
 # Additionally, EchoSpacing and UnwarpDir needed for all except NONE
 if [[ $DistortionCorrection != "${NONE_METHOD_OPT}" ]]; then
-	if [ -z ${EchoSpacing} ]; then
-		log_Err_Abort "--echospacing must be specified with --dcmethod=${DistortionCorrection}"
-	fi
-	if [ -z ${UnwarpDir} ]; then
-		log_Err_Abort "--unwarpdir must be specified with --dcmethod=${DistortionCorrection}"
-	fi
+    if [ -z ${EchoSpacing} ]; then
+        log_Err_Abort "--echospacing must be specified with --dcmethod=${DistortionCorrection}"
+    fi
+    if [ -z ${UnwarpDir} ]; then
+        log_Err_Abort "--unwarpdir must be specified with --dcmethod=${DistortionCorrection}"
+    fi
 fi
 
 
@@ -452,23 +452,23 @@ fMRIFolder="$Path"/"$Subject"/"$NameOffMRI"
 case "$BiasCorrection" in
     NONE)
         UseBiasFieldMNI=""
-		;;
+        ;;
     LEGACY)
         UseBiasFieldMNI="${fMRIFolder}/${BiasFieldMNI}.${FinalfMRIResolution}"
-		;;    
+        ;;    
     SEBASED)
         if [[ "$DistortionCorrection" != "${SPIN_ECHO_METHOD_OPT}" ]]
         then
             log_Err_Abort "--biascorrection=SEBASED is only available with --dcmethod=${SPIN_ECHO_METHOD_OPT}"
         fi
         UseBiasFieldMNI="$sebasedBiasFieldMNI"
-		;;
+        ;;
     "")
         log_Err_Abort "--biascorrection option not specified"
-		;;
+        ;;
     *)
         log_Err_Abort "unrecognized value for bias correction: $BiasCorrection"
-		;;
+        ;;
 esac
 
 # ------------------------------------------------------------------------------
@@ -687,26 +687,26 @@ if [ ! $GradientDistortionCoeffs = "NONE" ] ; then
     log_Msg "mkdir -p ${fMRIFolder}/GradientDistortionUnwarp"
     mkdir -p "$fMRIFolder"/GradientDistortionUnwarp
     ${RUN} "$GlobalScripts"/GradientDistortionUnwarp.sh \
-		   --workingdir="$fMRIFolder"/GradientDistortionUnwarp \
-		   --coeffs="$GradientDistortionCoeffs" \
-		   --in="$fMRIFolder"/"$OrigTCSName" \
-		   --out="$fMRIFolder"/"$NameOffMRI"_gdc \
-		   --owarp="$fMRIFolder"/"$NameOffMRI"_gdc_warp
-	
-    log_Msg "mkdir -p ${fMRIFolder}/${ScoutName}_GradientDistortionUnwarp"	
+           --workingdir="$fMRIFolder"/GradientDistortionUnwarp \
+           --coeffs="$GradientDistortionCoeffs" \
+           --in="$fMRIFolder"/"$OrigTCSName" \
+           --out="$fMRIFolder"/"$NameOffMRI"_gdc \
+           --owarp="$fMRIFolder"/"$NameOffMRI"_gdc_warp
+    
+    log_Msg "mkdir -p ${fMRIFolder}/${ScoutName}_GradientDistortionUnwarp"    
     mkdir -p "$fMRIFolder"/"$ScoutName"_GradientDistortionUnwarp
     ${RUN} "$GlobalScripts"/GradientDistortionUnwarp.sh \
-		   --workingdir="$fMRIFolder"/"$ScoutName"_GradientDistortionUnwarp \
-		   --coeffs="$GradientDistortionCoeffs" \
-		   --in="$fMRIFolder"/"$OrigScoutName" \
-		   --out="$fMRIFolder"/"$ScoutName"_gdc \
-		   --owarp="$fMRIFolder"/"$ScoutName"_gdc_warp
-	
-	if [[ $UseJacobian == "true" ]]
-	then
-	    ${RUN} ${FSLDIR}/bin/fslmaths "$fMRIFolder"/"$NameOffMRI"_gdc -mul "$fMRIFolder"/"$NameOffMRI"_gdc_warp_jacobian "$fMRIFolder"/"$NameOffMRI"_gdc
-	    ${RUN} ${FSLDIR}/bin/fslmaths "$fMRIFolder"/"$ScoutName"_gdc -mul "$fMRIFolder"/"$ScoutName"_gdc_warp_jacobian "$fMRIFolder"/"$ScoutName"_gdc
-	fi
+           --workingdir="$fMRIFolder"/"$ScoutName"_GradientDistortionUnwarp \
+           --coeffs="$GradientDistortionCoeffs" \
+           --in="$fMRIFolder"/"$OrigScoutName" \
+           --out="$fMRIFolder"/"$ScoutName"_gdc \
+           --owarp="$fMRIFolder"/"$ScoutName"_gdc_warp
+    
+    if [[ $UseJacobian == "true" ]]
+    then
+        ${RUN} ${FSLDIR}/bin/fslmaths "$fMRIFolder"/"$NameOffMRI"_gdc -mul "$fMRIFolder"/"$NameOffMRI"_gdc_warp_jacobian "$fMRIFolder"/"$NameOffMRI"_gdc
+        ${RUN} ${FSLDIR}/bin/fslmaths "$fMRIFolder"/"$ScoutName"_gdc -mul "$fMRIFolder"/"$ScoutName"_gdc_warp_jacobian "$fMRIFolder"/"$ScoutName"_gdc
+    fi
 else
     log_Msg "NOT PERFORMING GRADIENT DISTORTION CORRECTION"
     ${RUN} ${FSLDIR}/bin/imcp "$fMRIFolder"/"$OrigTCSName" "$fMRIFolder"/"$NameOffMRI"_gdc

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -113,7 +113,7 @@ opts_AddOptional '--topupconfig' 'TopupConfig' 'file' "topup config file"
 
 opts_AddOptional '--subjectfolder' 'SubjectFolder' 'path' "subject processing folder"
 
-opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'field_map' "input field map magnitude image"
+opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'field_map' "field map magnitude image"
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in hertz (GE HealthCare)"
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -12,7 +12,7 @@ FIELDMAP_METHOD_OPT="FIELDMAP"
 SIEMENS_METHOD_OPT="SiemensFieldMap"
 # For GE HealthCare Fieldmap Distortion Correction methods 
 # see explanations in global/scripts/FieldMapPreprocessingAll.sh
-GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap" 
+GE_HEALTHCARE_LEGACY_METHOD_OPT="GEHealthCareLegacyFieldMap" 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 SPIN_ECHO_METHOD_OPT="TOPUP"
@@ -84,7 +84,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
              use a pair of Spin Echo EPI images ('Spin Echo Field Maps') acquired with
              opposing polarity for SDC
 
-        '${GENERAL_ELECTRIC_METHOD_OPT}'
+        '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
              use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
              This option is maintained for backward compatibility.
 
@@ -265,7 +265,7 @@ fi
 
 case $DistortionCorrection in
 
-    ${FIELDMAP_METHOD_OPT} | ${SIEMENS_METHOD_OPT} | ${GENERAL_ELECTRIC_METHOD_OPT} | ${GE_HEALTHCARE_METHOD_OPT} | ${PHILIPS_METHOD_OPT})
+    ${FIELDMAP_METHOD_OPT} | ${SIEMENS_METHOD_OPT} | ${GE_HEALTHCARE_LEGACY_METHOD_OPT} | ${GE_HEALTHCARE_METHOD_OPT} | ${PHILIPS_METHOD_OPT})
 
         if [ $DistortionCorrection = "${FIELDMAP_METHOD_OPT}" ] || [ $DistortionCorrection = "${SIEMENS_METHOD_OPT}" ] ; then
             # --------------------------------------
@@ -284,7 +284,7 @@ case $DistortionCorrection in
                 --ofmap=${WD}/FieldMap \
                 --gdcoeffs=${GradientDistortionCoeffs}
 
-        elif [ $DistortionCorrection = "${GENERAL_ELECTRIC_METHOD_OPT}" ] ; then
+        elif [ $DistortionCorrection = "${GE_HEALTHCARE_LEGACY_METHOD_OPT}" ] ; then
             # ---------------------------------------------------
             # -- GE HealthCare Legacy Gradient Echo Field Maps --
             # ---------------------------------------------------

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -115,7 +115,7 @@ opts_AddOptional '--subjectfolder' 'SubjectFolder' 'path' "subject processing fo
 
 opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'field_map' "field map magnitude image"
 
-opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase images in radians (Siemens/Philips) or in hertz (GE HealthCare)"
+opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "fieldmap phase images in radians (Siemens/Philips) or in Hz (GE HealthCare)"
 
 opts_AddOptional '--echodiff' 'deltaTE' 'number (milliseconds)' "difference of echo times for fieldmap, in milliseconds"
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
              opposing polarity for SDC
 
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmap argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -119,7 +119,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "fieldmap phase images i
 
 opts_AddOptional '--echodiff' 'deltaTE' 'number (milliseconds)' "difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)"
+opts_AddOptional '--fmap' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)"
 
 opts_AddOptional '--dof' 'dof' '6 OR 9 OR 12' "degrees of freedom for EPI to T1 registration" '6'
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
              opposing polarity for SDC
 
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmap argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapgelegacy argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -119,7 +119,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "fieldmap phase images i
 
 opts_AddOptional '--echodiff' 'deltaTE' 'number (milliseconds)' "difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmap' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)"
+opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)"
 
 opts_AddOptional '--dof' 'dof' '6 OR 9 OR 12' "degrees of freedom for EPI to T1 registration" '6'
 
@@ -293,7 +293,7 @@ case $DistortionCorrection in
             ${GlobalScripts}/FieldMapPreprocessingAll.sh \
                 --workingdir=${WD}/FieldMap \
                 --method="GEHealthCareLegacyFieldMap" \
-                --fmap=${GEB0InputName} \
+                --fmapgelegacy=${GEB0InputName} \
                 --echodiff=${deltaTE} \
                 --ofmapmag=${WD}/Magnitude \
                 --ofmapmagbrain=${WD}/Magnitude_brain \

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -119,7 +119,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "input fieldmap phase im
 
 opts_AddOptional '--echodiff' 'deltaTE' 'number (milliseconds)' "difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "input GE HealthCare Legacy field map only (two volumes: 1. field map in Hz or  2. magnitude)"
+opts_AddOptional '--fmapgeneralelectric' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)"
 
 opts_AddOptional '--dof' 'dof' '6 OR 9 OR 12' "degrees of freedom for EPI to T1 registration" '6'
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
              opposing polarity for SDC
 
         '${GENERAL_ELECTRIC_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in a single NIfTI file via --fmapgeneralelectric argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapgeneralelectric argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -85,7 +85,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
              opposing polarity for SDC
 
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapgelegacy argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapcombined argument).
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
@@ -119,7 +119,7 @@ opts_AddOptional '--fmapphase' 'PhaseInputName' 'image' "fieldmap phase images i
 
 opts_AddOptional '--echodiff' 'deltaTE' 'number (milliseconds)' "difference of echo times for fieldmap, in milliseconds"
 
-opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)"
+opts_AddOptional '--fmapcombined' 'GEB0InputName' 'image' "GE HealthCare Legacy field map only (two volumes: 1. field map in Hz  and 2. magnitude image)" '' '--fmap'
 
 opts_AddOptional '--dof' 'dof' '6 OR 9 OR 12' "degrees of freedom for EPI to T1 registration" '6'
 
@@ -293,7 +293,7 @@ case $DistortionCorrection in
             ${GlobalScripts}/FieldMapPreprocessingAll.sh \
                 --workingdir=${WD}/FieldMap \
                 --method="GEHealthCareLegacyFieldMap" \
-                --fmapgelegacy=${GEB0InputName} \
+                --fmapcombined=${GEB0InputName} \
                 --echodiff=${deltaTE} \
                 --ofmapmag=${WD}/Magnitude \
                 --ofmapmagbrain=${WD}/Magnitude_brain \

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -89,7 +89,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
              This option is maintained for backward compatibility.
 
         '${GE_HEALTHCARE_METHOD_OPT}'
-             use GE HealthCare specific Gradient Echo Field Maps for SDC (fieldmap in Hz and magnitude in two separate NIfTI files via --fmapphase and --fmapmag).
+             use GE HealthCare specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in two separate NIfTI files, via --fmapphase and --fmapmag).
 
         '${PHILIPS_METHOD_OPT}'
              use Philips specific Gradient Echo Field Maps for SDC

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -171,10 +171,10 @@ case $DistortionCorrection in
         # -- Siemens Gradient Echo Field Maps --
         # --------------------------------------
 
-	${FSLDIR}/bin/fslmaths ${MagnitudeInputName} -Tmean ${WD}/Magnitude
-	${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
-	${FSLDIR}/bin/imcp ${PhaseInputName} ${WD}/Phase
-	${FSLDIR}/bin/fsl_prepare_fieldmap SIEMENS ${WD}/Phase ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
+        ${FSLDIR}/bin/fslmaths ${MagnitudeInputName} -Tmean ${WD}/Magnitude
+        ${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
+        ${FSLDIR}/bin/imcp ${PhaseInputName} ${WD}/Phase
+        ${FSLDIR}/bin/fsl_prepare_fieldmap SIEMENS ${WD}/Phase ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
 
         ;;
 
@@ -185,10 +185,10 @@ case $DistortionCorrection in
         # --------------------------------------------------- 
 
         ${FSLDIR}/bin/fslsplit ${GEB0InputName}     # split image into vol0000=fieldmap and vol0001=magnitude
-	${FSLDIR}/bin/immv vol0000 ${WD}/FieldMapHertz
-	${FSLDIR}/bin/immv vol0001 ${WD}/Magnitude
-	${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
-	${FSLDIR}/bin/fsl_prepare_fieldmap GEHC_FIELDMAPHZ ${WD}/FieldMapHertz ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
+        ${FSLDIR}/bin/immv vol0000 ${WD}/FieldMapHertz
+        ${FSLDIR}/bin/immv vol0001 ${WD}/Magnitude
+        ${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
+        ${FSLDIR}/bin/fsl_prepare_fieldmap GEHC_FIELDMAPHZ ${WD}/FieldMapHertz ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
 
         ;;
     ${GE_HEALTHCARE_METHOD_OPT})

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -46,7 +46,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
         '${SIEMENS_METHOD_OPT}'
              use Siemens specific Gradient Echo Field Maps for SDC
         '${GENERAL_ELECTRIC_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in a single NIfTI file via --GEB0InputName argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --GEB0InputName argument).
         '${GE_HEALTHCARE_METHOD_OPT}'
              use GE HealthCare specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in two separate NIfTI files).
         '${PHILIPS_METHOD_OPT}'

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -17,7 +17,7 @@ GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap"
 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 # "GEHealthCareFieldMap" refers to fieldmap in the form of 2 separate NIfTI files.
-# One file withe the Fieldmap in Hertz and the magnitude image). 
+# One file with the Fieldmap in Hz and another file with the magnitude image). 
 # Note: dcm2niix (v1.0.20210410 and later) convert the GEHC B0Maps as 2 NIFTI files
 # using the suffix _fieldmaphz for the fieldmap in Hertz and no suffix for the magnitude. 
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -64,7 +64,7 @@ opts_AddMandatory '--echodiff' 'DeltaTE' 'number (milliseconds)' "echo time diff
 # Optional Arguments
 opts_AddOptional '--fmap' 'GEB0InputName' 'image (hertz and magnitude)' "GE HealthCare Legacy fieldmap with field map in Hz and magnitude image included as two volumes in a single file"
 
-opts_AddOptional '--fmapphase' 'PhaseInputName' 'image (radians or hertz)' "input phase image in radians for Siemens/Philips fieldmap and in Hertz for GE HealthCare fieldmap"
+opts_AddOptional '--fmapphase' 'PhaseInputName' 'image (radians or Hz)' "phase image in radians for Siemens/Philips fieldmap and in Hertz for GE HealthCare fieldmap"
 
 opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input Siemens/Philips/GE HealthCare fieldmap magnitude image - can be a 4D containing more than one"
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -23,9 +23,6 @@ GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 
-# Minimum required FSL version for GE_HEALTHCARE_LEGACY_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
-GEHEALTHCARE_MINIMUM_FSL_VERSION="6.0.7.1"
-
 set -eu
 
 pipedirguessed=0
@@ -109,6 +106,7 @@ case $DistortionCorrection in
         fi
         
         # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
+        # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
         fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
             "For $DistortionCorrection method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}."
 
@@ -126,6 +124,7 @@ case $DistortionCorrection in
         fi
         
         # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
+        # GEHEALTHCARE_MINIMUM_FSL_VERSION defined in global/scripts/fsl_version.shlib
         fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
             "For $DistortionCorrection method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}."
         

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -197,10 +197,10 @@ case $DistortionCorrection in
         # -- GE HealthCare Gradient Echo Field Maps --
         # -------------------------------------------- 
         	
-            ${FSLDIR}/bin/fslmaths ${MagnitudeInputName} -Tmean ${WD}/Magnitude #normally only one volume 
-		    ${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
-		    ${FSLDIR}/bin/imcp ${PhaseInputName} ${WD}/FieldMapHertz
-		    ${FSLDIR}/bin/fsl_prepare_fieldmap GEHC_FIELDMAPHZ ${WD}/FieldMapHertz ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
+        ${FSLDIR}/bin/fslmaths ${MagnitudeInputName} -Tmean ${WD}/Magnitude #normally only one volume 
+        ${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
+        ${FSLDIR}/bin/imcp ${PhaseInputName} ${WD}/FieldMapHertz
+        ${FSLDIR}/bin/fsl_prepare_fieldmap GEHC_FIELDMAPHZ ${WD}/FieldMapHertz ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
 
         ;;
     ${PHILIPS_METHOD_OPT})

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -127,7 +127,7 @@ case $DistortionCorrection in
         
         # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)
         fsl_minimum_required_version_check "$GEHEALTHCARE_MINIMUM_FSL_VERSION" \
-            "For $DistortionCorrection method the minimun required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}."
+            "For $DistortionCorrection method the minimum required FSL version is ${GEHEALTHCARE_MINIMUM_FSL_VERSION}."
         
         ;;
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -18,7 +18,7 @@ GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap"
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 # "GEHealthCareFieldMap" refers to fieldmap in the form of 2 separate NIfTI files.
 # One file with the Fieldmap in Hz and another file with the magnitude image). 
-# Note: dcm2niix (v1.0.20210410 and later) convert the GEHC B0Maps as 2 NIFTI files
+# Note: dcm2niix (v1.0.20210410 and later) convert the GEHC B0Maps as 2 separate NIFTI files
 # using the suffix _fieldmaphz for the fieldmap in Hertz and no suffix for the magnitude. 
 
 PHILIPS_METHOD_OPT="PhilipsFieldMap"

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -62,7 +62,7 @@ opts_AddMandatory '--ofmap' 'FieldMapOutput' 'image' "output distortion correcte
 opts_AddMandatory '--echodiff' 'DeltaTE' 'number (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
 # Optional Arguments
-opts_AddOptional '--fmap' 'GEB0InputName' 'image (hertz and magnitude)' "GE HealthCare Legacy fieldmap with field map in Hz and magnitude image included as two volumes in a single file"
+opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'image (hertz and magnitude)' "GE HealthCare Legacy fieldmap with field map in Hz and magnitude image included as two volumes in a single file"
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image (radians or Hz)' "phase image in radians for Siemens/Philips fieldmap and in Hertz for GE HealthCare fieldmap"
 
@@ -105,7 +105,7 @@ case $DistortionCorrection in
 
         if [[ $GEB0InputName == "" ]]
         then 
-            log_Err_Abort "$DistortionCorrection method requires --fmap"
+            log_Err_Abort "$DistortionCorrection method requires --fmapgelegacy"
         fi
         
         # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -40,7 +40,7 @@ source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"         # Debugging funct
 source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/fsl_version.shlib"          # FSL-version checks functions
 
-opts_SetScriptDescription "Script for generating a fieldmap suitable for FSL from Gradient Echo field map, and also do gradient non-linearity distortion correction of these"
+opts_SetScriptDescription "Script for generating a fieldmap suitable for FSL from a dual-echo Gradient Echo field map acquisition, and also do gradient non-linearity distortion correction of these"
 
 opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for susceptibility distortion correction (SDC)
         '${SIEMENS_METHOD_OPT}'

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -62,7 +62,7 @@ opts_AddMandatory '--ofmap' 'FieldMapOutput' 'image' "output distortion correcte
 opts_AddMandatory '--echodiff' 'DeltaTE' 'number (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
 # Optional Arguments
-opts_AddOptional '--fmap' 'GEB0InputName' 'image (hertz and magnitude)' "input GE HealthCare Legacy fieldmap with fieldmap in hertz and magnitude image"
+opts_AddOptional '--fmap' 'GEB0InputName' 'image (hertz and magnitude)' "GE HealthCare Legacy fieldmap with field map in Hz and magnitude image included as two volumes in a single file"
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image (radians or hertz)' "input phase image in radians for Siemens/Philips fieldmap and in Hertz for GE HealthCare fieldmap"
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -48,7 +48,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
         '${GENERAL_ELECTRIC_METHOD_OPT}'
              use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --GEB0InputName argument).
         '${GE_HEALTHCARE_METHOD_OPT}'
-             use GE HealthCare specific Gradient Echo Field Maps for SDC (fieldmap and magnitude in two separate NIfTI files).
+             use GE HealthCare specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in two separate NIfTI files).
         '${PHILIPS_METHOD_OPT}'
              use Philips specific Gradient Echo Field Maps for SDC"
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -19,7 +19,7 @@ GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 # "GEHealthCareFieldMap" refers to fieldmap in the form of 2 separate NIfTI files.
 # One file with the Fieldmap in Hz and another file with the magnitude image). 
 # Note: dcm2niix (v1.0.20210410 and later) convert the GEHC B0Maps as 2 separate NIFTI files
-# using the suffix _fieldmaphz for the fieldmap in Hertz and no suffix for the magnitude. 
+# using the suffix '_fieldmaphz' for the fieldmap in Hz and no suffix for the magnitude image. 
 
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -16,7 +16,7 @@ GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap"
 # Note: dcm2niix (pre-v1.0.20210410) used to convert the GEHC B0Maps in this format (a single NIFTI file with 2 volumes). 
 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
-# "GEHealthCareFieldMap" refers to fieldmap in the form of 2 NIfTI files.
+# "GEHealthCareFieldMap" refers to fieldmap in the form of 2 separate NIfTI files.
 # One file withe the Fieldmap in Hertz and the magnitude image). 
 # Note: dcm2niix (v1.0.20210410 and later) convert the GEHC B0Maps as 2 NIFTI files
 # using the suffix _fieldmaphz for the fieldmap in Hertz and no suffix for the magnitude. 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -58,7 +58,7 @@ opts_AddMandatory '--ofmapmagbrain' 'MagnitudeBrainOutput' 'image' "output disto
 
 opts_AddMandatory '--ofmap' 'FieldMapOutput' 'image' "output distortion corrected fieldmap image (rad/s)"
 
-# options --echodiff is now mandatory - used by all "--method" (and all manufacturer). 
+# options --echodiff is now mandatory; used by all "--method" options (and necessary for processing of all vendors). 
 opts_AddMandatory '--echodiff' 'DeltaTE' 'number (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
 # Optional Arguments

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -46,7 +46,7 @@ opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for 
         '${SIEMENS_METHOD_OPT}'
              use Siemens specific Gradient Echo Field Maps for SDC
         '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
-             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --GEB0InputName argument).
+             use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --fmapcombined argument).
         '${GE_HEALTHCARE_METHOD_OPT}'
              use GE HealthCare specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in two separate NIfTI files).
         '${PHILIPS_METHOD_OPT}'
@@ -62,7 +62,7 @@ opts_AddMandatory '--ofmap' 'FieldMapOutput' 'image' "output distortion correcte
 opts_AddMandatory '--echodiff' 'DeltaTE' 'number (milliseconds)' "echo time difference for fieldmap images (in milliseconds)"
 
 # Optional Arguments
-opts_AddOptional '--fmapgelegacy' 'GEB0InputName' 'image (hertz and magnitude)' "GE HealthCare Legacy fieldmap with field map in Hz and magnitude image included as two volumes in a single file"
+opts_AddOptional '--fmapcombined' 'GEB0InputName' 'image (Hz and magnitude)' "GE HealthCare Legacy fieldmap with field map in Hz and magnitude image included as two volumes in a single file" '' '--fmap'
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image (radians or Hz)' "phase image in radians for Siemens/Philips fieldmap and in Hertz for GE HealthCare fieldmap"
 
@@ -105,7 +105,7 @@ case $DistortionCorrection in
 
         if [[ $GEB0InputName == "" ]]
         then 
-            log_Err_Abort "$DistortionCorrection method requires --fmapgelegacy"
+            log_Err_Abort "$DistortionCorrection method requires --fmapcombined"
         fi
         
         # Check that FSL is at least the minimum required FSL version, abort if needed (and log FSL-version)

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -10,7 +10,7 @@
 
 SIEMENS_METHOD_OPT="SiemensFieldMap"
 
-GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap"
+GE_HEALTHCARE_LEGACY_METHOD_OPT="GEHealthCareLegacyFieldMap"
 # "GEHealthCareLegacyFieldMap" refers to fieldmap in the form of a single NIfTI file 
 # with 2 volumes in it (volume-1: the Fieldmap in Hertz; volume-2: the magnitude image). 
 # Note: dcm2niix (pre-v1.0.20210410) used to convert the GEHC B0Maps in this format (a single NIFTI file with 2 volumes). 
@@ -23,7 +23,7 @@ GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 
 PHILIPS_METHOD_OPT="PhilipsFieldMap"
 
-# Minimum required FSL version for GENERAL_ELECTRIC_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
+# Minimum required FSL version for GE_HEALTHCARE_LEGACY_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
 GEHEALTHCARE_MINIMUM_FSL_VERSION="6.0.7.1"
 
 set -eu
@@ -45,7 +45,7 @@ opts_SetScriptDescription "Script for generating a fieldmap suitable for FSL fro
 opts_AddMandatory '--method' 'DistortionCorrection' 'method' "method to use for susceptibility distortion correction (SDC)
         '${SIEMENS_METHOD_OPT}'
              use Siemens specific Gradient Echo Field Maps for SDC
-        '${GENERAL_ELECTRIC_METHOD_OPT}'
+        '${GE_HEALTHCARE_LEGACY_METHOD_OPT}'
              use GE HealthCare Legacy specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in a single NIfTI file, via --GEB0InputName argument).
         '${GE_HEALTHCARE_METHOD_OPT}'
              use GE HealthCare specific Gradient Echo Field Maps for SDC (field map in Hz and magnitude image in two separate NIfTI files).
@@ -97,7 +97,7 @@ case $DistortionCorrection in
         fi
         ;;
 
-    ${GENERAL_ELECTRIC_METHOD_OPT})
+    ${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 
         # ---------------------------------------------------
         # -- GE HealthCare Legacy Gradient Echo Field Maps --
@@ -178,7 +178,7 @@ case $DistortionCorrection in
 
         ;;
 
-    ${GENERAL_ELECTRIC_METHOD_OPT})
+    ${GE_HEALTHCARE_LEGACY_METHOD_OPT})
 
         # ---------------------------------------------------
         # -- GE HealthCare Legacy Gradient Echo Field Maps --

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -13,7 +13,7 @@ SIEMENS_METHOD_OPT="SiemensFieldMap"
 GENERAL_ELECTRIC_METHOD_OPT="GEHealthCareLegacyFieldMap"
 # "GEHealthCareLegacyFieldMap" refers to fieldmap in the form of a single NIfTI file 
 # with 2 volumes in it (volume-1: the Fieldmap in Hertz; volume-2: the magnitude image). 
-# Note: dcm2niix (pre-v1.0.20210410) use to convert the GEHC B0Maps as a 2 volumes NIFTI file. 
+# Note: dcm2niix (pre-v1.0.20210410) used to convert the GEHC B0Maps in this format (a single NIFTI file with 2 volumes). 
 
 GE_HEALTHCARE_METHOD_OPT="GEHealthCareFieldMap"
 # "GEHealthCareFieldMap" refers to fieldmap in the form of 2 NIfTI files.

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -66,7 +66,7 @@ opts_AddOptional '--fmap' 'GEB0InputName' 'image (hertz and magnitude)' "GE Heal
 
 opts_AddOptional '--fmapphase' 'PhaseInputName' 'image (radians or Hz)' "phase image in radians for Siemens/Philips fieldmap and in Hertz for GE HealthCare fieldmap"
 
-opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "input Siemens/Philips/GE HealthCare fieldmap magnitude image - can be a 4D containing more than one"
+opts_AddOptional '--fmapmag' 'MagnitudeInputName' 'image' "Siemens/Philips/GE HealthCare fieldmap magnitude image; multiple volumes (i.e., magnitude images from both echoes) are allowed"
 
 opts_AddOptional '--workingdir' 'WD' 'path' 'working dir' "."
 

--- a/global/scripts/FieldMapPreprocessingAll.sh
+++ b/global/scripts/FieldMapPreprocessingAll.sh
@@ -171,10 +171,10 @@ case $DistortionCorrection in
         # -- Siemens Gradient Echo Field Maps --
         # --------------------------------------
 
-		    ${FSLDIR}/bin/fslmaths ${MagnitudeInputName} -Tmean ${WD}/Magnitude
-		    ${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
-		    ${FSLDIR}/bin/imcp ${PhaseInputName} ${WD}/Phase
-		    ${FSLDIR}/bin/fsl_prepare_fieldmap SIEMENS ${WD}/Phase ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
+	${FSLDIR}/bin/fslmaths ${MagnitudeInputName} -Tmean ${WD}/Magnitude
+	${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
+	${FSLDIR}/bin/imcp ${PhaseInputName} ${WD}/Phase
+	${FSLDIR}/bin/fsl_prepare_fieldmap SIEMENS ${WD}/Phase ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
 
         ;;
 
@@ -184,11 +184,11 @@ case $DistortionCorrection in
         # -- GE HealthCare Legacy Gradient Echo Field Maps --
         # --------------------------------------------------- 
 
-            ${FSLDIR}/bin/fslsplit ${GEB0InputName}     # split image into vol0000=fieldmap and vol0001=magnitude
-		    ${FSLDIR}/bin/immv vol0000 ${WD}/FieldMapHertz
-		    ${FSLDIR}/bin/immv vol0001 ${WD}/Magnitude
-		    ${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
-		    ${FSLDIR}/bin/fsl_prepare_fieldmap GEHC_FIELDMAPHZ ${WD}/FieldMapHertz ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
+        ${FSLDIR}/bin/fslsplit ${GEB0InputName}     # split image into vol0000=fieldmap and vol0001=magnitude
+	${FSLDIR}/bin/immv vol0000 ${WD}/FieldMapHertz
+	${FSLDIR}/bin/immv vol0001 ${WD}/Magnitude
+	${FSLDIR}/bin/bet ${WD}/Magnitude ${WD}/Magnitude_brain -f 0.35 -m #Brain extract the magnitude image
+	${FSLDIR}/bin/fsl_prepare_fieldmap GEHC_FIELDMAPHZ ${WD}/FieldMapHertz ${WD}/Magnitude_brain ${WD}/FieldMap ${DeltaTE}
 
         ;;
     ${GE_HEALTHCARE_METHOD_OPT})

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -155,7 +155,7 @@ fsl_minimum_required_version(){
 #  in argument 2 ($2).  
 #
 # Usage Example:
-#  fsl_minimum_required_version_check "6.0.7.1" "My Optionnal Error Message"
+#  fsl_minimum_required_version_check "6.0.7.1" "My Optional Error Message"
 # 
 fsl_minimum_required_version_check(){
     local min_ver="${1}"

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -167,11 +167,11 @@ fsl_minimum_required_version_check(){
     min_criterion_met=$(fsl_minimum_required_version "$min_ver")
 
     if [ "$min_criterion_met" == "true" ]; then
-        log_Msg "INFO: The minimum FSL version criterion is met (mininum-version: ${min_ver} <= current-version ${cur_ver})"
+        log_Msg "INFO: The minimum FSL version criterion is met (minimum-version: ${min_ver} <= current-version ${cur_ver})"
     else
         if [[ -n "$my_err_msg" ]]; then
             log_Err "$my_err_msg"
         fi
-        log_Err_Abort "The minimum FSL version criterion is NOT met (mininum-version: ${min_ver} > current-version ${cur_ver})"
+        log_Err_Abort "The minimum FSL version criterion is NOT met (minimum-version: ${min_ver} > current-version ${cur_ver})"
     fi
 }

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -1,7 +1,7 @@
 #!/bin/echo This script should not be run directly:
 
 # Max number of dots in FSL-version strings.
-# We assume the FSL is maximum 4 digits separated 
+# We assume the FSL version is a maximum of 4 digits separated 
 # by 3 dots such as X.Y.Z.W (e.g. 6.0.7.6)
 MAX_NDOTS_IN_FSLVERSION=3
 #

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -114,44 +114,35 @@ fsl_minimum_required_version(){
     IFS=. read -a min_ver_array <<< "$min_ver"
 
     # count the dots
-    ndots_cur_ver=$(awk -F"." '{print NF-1}' <<< "$cur_ver")
-    ndots_min_ver=$(awk -F"." '{print NF-1}' <<< "$min_ver")
+    ndots_cur_ver=$((${#cur_ver_array[@]} - 1))
+    ndots_min_ver=$((${#min_ver_array[@]} - 1))
 
-    # get the maximum number of dots
-    if [ "$ndots_cur_ver" -ge "$ndots_min_ver" ]; 
-    then
-        max_ndots=$ndots_cur_ver
-    else 
-        max_ndots=$ndots_min_ver
-    fi
-
-    for k in $(seq 0 $max_ndots)
-    do
-        # In case the version string is not exactly as expected.
-        if [[ -z "${cur_ver_array[$k]}" ]]; then
-            cur_ver_array[$k]=0
-        fi
-
-        if [[ -z "${min_ver_array[$k]}" ]]; then
-            min_ver_array[$k]=0
-        fi
-
+    # the version comparison consider "x.0 is newer than x"
+    for ((i = 0; i < ${#cur_ver_array[@]} && i < ${#min_ver_array[@]}; ++i)); 
+    do 
         # compare version numbers. is "current < minimum" ?
-        if [[ "${cur_ver_array[$k]}" -lt "${min_ver_array[$k]}" ]]; 
-        then
+        if ((cur_ver_array[i] < min_ver_array[i])); 
+        then 
             echo "false"
             return 0
         fi
+
         # compare version numbers. is "current > minimum" ?
-        if [[ "${cur_ver_array[$k]}" -gt "${min_ver_array[$k]}" ]]; 
-        then
+        if ((cur_ver_array[i] > min_ver_array[i])); 
+        then 
             echo "true"
             return 0
         fi
     done
 
-    # This situation is "=" case but different string length.
-    echo "true"
+    # if current string length >= minimum version string length then true
+    if ((${#cur_ver_array[@]} >= ${#min_ver_array[@]})); 
+    then 
+        echo "true"
+        return 0
+    fi
+    
+    echo "false"
     return 0
 }
 

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -94,13 +94,13 @@ fsl_minimum_required_version(){
     local cur_ver 
     local min_ver_array
     local cur_ver_array
+    local ndots_cur_ver
+    local ndots_min_ver
     # maximum number of dots in FSL-version string
-    local max_ndots=$MAX_NDOTS_IN_FSLVERSION
+    local max_ndots
 
-    # get current FSL version, format it in X.Y.Z.W, format min version too
+    # get current FSL version
     fsl_version_get cur_ver >> /dev/null
-    cur_ver=$(fsl_version_format "$cur_ver")
-    min_ver=$(fsl_version_format "$min_ver")
 
     # if the 2 version strings are identical, no need to test further
     if [ "$cur_ver" == "$min_ver" ]; 
@@ -109,12 +109,21 @@ fsl_minimum_required_version(){
         return 0
     fi
 
-    # split version by dots - assuming the format X.Y.Z.W
-    for k in $(seq 0 $max_ndots); 
-    do 
-        cur_ver_array[$k]=$(awk -F"." -v i=$((k+1)) '{print $i}' <<< "$cur_ver")
-        min_ver_array[$k]=$(awk -F"." -v i=$((k+1)) '{print $i}' <<< "$min_ver")
-    done
+    # split version by dots
+    IFS=. read -a cur_ver_array <<< "$cur_ver"
+    IFS=. read -a min_ver_array <<< "$min_ver"
+
+    # count the dots
+    ndots_cur_ver=$(awk -F"." '{print NF-1}' <<< "$cur_ver")
+    ndots_min_ver=$(awk -F"." '{print NF-1}' <<< "$min_ver")
+
+    # get the maximum number of dots
+    if [ "$ndots_cur_ver" -ge "$ndots_min_ver" ]; 
+    then
+        max_ndots=$ndots_cur_ver
+    else 
+        max_ndots=$ndots_min_ver
+    fi
 
     for k in $(seq 0 $max_ndots)
     do
@@ -139,10 +148,9 @@ fsl_minimum_required_version(){
             echo "true"
             return 0
         fi
-
     done
 
-    # This situation should never happen as the "=" case is tested before.
+    # This situation is "=" case but different string length.
     echo "true"
     return 0
 }

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -82,7 +82,7 @@ fsl_version_format(){
 # Usage Example:
 #  ret_val=$(fsl_minimum_required_version "6.0.7.2")
 #  if [ "$ret_val" == "false" ]; then
-#      log_Msg "ERROR: FSL minimun required version is 6.0.7.2. 
+#      log_Msg "ERROR: FSL minimum required version is 6.0.7.2. 
 #      exit 1
 #  else 
 #      log_Msg "INFO: FSL version > 6.0.7.2"

--- a/global/scripts/fsl_version.shlib
+++ b/global/scripts/fsl_version.shlib
@@ -4,6 +4,12 @@
 # We assume the FSL version is a maximum of 4 digits separated 
 # by 3 dots such as X.Y.Z.W (e.g. 6.0.7.6)
 MAX_NDOTS_IN_FSLVERSION=3
+
+# Minimum required FSL version for GE_HEALTHCARE_LEGACY_METHOD_OPT and GE_HEALTHCARE_METHOD_OPT
+# for processing of B0Maps. See global/scripts/FieldMapPreprocessingAll.sh
+# and fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+GEHEALTHCARE_MINIMUM_FSL_VERSION="6.0.7.1"
+
 #
 # Function Description
 #  Get the current version string for FSL


### PR DESCRIPTION
Correction of the existing GEHC B0 fieldmap processing (which was incomplete) and implementation of a new B0 fieldmap processing for GEHC data. The minimum required FSL-version is 6.0.7.1 for GEHC B0 fieldmap processing.

The existing fieldmap processing "GeneralElectricFieldMap" was renamed "GEHealthCareLegacyFieldMap". It is made for Legacy existing data converted with dcm2niix (pre-v1.0.20210410). These GEHC B0Maps were a 2 volumes NIFTI file (Volume 1 is the B0Map in Hertz, and Volume 2 the magnitude image).

A new fieldmap processing is introduced and named "GEHealthCareFieldMap". This is intended for new data converted with recent dcm2niix (v1.0.20220720 and later). The GEHC B0Maps are split as 2 NIfTI files (the magnitude and the b0map_fieldmaphz in Hertz - with the suffix "_fieldmaphz" for easy identification). The usage of this fieldmap processing is identical to Siemens/Philips pipeline.

For both "GEHealthCareLegacyFieldMap" and "GEHealthCareFieldMap" correction methods the "DeltaTE" is now a mandatory input.

Description of changes:
modified:   global/scripts/fsl_version.shlib
Functions to format FSL-version strings, to compare FSL-version and to check that minimun required FSL-version were added.

modified:   global/scripts/FieldMapPreprocessingAll.sh
Modification of "GeneralElectricFieldMap" renamed "GEHealthCareLegacyFieldMap" to add phase unwrapping and processing with fsl_prepare_fieldmap.
Added the "GEHealthCareFieldMap" processing via fsl_prepare_fieldmap.
The input DeltaTE is now mandatory.
And a verification that the minimum FSL-version criterion is met.

The following scripts were also modified to reflect the changes made in global/scripts/fsl_version.shlib and mainly global/scripts/FieldMapPreprocessingAll.sh.

modified:   Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch.sh
modified:   Examples/Scripts/Historical/7T/GenericfMRIVolumeProcessingPipelineBatch.7T.sh
modified:   Examples/Scripts/PreFreeSurferPipelineBatch.sh
modified:   PreFreeSurfer/PreFreeSurferPipeline.sh
modified:   PreFreeSurfer/scripts/T2wToT1wDistortionCorrectAndReg.sh
modified:   fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
modified:   fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh

Modification tested on a database of 7 subjects containing 3DT1w, 3DT2w, resting-state fMRI, 3D-B0maps, and a pair of Spin-Echo EPI with positve and negative phase-encodings (a.k.a SpinEchoFielMaps for TOPUP).