### PR TITLE
Diffusion preprocessing longitudinal

### DIFF
--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -394,10 +394,12 @@ if (( ! IsLongitudinal )); then
     log_Msg "eddy_cmd: ${eddy_cmd[*]}"
     "${eddy_cmd[@]}"
 else #copy cross-sectional output to longitudinal session
+    log_Msg "Longitudinal mode, copying cross-sectional output of Pre-Eddy and Eddy steps to longitudinal session"
     cp -rf "$StudyFolder/$Session/Diffusion" "$StudyFolder/$SessionLong/Diffusion"
     cp -rf "$StudyFolder/$Session/T1w/Diffusion" "$StudyFolder/$SessionLong/T1w/Diffusion"
 fi
 
+#PostEddy step must be run on longitudinal session rather than copied from cross-sectional.
 if (( IsLongitudinal )); then Session="$SessionLong"; fi
 
 log_Msg "Invoking Post-Eddy Steps"

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -176,7 +176,7 @@ opts_SetScriptDescription "Perform the steps of the HCP Diffusion Preprocessing 
 
 opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--session' 'Session' 'session ID' "subject"
+opts_AddMandatory '--session' 'Session' 'session ID' "" "subject"
 
 opts_AddMandatory '--PEdir' 'PEdir' 'Path' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA"
 
@@ -222,6 +222,9 @@ opts_AddOptional '--combine-data-flag' 'CombineDataFlag' 'number' "Specified val
 Defaults to 1" "1"
 
 opts_AddOptional '--printcom' 'runcmd' 'echo' 'to echo or otherwise  output the commands that would be executed instead of  actually running them. --printcom=echo is intended to  be used for testing purposes'
+#longitudinal options
+opts_AddOptional '--is-longitudinal' 'IsLongitudinal' 'TRUE/FALSE' "Specifies whether this is run on a longitudinal timepoint" "0"
+opts_AddOptional '--longitudinal-session' 'SessionLong' 'folder' "Specifies longitudinal session name. If specified,  --session must point to the cross-sectional session." "NONE"
 
 opts_ParseArguments "$@"
 
@@ -307,6 +310,19 @@ if ((SelectBestB0)); then
     fi
 fi
 
+#parse longitudinal arguments
+IsLongitudinal=$(opts_StringToBool "$IsLongitudinal")
+T1wCross2LongXfm=""
+
+if (( IsLongitudinal )); then
+    if [ ! -d "$Path/$SessionLong" ]; then
+        log_Err_Abort "the --longitudinal-session must be specified and folder must exist in longitudinal mode"
+    fi
+    T1wCross2LongXfm=$Path/$SessionLong/T1w/xfms/T1w_cross_to_T1w_long.mat
+    if [ ! -f "$T1wCross2LongXfm" ]; then 
+        log_Err_Abort "Longitudinal session $SessionLong: cross-sectional to longitudinal transform $T1wCross2LongXfm does not exist. Has longtudinal PostFreesurfer been run?"
+    fi
+fi
 
 #
 # Function Description
@@ -343,39 +359,46 @@ validate_scripts() {
 # Validate scripts
 validate_scripts "$@"
 
-log_Msg "Invoking Pre-Eddy Steps"
-pre_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh"
-    "--path=${StudyFolder}"
-    "--session=${Session}"
-    "--dwiname=${DWIName}"
-    "--PEdir=${PEdir}"
-    "--posData=${PosInputImages}"
-    "--negData=${NegInputImages}"
-    "--echospacing=${echospacingmilli}"
-    "--b0maxbval=${b0maxbval}"
-    "--topup-config-file=${TopupConfig}"
-    "--printcom=${runcmd}"
-    "--select-best-b0=${SelectBestB0}"
-    "--ensure-even-slices=${EnsureEvenSlices}")
+if (( ! IsLongitudinal )); then 
+    log_Msg "Invoking Pre-Eddy Steps"
+    pre_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh"
+        "--path=${StudyFolder}"
+        "--session=${Session}"
+        "--dwiname=${DWIName}"
+        "--PEdir=${PEdir}"
+        "--posData=${PosInputImages}"
+        "--negData=${NegInputImages}"
+        "--echospacing=${echospacingmilli}"
+        "--b0maxbval=${b0maxbval}"
+        "--topup-config-file=${TopupConfig}"
+        "--printcom=${runcmd}"
+        "--select-best-b0=${SelectBestB0}"
+        "--ensure-even-slices=${EnsureEvenSlices}")
 
-log_Msg "pre_eddy_cmd: ${pre_eddy_cmd[*]}"
-"${pre_eddy_cmd[@]}"
+    log_Msg "pre_eddy_cmd: ${pre_eddy_cmd[*]}"
+    "${pre_eddy_cmd[@]}"
 
-log_Msg "Invoking Eddy Step"
-eddy_cmd=("${HCPPIPEDIR}"/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
-    --path="$StudyFolder"
-    --session="$Session"
-    --dwiname="$DWIName"
-    --printcom="$runcmd"
-    --gpu="$gpu"
-    --cuda-version="$cuda_version")
-for extra_eddy_arg in ${extra_eddy_args[@]+"${extra_eddy_args[@]}"}
-do
-    eddy_cmd+=(--extra-eddy-arg="$extra_eddy_arg")
-done
+    log_Msg "Invoking Eddy Step"
+    eddy_cmd=("${HCPPIPEDIR}"/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+        --path="$StudyFolder"
+        --session="$Session"
+        --dwiname="$DWIName"
+        --printcom="$runcmd"
+        --gpu="$gpu"
+        --cuda-version="$cuda_version")
+    for extra_eddy_arg in ${extra_eddy_args[@]+"${extra_eddy_args[@]}"}
+    do
+        eddy_cmd+=(--extra-eddy-arg="$extra_eddy_arg")
+    done
 
-log_Msg "eddy_cmd: ${eddy_cmd[*]}"
-"${eddy_cmd[@]}"
+    log_Msg "eddy_cmd: ${eddy_cmd[*]}"
+    "${eddy_cmd[@]}"
+else #copy cross-sectional output to longitudinal session
+    cp -rf "$StudyFolder/$Session/Diffusion" "$StudyFolder/$SessionLong/Diffusion"
+    cp -rf "$StudyFolder/$Session/T1w/Diffusion" "$StudyFolder/$SessionLong/T1w/Diffusion"
+fi
+
+if (( IsLongitudinal )); then Session="$SessionLong"; fi
 
 log_Msg "Invoking Post-Eddy Steps"
 post_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh"
@@ -386,7 +409,8 @@ post_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PostEdd
     "--dof=${DegreesOfFreedom}"
     "--combine-data-flag=${CombineDataFlag}"
     "--printcom=${runcmd}"
-    "--select-best-b0=${SelectBestB0}")
+    "--select-best-b0=${SelectBestB0}"
+    "--t1w_cross2long_xfm=${T1wCross2LongXfm}")
 
 log_Msg "post_eddy_cmd: ${post_eddy_cmd[*]}"
 "${post_eddy_cmd[@]}"

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -176,7 +176,7 @@ opts_SetScriptDescription "Perform the steps of the HCP Diffusion Preprocessing 
 
 opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--session' 'Session' 'session ID' "" "subject"
+opts_AddMandatory '--session' 'Session' 'session ID' "" "--subject"
 
 opts_AddMandatory '--PEdir' 'PEdir' 'Path' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA"
 
@@ -315,10 +315,10 @@ IsLongitudinal=$(opts_StringToBool "$IsLongitudinal")
 T1wCross2LongXfm=""
 
 if (( IsLongitudinal )); then
-    if [ ! -d "$Path/$SessionLong" ]; then
+    if [ ! -d "$StudyFolder/$SessionLong" ]; then
         log_Err_Abort "the --longitudinal-session must be specified and folder must exist in longitudinal mode"
     fi
-    T1wCross2LongXfm=$Path/$SessionLong/T1w/xfms/T1w_cross_to_T1w_long.mat
+    T1wCross2LongXfm=$StudyFolder/$SessionLong/T1w/xfms/T1w_cross_to_T1w_long.mat
     if [ ! -f "$T1wCross2LongXfm" ]; then 
         log_Err_Abort "Longitudinal session $SessionLong: cross-sectional to longitudinal transform $T1wCross2LongXfm does not exist. Has longtudinal PostFreesurfer been run?"
     fi
@@ -412,7 +412,7 @@ post_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PostEdd
     "--combine-data-flag=${CombineDataFlag}"
     "--printcom=${runcmd}"
     "--select-best-b0=${SelectBestB0}"
-    "--t1w_cross2long_xfm=${T1wCross2LongXfm}")
+    "--t1w-cross2long-xfm=${T1wCross2LongXfm}")
 
 log_Msg "post_eddy_cmd: ${post_eddy_cmd[*]}"
 "${post_eddy_cmd[@]}"

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -59,14 +59,14 @@
 # Output path specifiers
 #
 # * <code>${StudyFolder}</code> is an input parameter
-# * <code>${Subject}</code> is an input parameter
+# * <code>${Session}</code> is an input parameter
 #
 # Main output directories
 #
-# * <code>DiffFolder=${StudyFolder}/${Subject}/Diffusion</code>
-# * <code>T1wDiffFolder=${StudyFolder}/${Subject}/T1w/Diffusion</code>
+# * <code>DiffFolder=${StudyFolder}/${Session}/Diffusion</code>
+# * <code>T1wDiffFolder=${StudyFolder}/${Session}/T1w/Diffusion</code>
 #
-# All outputs are within the directory: <code>${StudyFolder}/${Subject}</code>
+# All outputs are within the directory: <code>${StudyFolder}/${Session}</code>
 #
 # The full list of output directories are the following
 #
@@ -78,7 +78,7 @@
 # * <code>$T1wDiffFolder</code>
 #
 # Also assumes that T1 preprocessing has been carried out with results in
-# <code>${StudyFolder}/${Subject}/T1w</code>
+# <code>${StudyFolder}/${Session}/T1w</code>
 #
 # <!-- References -->
 #
@@ -174,9 +174,9 @@ DEFAULT_DEGREES_OF_FREEDOM=6
 # Perform the steps of the HCP Diffusion Preprocessing Pipeline
 opts_SetScriptDescription "Perform the steps of the HCP Diffusion Preprocessing Pipeline"
 
-opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to subject's data folder" 
+opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--subject' 'Subject' 'subject ID' "subject-id"
+opts_AddMandatory '--session' 'Session' 'session ID' "subject"
 
 opts_AddMandatory '--PEdir' 'PEdir' 'Path' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA"
 
@@ -346,7 +346,7 @@ validate_scripts "$@"
 log_Msg "Invoking Pre-Eddy Steps"
 pre_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh"
     "--path=${StudyFolder}"
-    "--subject=${Subject}"
+    "--session=${Session}"
     "--dwiname=${DWIName}"
     "--PEdir=${PEdir}"
     "--posData=${PosInputImages}"
@@ -364,7 +364,7 @@ log_Msg "pre_eddy_cmd: ${pre_eddy_cmd[*]}"
 log_Msg "Invoking Eddy Step"
 eddy_cmd=("${HCPPIPEDIR}"/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
     --path="$StudyFolder"
-    --subject="$Subject"
+    --session="$Session"
     --dwiname="$DWIName"
     --printcom="$runcmd"
     --gpu="$gpu"
@@ -380,7 +380,7 @@ log_Msg "eddy_cmd: ${eddy_cmd[*]}"
 log_Msg "Invoking Post-Eddy Steps"
 post_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh"
     "--path=${StudyFolder}"
-    "--subject=${Subject}"
+    "--session=${Session}"
     "--dwiname=${DWIName}"
     "--gdcoeffs=${GdCoeffs}"
     "--dof=${DegreesOfFreedom}"

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
@@ -159,7 +159,7 @@ opts_AddOptional '--ff' 'ff_val' 'Number' "Ff-value to be passed to the eddy bin
 
 opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
   
-opts_AddMandatory '--session' 'Session' 'session ID' "subject"
+opts_AddMandatory '--session' 'Session' 'session ID' "" "--subject"
 
 opts_AddOptional '--dwiname' 'DWIName' 'String' "Name to give DWI output directories. Defaults to Diffusion" "Diffusion" 
 

--- a/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_Eddy.sh
@@ -157,9 +157,9 @@ opts_AddOptional '--rms' 'rmsString' 'Boolean' "Write root-mean-squared movement
 
 opts_AddOptional '--ff' 'ff_val' 'Number' "Ff-value to be passed to the eddy binary. See eddy documentation at http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/EDDY/UsersGuide#A--ff for further information. Note: This option has no effect if the GPU-enabled version of eddy is not used."
 
-opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to subject's data folder" 
+opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
   
-opts_AddMandatory '--subject' 'Subject' 'subject ID' "subject-id"
+opts_AddMandatory '--session' 'Session' 'session ID' "subject"
 
 opts_AddOptional '--dwiname' 'DWIName' 'String' "Name to give DWI output directories. Defaults to Diffusion" "Diffusion" 
 
@@ -212,7 +212,7 @@ log_Check_Env_Var FSLDIR
 HCPPIPEDIR_dMRI=${HCPPIPEDIR}/DiffusionPreprocessing/scripts
 
 # Establish output directory paths
-outdir=${StudyFolder}/${Subject}/${DWIName}
+outdir=${StudyFolder}/${Session}/${DWIName}
 
 run_eddy_cmd=("${HCPPIPEDIR_dMRI}"/run_eddy.sh
     --nvoxhp="$nvoxhp"

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -238,21 +238,21 @@ DiffRes=$(printf "%0.2f" ${DiffRes})
 
 log_Msg "Running Diffusion to Structural Registration"
 ${runcmd} ${HCPPIPEDIR_dMRI}/DiffusionToStructural.sh \
-	--t1folder="${T1wFolder}" \
-	--session="${Session}" \
-	--workingdir="${outdir}/reg" \
-	--datadiffdir="${outdir}/data" \
-	--t1="${T1wImage}" \
-	--t1restore="${T1wRestoreImage}" \
-	--t1restorebrain="${T1wRestoreImageBrain}" \
-	--biasfield="${BiasField}" \
-	--brainmask="${FreeSurferBrainMask}" \
-	--datadiffT1wdir="${outdirT1w}" \
-	--regoutput="${RegOutput}" \
-	--QAimage="${QAImage}" \
-	--dof="${DegreesOfFreedom}" \
-	--gdflag=${GdFlag} \
-	--diffresol=${DiffRes} \
+    --t1folder="${T1wFolder}" \
+    --session="${Session}" \
+    --workingdir="${outdir}/reg" \
+    --datadiffdir="${outdir}/data" \
+    --t1="${T1wImage}" \
+    --t1restore="${T1wRestoreImage}" \
+    --t1restorebrain="${T1wRestoreImageBrain}" \
+    --biasfield="${BiasField}" \
+    --brainmask="${FreeSurferBrainMask}" \
+    --datadiffT1wdir="${outdirT1w}" \
+    --regoutput="${RegOutput}" \
+    --QAimage="${QAImage}" \
+    --dof="${DegreesOfFreedom}" \
+    --gdflag=${GdFlag} \
+    --diffresol=${DiffRes} \
     --t1w-cross2long-xfm="$T1wCross2LongXfm"
 
 to_location="${outdirT1w}/eddylogs"

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -120,9 +120,9 @@ DEFAULT_DEGREES_OF_FREEDOM=6
 
 opts_SetScriptDescription "Perform the Post-Eddy steps of the HCP Diffusion Preprocessing Pipeline"
 
-opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to subject's data folder" 
+opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--subject' 'Subject' 'subject ID' "subject-id"
+opts_AddMandatory '--session' 'Session' 'session ID' "subject"
 
 opts_AddMandatory '--gdcoeffs' 'GdCoeffs' 'Path' "Path to file containing coefficients that describe spatial variations of the scanner gradients. Applied *after* 'eddy'. Use --gdcoeffs=NONE if not available."
 
@@ -196,8 +196,8 @@ validate_scripts() {
 validate_scripts "$@"
 
 # Establish output directory paths
-outdir=${StudyFolder}/${Subject}/${DWIName}
-outdirT1w=${StudyFolder}/${Subject}/T1w/${DWIName}
+outdir=${StudyFolder}/${Session}/${DWIName}
+outdirT1w=${StudyFolder}/${Session}/T1w/${DWIName}
 
 # Determine whether Gradient Nonlinearity Distortion coefficients are supplied
 GdFlag=0
@@ -215,7 +215,7 @@ fi
 ${runcmd} ${HCPPIPEDIR_dMRI}/eddy_postproc.sh ${outdir} ${GdCoeffs} ${CombineDataFlag} ${select_flag}
 
 # Establish variables that follow naming conventions
-T1wFolder="${StudyFolder}/${Subject}/T1w" #Location of T1w images
+T1wFolder="${StudyFolder}/${Session}/T1w" #Location of T1w images
 T1wImage="${T1wFolder}/T1w_acpc_dc"
 T1wRestoreImage="${T1wFolder}/T1w_acpc_dc_restore"
 T1wRestoreImageBrain="${T1wFolder}/T1w_acpc_dc_restore_brain"
@@ -229,7 +229,7 @@ DiffRes=$(printf "%0.2f" ${DiffRes})
 log_Msg "Running Diffusion to Structural Registration"
 ${runcmd} ${HCPPIPEDIR_dMRI}/DiffusionToStructural.sh \
 	--t1folder="${T1wFolder}" \
-	--subject="${Subject}" \
+	--session="${Session}" \
 	--workingdir="${outdir}/reg" \
 	--datadiffdir="${outdir}/data" \
 	--t1="${T1wImage}" \
@@ -253,11 +253,11 @@ from_files=$(ls ${from_directory}/eddy_unwarped_images.* | grep -v .nii)
 
 ${runcmd} mkdir -p ${to_location}
 for filename in ${from_files}; do
-	${runcmd} cp -p ${filename} ${to_location}
+	${runcmd} cp -p ${filename} ${to_location} || ${runcmd} cp ${filename} ${to_location}
 done
 
 ${runcmd} mkdir -p ${outdirT1w}/QC
-${runcmd} cp -p ${outdir}/QC/* ${outdirT1w}/QC
+${runcmd} cp -p ${outdir}/QC/* ${outdirT1w}/QC || ${runcmd} cp ${outdir}/QC/* ${outdirT1w}/QC
 ${runcmd} immv ${outdirT1w}/cnr_maps ${outdirT1w}/QC/cnr_maps
 
 log_Msg "Completed!"

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PostEddy.sh
@@ -122,7 +122,7 @@ opts_SetScriptDescription "Perform the Post-Eddy steps of the HCP Diffusion Prep
 
 opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--session' 'Session' 'session ID' "subject"
+opts_AddMandatory '--session' 'Session' 'session ID' "" "--subject"
 
 opts_AddMandatory '--gdcoeffs' 'GdCoeffs' 'Path' "Path to file containing coefficients that describe spatial variations of the scanner gradients. Applied *after* 'eddy'. Use --gdcoeffs=NONE if not available."
 

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -121,7 +121,7 @@ opts_SetScriptDescription "Perform the Pre-Eddy steps of the HCP Diffusion Prepr
 
 opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--session' 'Session' 'session ID' "subject"
+opts_AddMandatory '--session' 'Session' 'session ID' "" "--subject"
 
 opts_AddMandatory '--PEdir' 'PEdir' 'Path' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA"
 

--- a/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline_PreEddy.sh
@@ -119,9 +119,9 @@ DEFAULT_B0_MAX_BVAL=50
 
 opts_SetScriptDescription "Perform the Pre-Eddy steps of the HCP Diffusion Preprocessing Pipeline"
 
-opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to subject's data folder" 
+opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder" 
 
-opts_AddMandatory '--subject' 'Subject' 'subject ID' "subject-id"
+opts_AddMandatory '--session' 'Session' 'session ID' "subject"
 
 opts_AddMandatory '--PEdir' 'PEdir' 'Path' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA"
 
@@ -231,8 +231,8 @@ MissingFileFlag="EMPTY" # String used in the input arguments to indicate that a 
 b0dist=45               # Minimum distance in volumes between b0s considered for preprocessing
 
 # Establish output directory paths
-outdir=${StudyFolder}/${Subject}/${DWIName}
-outdirT1w=${StudyFolder}/${Subject}/T1w/${DWIName}
+outdir=${StudyFolder}/${Session}/${DWIName}
+outdirT1w=${StudyFolder}/${Session}/T1w/${DWIName}
 
 # Delete any existing output sub-directories
 if [ -d ${outdir} ]; then

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -36,6 +36,8 @@ InputBrainMask=$(getopt1 "--brainmask" "$@")          # "$9" #Freesurfer Brain M
 GdcorrectionFlag=$(getopt1 "--gdflag" "$@")           # "$10"#Flag for gradient nonlinearity correction (0/1 for Off/On)
 DiffRes=$(getopt1 "--diffresol" "$@")                 # "$11"#Diffusion resolution in mm (assume isotropic)
 dof=$(getopt1 "--dof" "$@")                           # Degrees of freedom for registration to T1w (defaults to 6)
+T1wCross2LongXfm=$(getopt1 "--t1w_cross2long_xfm" "$@") # Additional transform for the longitudinal processing.
+
 
 # Output Variables
 T1wOutputDirectory=$(getopt1 "--datadiffT1wdir" "$@") # "$12" #Path to T1w space diffusion data (for producing output)
@@ -45,26 +47,31 @@ QAImage=$(getopt1 "--QAimage" "$@")                   # "$14" #Temporary file fo
 # Set default option values
 dof=$(defaultopt $dof 6)
 
+IsLongitudinal=0
+if [ -n "$T1wCross2LongXfm" ]; then IsLongitudinal=1; fi
+
 # Paths for scripts etc (uses variables defined in SetUpHCPPipeline.sh)
 GlobalScripts=${HCPPIPEDIR_Global}
 
 T1wBrainImageFile=$(basename $T1wBrainImage)
 regimg="nodif"
 
-${FSLDIR}/bin/imcp "$T1wBrainImage" "$WorkingDirectory"/"$T1wBrainImageFile"
+if (( ! IsLongitudinal )); then 
+	${FSLDIR}/bin/imcp "$T1wBrainImage" "$WorkingDirectory"/"$T1wBrainImageFile"
 
-#b0 FLIRT BBR and bbregister to T1w
-${GlobalScripts}/epi_reg_dof --dof=${dof} --epi="$DataDirectory"/"$regimg" --t1="$T1wImage" --t1brain="$WorkingDirectory"/"$T1wBrainImageFile" --out="$WorkingDirectory"/"$regimg"2T1w_initII
+	#b0 FLIRT BBR and bbregister to T1w
+	${GlobalScripts}/epi_reg_dof --dof=${dof} --epi="$DataDirectory"/"$regimg" --t1="$T1wImage" --t1brain="$WorkingDirectory"/"$T1wBrainImageFile" --out="$WorkingDirectory"/"$regimg"2T1w_initII
 
-${FSLDIR}/bin/applywarp --rel --interp=spline -i "$DataDirectory"/"$regimg" -r "$T1wImage" --premat="$WorkingDirectory"/"$regimg"2T1w_initII_init.mat -o "$WorkingDirectory"/"$regimg"2T1w_init.nii.gz
-${FSLDIR}/bin/applywarp --rel --interp=spline -i "$DataDirectory"/"$regimg" -r "$T1wImage" --premat="$WorkingDirectory"/"$regimg"2T1w_initII.mat -o "$WorkingDirectory"/"$regimg"2T1w_initII.nii.gz
-${FSLDIR}/bin/fslmaths "$WorkingDirectory"/"$regimg"2T1w_initII.nii.gz -div "$BiasField" "$WorkingDirectory"/"$regimg"2T1w_restore_initII.nii.gz
+	${FSLDIR}/bin/applywarp --rel --interp=spline -i "$DataDirectory"/"$regimg" -r "$T1wImage" --premat="$WorkingDirectory"/"$regimg"2T1w_initII_init.mat -o "$WorkingDirectory"/"$regimg"2T1w_init.nii.gz
+	${FSLDIR}/bin/applywarp --rel --interp=spline -i "$DataDirectory"/"$regimg" -r "$T1wImage" --premat="$WorkingDirectory"/"$regimg"2T1w_initII.mat -o "$WorkingDirectory"/"$regimg"2T1w_initII.nii.gz
+	${FSLDIR}/bin/fslmaths "$WorkingDirectory"/"$regimg"2T1w_initII.nii.gz -div "$BiasField" "$WorkingDirectory"/"$regimg"2T1w_restore_initII.nii.gz
 
-SUBJECTS_DIR="$FreeSurferSubjectFolder"
-export SUBJECTS_DIR
-# Use "hidden" bbregister DOF options (--6 (default), --9, or --12 are supported)
-${FREESURFER_HOME}/bin/bbregister --s "$FreeSurferSubjectID" --mov "$WorkingDirectory"/"$regimg"2T1w_restore_initII.nii.gz --surf white.deformed --init-reg "$FreeSurferSubjectFolder"/"$FreeSurferSubjectID"/mri/transforms/eye.dat --bold --reg "$WorkingDirectory"/EPItoT1w.dat --${dof} --o "$WorkingDirectory"/"$regimg"2T1w.nii.gz
-${FREESURFER_HOME}/bin/tkregister2 --noedit --reg "$WorkingDirectory"/EPItoT1w.dat --mov "$WorkingDirectory"/"$regimg"2T1w_restore_initII.nii.gz --targ "$T1wImage".nii.gz --fslregout "$WorkingDirectory"/diff2str_fs.mat
+	SUBJECTS_DIR="$FreeSurferSubjectFolder"
+	export SUBJECTS_DIR
+	# Use "hidden" bbregister DOF options (--6 (default), --9, or --12 are supported)
+	${FREESURFER_HOME}/bin/bbregister --s "$FreeSurferSubjectID" --mov "$WorkingDirectory"/"$regimg"2T1w_restore_initII.nii.gz --surf white.deformed --init-reg "$FreeSurferSubjectFolder"/"$FreeSurferSubjectID"/mri/transforms/eye.dat --bold --reg "$WorkingDirectory"/EPItoT1w.dat --${dof} --o "$WorkingDirectory"/"$regimg"2T1w.nii.gz
+	${FREESURFER_HOME}/bin/tkregister2 --noedit --reg "$WorkingDirectory"/EPItoT1w.dat --mov "$WorkingDirectory"/"$regimg"2T1w_restore_initII.nii.gz --targ "$T1wImage".nii.gz --fslregout "$WorkingDirectory"/diff2str_fs.mat
+fi
 
 ${FSLDIR}/bin/convert_xfm -omat "$WorkingDirectory"/diff2str.mat -concat "$WorkingDirectory"/diff2str_fs.mat "$WorkingDirectory"/"$regimg"2T1w_initII.mat
 ${FSLDIR}/bin/convert_xfm -omat "$WorkingDirectory"/str2diff.mat -inverse "$WorkingDirectory"/diff2str.mat

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -24,10 +24,10 @@ defaultopt() {
 ################################################## OPTION PARSING #####################################################
 # Input Variables
 
-FreeSurferSubjectFolder=$(getopt1 "--t1folder" "$@")  # "$1" #${StudyFolder}/${Subject}/T1w
-FreeSurferSubjectID=$(getopt1 "--subject" "$@")       # "$2" #Subject ID
-WorkingDirectory=$(getopt1 "--workingdir" "$@")       # "$3" #Path to registration working dir, e.g. ${StudyFolder}/${Subject}/Diffusion/reg
-DataDirectory=$(getopt1 "--datadiffdir" "$@")         # "$4" #Path to diffusion space diffusion data, e.g. ${StudyFolder}/${Subject}/Diffusion/data
+FreeSurferSubjectFolder=$(getopt1 "--t1folder" "$@")  # "$1" #${StudyFolder}/${Session}/T1w
+FreeSurferSubjectID=$(getopt1 "--session" "$@")       # "$2" #Session ID
+WorkingDirectory=$(getopt1 "--workingdir" "$@")       # "$3" #Path to registration working dir, e.g. ${StudyFolder}/${Session}/Diffusion/reg
+DataDirectory=$(getopt1 "--datadiffdir" "$@")         # "$4" #Path to diffusion space diffusion data, e.g. ${StudyFolder}/${Session}/Diffusion/data
 T1wImage=$(getopt1 "--t1" "$@")                       # "$5" #T1w_acpc_dc image
 T1wRestoreImage=$(getopt1 "--t1restore" "$@")         # "$6" #T1w_acpc_dc_restore image
 T1wBrainImage=$(getopt1 "--t1restorebrain" "$@")      # "$7" #T1w_acpc_dc_restore_brain image

--- a/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
+++ b/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
@@ -1,0 +1,151 @@
+#!/bin/bash 
+
+StudyFolder="my_study_folder" #Location of Subject folders (named by subjectID)
+Subjects=(HCA6002236) #list of subject IDs
+PossibleVisits=(V1_MR V2_MR V3_MR)
+ExcludeVisits=()
+Templates=(HCA6002236_V1_V2_V3)
+
+EnvironmentScript="<hcp pipelines install dir>/scripts/SetUpHCPPipeline.sh" #Pipeline environment script
+
+# Requirements for this script
+#  installed versions of: FSL, FreeSurfer, Connectome Workbench (wb_command), gradunwarp (HCP version)
+#  environment: HCPPIPEDIR, FSLDIR, FREESURFER_HOME, CARET7DIR, PATH for gradient_unwarp.py
+
+#Set up pipeline environment variables and software
+source "$EnvironmentScript"
+
+# Log the originating call
+echo "$@"
+
+function identify_timepoints
+{
+    local subject=$1
+    local tplist=""
+    local tp visit n
+
+    #build the list of timepoints
+    n=0
+    for visit in ${PossibleVisits[*]}; do
+        tp="${subject}_${visit}"
+        if [ -d "$StudyFolder/$tp" ] && ! [[ " ${ExcludeVisits[*]+${ExcludeVisits[*]}} " =~ [[:space:]]"$tp"[[:space:]] ]]; then
+             if (( n==0 )); then 
+                    tplist="$tp"
+             else
+                    tplist="$tplist@$tp"
+             fi
+        fi
+        ((n++))
+    done
+    echo $tplist
+}
+
+#Assume that submission nodes have OPENMP enabled (needed for eddy - at least 8 cores suggested for HCP data)
+#NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
+#DO NOT include "-q " at the beginning
+#default to no queue, implying run local
+QUEUE="long.q"
+#QUEUE="hcp_priority.q"
+
+#specify PRINTCOM="echo" to echo commands the pipeline would run, instead of running them
+#this appears to be fully implemented in the diffusion pipeline
+PRINTCOM=""
+#PRINTCOM="echo"
+
+########################################## INPUTS ########################################## 
+
+#Scripts called by this script do assume they run on the outputs of the PreFreeSurfer Pipeline,
+#which is a prerequisite for this pipeline
+
+#Scripts called by this script do NOT assume anything about the form of the input names or paths.
+#This batch script assumes the HCP raw data naming convention, e.g.
+
+#	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir95_RL.nii.gz
+#	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir96_RL.nii.gz
+#	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir97_RL.nii.gz
+#	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir95_LR.nii.gz
+#	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir96_LR.nii.gz
+#	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir97_LR.nii.gz
+
+#Change Scan Settings: Echo Spacing and PEDir to match your images
+#These are set to match the HCP Protocol by default
+
+#If using gradient distortion correction, use the coefficents from your scanner
+#The HCP gradient distortion coefficents are only available through Siemens
+#Gradient distortion in standard scanners like the Trio is much less than for the HCP Skyra.
+
+######################################### DO WORK ##########################################
+for i in "${!Subjects[@]}"; do
+	Subject="${Subjects[i]}"
+	echo $Subject
+	TemplateLong="${Templates[i]}"
+	Timepoint_list_cross_at_separated=$(identify_timepoints "$Subject")
+	IFS=@ read -r -a Timepoint_list_cross <<< "${Timepoint_list_cross_at_separated}"
+	echo "${SCRIPT_NAME}: Processing Subject: ${Subject}"
+	
+	for TimepointCross in "${Timepoint_list_cross[@]}"; do		
+		TimepointLong=${TimepointCross}.long.${TemplateLong}
+		echo "Processing Timepoint: ${TimepointLong}"
+	    #Input Variables
+	    RawDataDir="$StudyFolder/$TimepointCross/unprocessed/Diffusion" #Folder where unprocessed diffusion data are
+
+	    # PosData is a list of files (separated by ‘@‘ symbol) having the same phase encoding (PE) direction 
+	    # and polarity. Similarly for NegData, which must have the opposite PE polarity of PosData.
+	    # The PosData files will come first in the merged data file that forms the input to ‘eddy’.
+	    # The particular PE polarity assigned to PosData/NegData is not relevant; the distortion and eddy 
+	    # current correction will be accurate either way.
+	    #
+	    # NOTE that PosData defines the reference space in 'topup' and 'eddy' AND it is assumed that
+	    # each scan series begins with a b=0 acquisition, so that the reference space in both
+	    # 'topup' and 'eddy' will be defined by the same (initial b=0) volume.
+	    #
+	    # On Siemens scanners, we typically use 'R>>L' ("RL") as the 'positive' direction for left-right
+	    # PE data, and 'P>>A' ("PA") as the 'positive' direction for anterior-posterior PE data.
+	    # And conversely, "LR" and "AP" are then the 'negative' direction data.
+	    # However, see preceding comment that PosData defines the reference space; so if you want the
+	    # first temporally acquired volume to define the reference space, then that series needs to be
+	    # the first listed series in PosData.
+	    #
+	    # Note that only volumes (gradient directions) that have matched Pos/Neg pairs are ultimately
+	    # propagated to the final output, *and* these pairs will be averaged to yield a single
+	    # volume per pair. This reduces file size by 2x (and thence speeds subsequent processing) and
+	    # avoids having volumes with different SNR features/ residual distortions.
+	    # [This behavior can be changed through the hard-coded 'CombineDataFlag' variable in the 
+	    # DiffPreprocPipeline_PostEddy.sh script if necessary].
+	  
+  	    PosData="${RawDataDir}/${TimepointCross}_dMRI_dir98_PA.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_PA.nii.gz"
+	    NegData="${RawDataDir}/${TimepointCross}_dMRI_dir98_AP.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_AP.nii.gz"
+	  
+	    # "Effective" Echo Spacing of dMRI image (now specified in seconds for the dMRI processing)
+	    # EchoSpacing = 1/(BWPPPE * ReconMatrixPE)
+	    #   where BWPPPE is the "BandwidthPerPixelPhaseEncode" = DICOM field (0019,1028) for Siemens, and
+	    #   ReconMatrixPE = size of the reconstructed image in the PE dimension
+	    # In-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
+	    # all potentially need to be accounted for (which they are in Siemen's reported BWPPPE)
+	    EchoSpacingSec=0.00078
+	  
+	    PEdir=2 #Use 1 for Left-Right Phase Encoding, 2 for Anterior-Posterior
+
+	    # Gradient distortion correction
+	    # Set to NONE to skip gradient distortion correction
+	    # (These files are considered proprietary and therefore not provided as part of the HCP Pipelines -- contact Siemens to obtain)
+	    # Gdcoeffs="${HCPPIPEDIR_Config}/coeff_SC72C_Skyra.grad"
+	    Gdcoeffs="NONE"
+
+	    if [[ "$QUEUE" == "" ]] ; then
+		    echo "About to locally run ${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline.sh"
+  		    queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
+	    else
+		    echo "About to use fsl_sub to queue ${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline.sh"
+		    queuing_command=("${FSLDIR}/bin/fsl_sub" -q "$QUEUE")
+	    fi
+
+	    "${queuing_command[@]}" "${HCPPIPEDIR}"/DiffusionPreprocessing/DiffPreprocPipeline.sh \
+		  --posData="${PosData}" --negData="${NegData}" \
+		  --path="${StudyFolder}" --session="${TimepointLong}" \
+		  --echospacing-seconds="${EchoSpacingSec}" --PEdir="${PEdir}" \
+		  --gdcoeffs="${Gdcoeffs}" \
+		  --gpu=FALSE  \
+		  --printcom="$PRINTCOM"  
+	done
+done

--- a/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
+++ b/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
@@ -1,12 +1,12 @@
 #!/bin/bash 
 
-StudyFolder="my_study_folder" #Location of Subject folders (named by subjectID)
+StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by subjectID)
 Subjects=(HCA6002236) #list of subject IDs
 PossibleVisits=(V1_MR V2_MR V3_MR)
 ExcludeVisits=()
 Templates=(HCA6002236_V1_V2_V3)
 
-EnvironmentScript="<hcp pipelines install dir>/scripts/SetUpHCPPipeline.sh" #Pipeline environment script
+EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script
 
 # Requirements for this script
 #  installed versions of: FSL, FreeSurfer, Connectome Workbench (wb_command), gradunwarp (HCP version)
@@ -39,6 +39,9 @@ function identify_timepoints
     done
     echo $tplist
 }
+
+
+
 
 #Assume that submission nodes have OPENMP enabled (needed for eddy - at least 8 cores suggested for HCP data)
 #NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
@@ -142,10 +145,12 @@ for i in "${!Subjects[@]}"; do
 
 	    "${queuing_command[@]}" "${HCPPIPEDIR}"/DiffusionPreprocessing/DiffPreprocPipeline.sh \
 		  --posData="${PosData}" --negData="${NegData}" \
-		  --path="${StudyFolder}" --session="${TimepointLong}" \
+		  --path="${StudyFolder}" --session="${TimepointCross}" \
 		  --echospacing-seconds="${EchoSpacingSec}" --PEdir="${PEdir}" \
 		  --gdcoeffs="${Gdcoeffs}" \
 		  --gpu=FALSE  \
-		  --printcom="$PRINTCOM"  
+		  --is-longitudinal=TRUE \
+		  --longitudinal-session="$TimepointLong" \
+  		  --printcom="$PRINTCOM"		  
 	done
 done


### PR DESCRIPTION
Longitudinal preprocessing saves time by using cross-sectional diffusion eddy_correct output. 
Requirements for the processing directory:
1) Structural timepoints with diffusion preprocessing
2) Longitudinal timepoints with all structural pipelines run