### PR TITLE
Update FSL contribution to PATH

### DIFF
--- a/Examples/Scripts/SetUpHCPPipeline.sh
+++ b/Examples/Scripts/SetUpHCPPipeline.sh
@@ -93,7 +93,14 @@ then
 fi
 
 # Add the specified versions of some things to the front of $PATH, so we can stop using absolute paths everywhere
-export PATH="$CARET7DIR:$FSLDIR/share/fsl/bin:$PATH"
+if [ -d "$FSLDIR/share/fsl/bin" ] ; then
+    # For FSL 6.0.6 (release date: 22 Nov 2022) or later
+    export PATH="$FSLDIR/share/fsl/bin:$PATH"
+else
+    # For older versions of FSL
+    export PATH="$FSLDIR/bin:$PATH"
+fi
+export PATH="$CARET7DIR:$PATH"
 
 # Source extra stuff that pipelines authors may need to edit, but users shouldn't ever need to
 # by separating them this way, a user can continue to use their previous setup file even if we

--- a/Examples/Scripts/SetUpHCPPipeline.sh
+++ b/Examples/Scripts/SetUpHCPPipeline.sh
@@ -101,7 +101,6 @@ else
     export PATH="$FSLDIR/bin:$PATH"
 fi
 export PATH="$CARET7DIR:$PATH"
-echo $PATH
 
 # Source extra stuff that pipelines authors may need to edit, but users shouldn't ever need to
 # by separating them this way, a user can continue to use their previous setup file even if we

--- a/Examples/Scripts/SetUpHCPPipeline.sh
+++ b/Examples/Scripts/SetUpHCPPipeline.sh
@@ -93,7 +93,7 @@ then
 fi
 
 # Add the specified versions of some things to the front of $PATH, so we can stop using absolute paths everywhere
-if [ -d "$FSLDIR/share/fsl/bin" ] ; then
+if [[ -d "$FSLDIR/share/fsl/bin" ]] ; then
     # For FSL 6.0.6 (release date: 22 Nov 2022) or later
     export PATH="$FSLDIR/share/fsl/bin:$PATH"
 else
@@ -101,6 +101,7 @@ else
     export PATH="$FSLDIR/bin:$PATH"
 fi
 export PATH="$CARET7DIR:$PATH"
+echo $PATH
 
 # Source extra stuff that pipelines authors may need to edit, but users shouldn't ever need to
 # by separating them this way, a user can continue to use their previous setup file even if we

--- a/Examples/Scripts/SetUpHCPPipeline.sh
+++ b/Examples/Scripts/SetUpHCPPipeline.sh
@@ -93,7 +93,7 @@ then
 fi
 
 # Add the specified versions of some things to the front of $PATH, so we can stop using absolute paths everywhere
-export PATH="$CARET7DIR:$FSLDIR/bin:$PATH"
+export PATH="$CARET7DIR:$FSLDIR/share/fsl/bin:$PATH"
 
 # Source extra stuff that pipelines authors may need to edit, but users shouldn't ever need to
 # by separating them this way, a user can continue to use their previous setup file even if we


### PR DESCRIPTION
As of FSL 6.0.6 (release date: 22 nov 2022), the binaries are stored in $FSLDIR/share/fsl/bin, not $FSLDIR/bin

See https://fsl.fmrib.ox.ac.uk/fsl/docs/#/development/history/index?id=_606-22nd-november-2022 for more details

Including $FSLDIR/bin in the $PATH will include all the FSL-specific binaries, but also a lot of other non-FSL related ones. This can lead to confusing behaviour, where FSL versions of generic tools will be used after running `source SetupHCPPipeline.sh` rather than built-in versions.