### PR TITLE
Fix isodd check before Pos_b0 exists

### DIFF
--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -174,6 +174,10 @@ log_Check_Env_Var HCPPIPEDIR_Config # Needed in run_topup.sh
 # --------------------------------------------------------------------------------
 
 isodd() {
+	if (($# < 1)) || [[ "$1" == "" ]]
+	then
+		log_Err_Abort "isodd function was passed no arguments or an empty string, something has gone wrong"
+	fi
 	echo "$(($1 % 2))"
 }
 
@@ -330,8 +334,9 @@ fi
 
 # if the number of slices are odd, check that the user has a way to deal with that
 if ((! EnsureEvenSlices)) && [ "${TopupConfig}" == "${HCPPIPEDIR_Config}/b02b0.cnf" ] ; then
-	dimz=$(${FSLDIR}/bin/fslval ${outdir}/topup/Pos_b0 dim3)
-	if [ $(isodd $dimz) -eq 1 ]; then
+	#Pos_b0 doesn't exist yet, assume "$any" has the relevant dims to check
+	dimz=$(${FSLDIR}/bin/fslval "$any" dim3)
+	if [[ $(isodd "$dimz") == "1" ]]; then
 		log_Msg "Input images have an odd number of slices. This is incompatible with the default topup configuration file."
 		log_Msg "Either supply a topup configuration file that doesn't use subsampling (e.g., FSL's 'b02b0_1.cnf') using the --topup-config-file=<file> flag (recommended)"
 		log_Msg "or instruct the HCP pipelines to remove a slice using the --ensure-even-slices flag (legacy option)."
@@ -388,7 +393,7 @@ fi
 
 if ((EnsureEvenSlices)); then
 	dimz=$(${FSLDIR}/bin/fslval ${outdir}/topup/Pos_b0 dim3)
-	if [[ $(isodd $dimz) == 1 ]]; then
+	if [[ $(isodd "$dimz") == 1 ]]; then
 		echo "Removing one slice from data to get even number of slices"
 		for filename in Pos_Neg_b0 Pos_b0 Neg_b0 ; do
 			${runcmd} ${FSLDIR}/bin/fslroi ${outdir}/topup/${filename} ${outdir}/topup/${filename}_tmp 0 -1 0 -1 1 -1


### PR DESCRIPTION
A user's error log currently looks like this:

```
Image Exception : #63 :: No image files match: /home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup/Pos_b0
No image files match: /home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup/Pos_b0
/home/<redacted>/projects/HCPpipelines/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh: line 177: $1: unbound variable
/home/<redacted>/projects/HCPpipelines/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh: line 334: [: -eq: unary operator expected

Part of FSL (ID: "")
topup

Usage: 
topup --imain=<some 4D image> --datain=<text file> --config=<text file with parameters> --out=my_topup_results

...

Topup::topup_clp::topup_clp: Subsampling levels incompatible with image data.
Wed May  1 18:12:50 JST 2024:run_topup.sh: While running '/home/<redacted>/projects/HCPpipelines/DiffusionPreprocessing/scripts/run_topup.sh /home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup /home/<redacted>/projects/HCPpipelines/global/config/b02b0.cnf':
Wed May  1 18:12:50 JST 2024:run_topup.sh: ERROR: '/home/<redacted>/fsl/bin/topup' command failed with return code: 1

===> ERROR: Command returned with nonzero exit code
---------------------------------------------------
         script: run_topup.sh
stopped at line: 9
           call: ${FSLDIR}/bin/topup --imain=${workingdir}/Pos_Neg_b0 --datain=${workingdir}/acqparams.txt --config=${topup_config_file} --out=${workingdir}/topup_Pos_Neg_b0 -v --fout=${workingdir}/topup_Pos_Neg_b0_field.nii.gz
  expanded call: /home/<redacted>/fsl/bin/topup --imain=/home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup/Pos_Neg_b0 --datain=/home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup/acqparams.txt --config=/home/<redacted>/projects/HCPpipelines/global/config/b02b0.cnf --out=/home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup/topup_Pos_Neg_b0 -v --fout=/home/<redacted>/projects/HcpPipelines_ExampleData/100307/Diffusion/topup/topup_Pos_Neg_b0_field.nii.gz
...
```
Those first 4 errors are the script failing to decide whether to display an informative error message because Pos_b0.nii.gz isn't generated until either `basic_preproc_best_b0.sh` or `basic_preproc_sequence.sh` run later on:

https://github.com/Washington-University/HCPpipelines/blob/ea8fdd4a47b9d83838121f3e00dcc7a6d1bc08ff/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh#L333

This PR is intended to fix the logic for checking whether to display this error message.