### PR TITLE
Longitudinal ICAFix+fMRIVolume multi-echo fix

### DIFF
--- a/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
+++ b/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+#set -xv
+
+# Global default values
+DEFAULT_STUDY_FOLDER="${HOME}/data/Pipelines_ExampleData"
+DEFAULT_SUBJECT_LIST="HCA6002236"
+DEFAULT_ENVIRONMENT_SCRIPT="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh"
+DEFAULT_RUN_LOCAL="FALSE"
+DEFAULT_POSSIBLE_VISITS="V1_MR V2_MR V3_MR"
+DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3"
+
+#
+# Function Description
+#	Get the command line options for this script
+#
+# Global Output Variables
+#	${StudyFolder}			- Path to folder containing all subjects data in subdirectories named 
+#							  for the subject id
+#	${Subjlist}				- Space delimited list of subject IDs
+#	${EnvironmentScript}	- Script to source to setup pipeline environment
+#	${RunLocal}				- Indication whether to run this processing "locally" i.e. not submit
+#							  the processing to a cluster or grid
+#
+get_options() {
+	local scriptName=$(basename ${0})
+	local arguments=("$@")
+
+	# initialize global output variables
+	StudyFolder="${DEFAULT_STUDY_FOLDER}"
+	Subjlist="${DEFAULT_SUBJECT_LIST}"
+	EnvironmentScript="${DEFAULT_ENVIRONMENT_SCRIPT}"
+	RunLocal="${DEFAULT_RUN_LOCAL}"
+	
+	# make these into command-line options later if desired.
+	PossibleVisits=($DEFAULT_POSSIBLE_VISITS)
+	Templates=($DEFAULT_TEMPLATE_LIST)
+
+	# parse arguments
+	local index=0
+	local numArgs=${#arguments[@]}
+	local argument
+
+	while [ ${index} -lt ${numArgs} ]
+	do
+		argument=${arguments[index]}
+
+		case ${argument} in
+			--StudyFolder=*)
+				StudyFolder=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--Subject=*)
+				Subjlist=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--EnvironmentScript=*)
+				EnvironmentScript=${argument#*=}
+				index=$(( index + 1 ))
+				;;
+			--runlocal | --RunLocal)
+				RunLocal="TRUE"
+				index=$(( index + 1 ))
+				;;
+			*)
+				echo "ERROR: Unrecognized Option: ${argument}"
+				exit 1
+				;;
+		esac
+	done
+
+	# check required parameters
+	if [ -z ${StudyFolder} ]
+	then
+		echo "ERROR: StudyFolder not specified"
+		exit 1
+	fi
+
+	if [ -z "${Subjlist}" ]
+	then
+		echo "ERROR: Subjlist not specified"
+		exit 1
+	fi
+
+	if [ -z ${EnvironmentScript} ]
+	then
+		echo "ERROR: EnvironmentScript not specified"
+		exit 1
+	fi
+
+	if [ -z ${RunLocal} ]
+	then
+		echo "ERROR: RunLocal is an empty string"
+		exit 1
+	fi
+
+	# report options
+	echo "-- ${scriptName}: Specified Command-Line Options: -- Start --"
+	echo "   StudyFolder: ${StudyFolder}"
+	echo "   Subjlist: ${Subjlist}"
+	echo "	 Templates: ${Templates[@]}"
+	echo "	 Possible visits: ${PossibleVisits[@]}"
+	echo "   EnvironmentScript: ${EnvironmentScript}"
+	echo "   RunLocal: ${RunLocal}"
+	echo "-- ${scriptName}: Specified Command-Line Options: -- End --"
+}  # get_options()
+
+# Function description
+#
+# For the given subject, identify_timepoins creates a string listing @ separated visits/timepoints to process
+# Uses StudyFolder, ExcludeVisits, PossibleVisits global variables as input.
+# Subject must be supplied as the first argument. 
+
+function identify_timepoints
+{
+    local subject=$1
+    local tplist=""
+    local tp visit n
+
+    #build the list of timepoints
+    n=0
+    for visit in ${PossibleVisits[*]}; do
+        tp="${subject}_${visit}"
+        if [ -d "$StudyFolder/$tp" ] && ! [[ " ${ExcludeVisits[*]+${ExcludeVisits[*]}} " =~ [[:space:]]"$tp"[[:space:]] ]]; then
+             if (( n==0 )); then 
+                    tplist="$tp"
+             else
+                    tplist="$tplist@$tp"
+             fi
+        fi
+        ((n++))
+    done
+    echo $tplist
+}
+
+#
+# Function Description
+#	Main processing of this script
+#
+#	Gets user specified command line options and runs a batch of ReApplyFix processing
+#
+main() {
+	# get command line options
+	get_options "$@"
+
+	# set up pipeline environment variables and software
+	source "$EnvironmentScript"
+
+	# set list of fMRI on which to run ReApplyFixPipeline, separate MR FIX groups with %, use spaces (or @ like dedrift...) to otherwise separate runs
+	# ReApplyFixPipeline
+	fMRINames="rfMRI_REST1_AP@rfMRI_REST1_PA@tfMRI_VISMOTOR_PA@tfMRI_CARIT_PA@tfMRI_FACENAME_PA@rfMRI_REST2_AP@rfMRI_REST2_PA"
+  
+	# specify the name of concatenated folder
+	# if run Multi-Run specify ConcatNames as null string
+	ConcatNames="fMRI_CONCAT_ALL"
+	#ConcatNames="tfMRI_WM_GAMBLING_MOTOR_RL_LR@tfMRI_LANGUAGE_SOCIAL_RELATIONAL_EMOTION_RL_LR"
+
+	# set highpass
+	highpass=2000
+	
+	#NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
+	#DO NOT include "-q " at the beginning
+	#default to no queue, implying run local
+	#QUEUE=""
+	QUEUE="short.q"
+
+	# regression mode
+	RegName="NONE"
+
+	# low res mesh
+	LowResMesh=32
+
+	# matlab mode
+	# 0 = Use compiled MATLAB
+	# 1 = Use interpreted MATLAB
+	# 2 = Use interpreted Octave
+	MatlabMode=1
+
+	# motion regression or not
+	MotionReg=FALSE
+
+	# clean up intermediates
+	DeleteIntermediates=FALSE
+
+	#MR FIX config support for non-HCP settings
+	config=""
+	processingmode="HCPStyleData"
+	#uncomment the below two lines for legacy-style data
+	#config="$HCPPIPEDIR"/ICAFIX/config/legacy.conf
+	#processingmode="LegacyStyleData"
+
+	if [[ "${RunLocal}" == "TRUE" || "$QUEUE" == "" ]]; then
+		queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
+	else
+		queuing_command=("${FSLDIR}/bin/fsl_sub" -q "$QUEUE")
+	fi
+
+	for Subject in ${Subjlist}; do
+		TemplateLong="${Templates[i]}"
+		Timepoint_list_cross_at_separated=$(identify_timepoints "$Subject")
+		IFS=@ read -r -a Timepoint_list_cross <<< "${Timepoint_list_cross_at_separated}"
+		
+		for TimepointCross in "${Timepoint_list_cross[@]}"; do
+			TimepointLong=${TimepointCross}.long.${TemplateLong}
+			if [ -z ${ConcatNames} ]; then
+					echo "Single run legacy processing is not supported in longitudinal mode."
+					exit -1
+			else # Multi-Run				
+				#need arrays to sanity check number of concat groups
+				IFS=' @' read -a concatarray <<< "${ConcatNames}"
+				IFS=% read -a fmriarray <<< "${fMRINames}"
+				
+				if ((${#concatarray[@]} != ${#fmriarray[@]})); then
+					echo "ERROR: number of names in ConcatNames does not match number of fMRINames groups"
+					exit 1
+				fi
+
+				for ((i = 0; i < ${#concatarray[@]}; ++i)); do
+					ConcatName="${concatarray[$i]}"
+					fMRINamesGroup="${fmriarray[$i]}"
+				
+					"${queuing_command[@]}" "$HCPPIPEDIR"/ICAFIX/ReApplyFixMultiRunPipeline.sh \
+						--path="$StudyFolder" \
+						--session="$TimepointCross" \
+						--fmri-names="$fMRINamesGroup" \
+						--high-pass="$highpass" \
+						--reg-name="$RegName" \
+						--concat-fmri-name="$ConcatName" \
+						--low-res-mesh="$LowResMesh" \
+						--matlab-run-mode="$MatlabMode" \
+						--motion-regression="$MotionReg" \
+						--config="$config" \
+						--processing-mode="$processingmode" \
+						--is-longitudinal="TRUE" \
+						--longitudinal-session="$TimepointLong"
+					
+					echo "${TimepointCross} ${TimepointLong} ${ConcatName}"					
+				done
+			fi
+		done #iterating over timepoints
+	done #iterating over subjects
+}  # main()
+
+#
+# Invoke the main function to get things started
+#
+main "$@"
+

--- a/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
+++ b/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
@@ -9,6 +9,7 @@ DEFAULT_RUN_LOCAL="FALSE"
 DEFAULT_POSSIBLE_VISITS="V1_MR V2_MR V3_MR"
 DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3"
 
+ExcludeVisits=()
 #
 # Function Description
 #	Get the command line options for this script

--- a/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
+++ b/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
 #set -xv
 
+
+# Naming assumptions
+# This script assumes that:
+# 1. The cross-sectional session dirs are named <Subject>_<PossibleVisit>, 
+# 2. Longitudinal session dirs are named <Subject>_<Possible_Visit>.long.<Template>,
+# 3. Both longitudinal and cross-sectional sessions exist in the study folder.
+
 # Global default values
 DEFAULT_STUDY_FOLDER="${HOME}/data/Pipelines_ExampleData"
-DEFAULT_SUBJECT_LIST="HCA6002236"
+DEFAULT_SUBJECT_LIST="HCA6002236 HCA6002237"
 DEFAULT_ENVIRONMENT_SCRIPT="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh"
 DEFAULT_RUN_LOCAL="FALSE"
+
 DEFAULT_POSSIBLE_VISITS="V1_MR V2_MR V3_MR"
-DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3"
+
+# The template list should include labels for the longitudinal template of each subject, similar to those used in longitudinal FreeSurfer.
+DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3 HCA6002237_V1_V2_V3"
 
 ExcludeVisits=()
 #
@@ -15,12 +25,12 @@ ExcludeVisits=()
 #	Get the command line options for this script
 #
 # Global Output Variables
-#	${StudyFolder}			- Path to folder containing all subjects data in subdirectories named 
-#							  for the subject id
-#	${Subjlist}				- Space delimited list of subject IDs
-#	${EnvironmentScript}	- Script to source to setup pipeline environment
-#	${RunLocal}				- Indication whether to run this processing "locally" i.e. not submit
-#							  the processing to a cluster or grid
+#	${StudyFolder}			-	Path to folder containing all subjects data in subdirectories named 
+#								for the subject id
+#	${Subjlist}				-	Space delimited list of subject IDs
+#	${EnvironmentScript}	-	Script to source to setup pipeline environment
+#	${RunLocal}				-	Indication whether to run this processing "locally" i.e. not submit
+#								the processing to a cluster or grid
 #
 get_options() {
 	local scriptName=$(basename ${0})
@@ -107,7 +117,7 @@ get_options() {
 
 # Function description
 #
-# For the given subject, identify_timepoins creates a string listing @ separated visits/timepoints to process
+# For the given subject, identify_timepoints creates a string listing @ separated visits/timepoints to process
 # Uses StudyFolder, ExcludeVisits, PossibleVisits global variables as input.
 # Subject must be supplied as the first argument. 
 

--- a/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
+++ b/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
@@ -22,7 +22,7 @@ DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3 HCA6002237_V1_V2_V3"
 ExcludeVisits=()
 #
 # Function Description
-#   Get the command line options for this script
+# Get the command line options for this script
 #
 # Global Output Variables
 #   ${StudyFolder}           - Path to folder containing all subjects data in subdirectories named 

--- a/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
+++ b/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
@@ -156,13 +156,13 @@ main() {
 	#ConcatNames="tfMRI_WM_GAMBLING_MOTOR_RL_LR@tfMRI_LANGUAGE_SOCIAL_RELATIONAL_EMOTION_RL_LR"
 
 	# set highpass
-	highpass=2000
+	highpass=0
 	
 	#NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
 	#DO NOT include "-q " at the beginning
 	#default to no queue, implying run local
 	#QUEUE=""
-	QUEUE="short.q"
+	QUEUE="hcp_priority.q"
 
 	# regression mode
 	RegName="NONE"

--- a/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
+++ b/Examples/Scripts/ReApplyFixMultiRunBatch-long.sh
@@ -22,15 +22,15 @@ DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3 HCA6002237_V1_V2_V3"
 ExcludeVisits=()
 #
 # Function Description
-#	Get the command line options for this script
+#   Get the command line options for this script
 #
 # Global Output Variables
-#	${StudyFolder}			-	Path to folder containing all subjects data in subdirectories named 
-#								for the subject id
-#	${Subjlist}				-	Space delimited list of subject IDs
-#	${EnvironmentScript}	-	Script to source to setup pipeline environment
-#	${RunLocal}				-	Indication whether to run this processing "locally" i.e. not submit
-#								the processing to a cluster or grid
+#   ${StudyFolder}           - Path to folder containing all subjects data in subdirectories named 
+#                              for the subject id
+#   ${Subjlist}              - Space delimited list of subject IDs
+#   ${EnvironmentScript}     - Script to source to setup pipeline environment
+#   ${RunLocal}              - Indication whether to run this processing "locally" i.e. not submit
+#                              the processing to a cluster or grid
 #
 get_options() {
 	local scriptName=$(basename ${0})

--- a/ICAFIX/ReApplyFixMultiRunPipeline.sh
+++ b/ICAFIX/ReApplyFixMultiRunPipeline.sh
@@ -49,7 +49,7 @@ G_DEFAULT_LOW_RES_MESH=32
 
 opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder containing all sessions" '--path'
 
-opts_AddMandatory '--session' 'SessionCross' 'session ID' "(e.g. 100610)" "--subject"
+opts_AddMandatory '--session' 'SessionCross' 'session ID' "(e.g. 100610_V1)" "--subject"
 
 opts_AddMandatory '--fmri-names' 'fMRINames' 'fMRI names' "an '@' symbol separated list of fMRI scan names (no whitespace, e.g. rfMRI_REST1_LR@rfMRI_REST1_RL).  Do not include path, nifti extension, or the 'hp' string.  All runs are assumed to have the same repetition time (TR)."
 
@@ -185,7 +185,13 @@ have_hand_reclassification()
 # ------------------------------------------------------------------------------
 function copy_to_longitudinal()
 {
-	local StudyFolder="$1" SessionCross="$2" SessionLong="$3" fMRINames="$4" ConcatName="$5" HighPass="$6"
+	local StudyFolder="$1"
+	local SessionCross="$2" 
+	local SessionLong="$3" 
+	local fMRINames="$4" 
+	local ConcatName="$5" 
+	local HighPass="$6"
+
 	local fmri S T
 	#copy for concatentated run
 	S="$StudyFolder/$SessionCross/MNINonLinear/Results/$ConcatName"
@@ -193,42 +199,42 @@ function copy_to_longitudinal()
 	local file files_to_copy="Movement_Regressors_demean.txt ReclassifyAsNoise.txt ReclassifyAsSignal.txt"
 	mkdir -p "$T"
 	for file in $files_to_copy; do
-		cp "$S"/"$file" "$T"/
+		cp -p "$S"/"$file" "$T"/
 	done
 	
 	local ICADir="$S/${ConcatName}_hp$HighPass.ica"
 	local ICADirLong="$T/${ConcatName}_hp$HighPass.ica"
 	mkdir -p "$ICADirLong"				
 	if [ -f "$ICADir/HandNoise.txt" ]; then 
-		cp $ICADir/HandNoise.txt $ICADirLong/
+		cp -p "$ICADir/HandNoise.txt" "$ICADirLong"/
 	fi
-	files_to_copy="fix4melview_HCP_Style_Single_Multirun_Dedrift_thr10.txt fix4melview_HCP_Style_Single_Multirun_Dedrift_thr10.wb_annsub.csv hand_labels_noise.txt HandNoise.txt \
-	HandSignal.txt Noise.txt ReclassifyAsNoise.txt ReclassifyAsSignal.txt Signal.txt .fix"
+	files_to_copy="fix4melview_HCP_Style_Single_Multirun_Dedrift_thr10.txt fix4melview_HCP_Style_Single_Multirun_Dedrift_thr10.wb_annsub.csv \
+		hand_labels_noise.txt HandNoise.txt HandSignal.txt Noise.txt ReclassifyAsNoise.txt ReclassifyAsSignal.txt Signal.txt .fix"
 	for file in $files_to_copy; do
-		cp $ICADir/$file $ICADirLong/
+		cp -p "$ICADir"/"$file" "$ICADirLong"/
 	done 
 	
-	mkdir -p $ICADirLong/mc
-	cp $ICADir/mc/prefiltered_func_data_mcf_conf.nii.gz $ICADirLong/mc/
-	cp $ICADir/mc/prefiltered_func_data_mcf_conf_hp.nii.gz $ICADirLong/mc/
-	cp $ICADir/mc/prefiltered_func_data_mcf.par $ICADirLong/mc/
+	mkdir -p "$ICADirLong/mc"
+	cp -p "$ICADir/mc/prefiltered_func_data_mcf_conf.nii.gz" "$ICADirLong"/mc/
+	cp -p "$ICADir/mc/prefiltered_func_data_mcf_conf_hp.nii.gz" "$ICADirLong"/mc/
+	cp -p "$ICADir/mc/prefiltered_func_data_mcf.par" "$ICADirLong"/mc/
 	
-	mkdir -p $ICADirLong/fix/
-	cp $ICADir/fix/features.csv $ICADirLong/fix/
+	mkdir -p "$ICADirLong"/fix/
+	cp -p "$ICADir"/fix/features.csv "$ICADirLong"/fix/
 	
 	files_to_copy="eigenvalues_percent ICAVolumeSpace.txt melodic_FTmix melodic_FTmix.sdseries.nii \
-	melodic_ICstats melodic_mix melodic_mix.sdseries.nii melodic_Tmodes melodic_unmix"
-	mkdir -p $ICADirLong/filtered_func_data.ica
+		melodic_ICstats melodic_mix melodic_mix.sdseries.nii melodic_Tmodes melodic_unmix"
+	mkdir -p "$ICADirLong"/filtered_func_data.ica
 	for file in $files_to_copy; do
-		cp $ICADir/filtered_func_data.ica/$file $ICADirLong/filtered_func_data.ica/
+		cp -p "$ICADir"/filtered_func_data.ica/"$file" "$ICADirLong"/filtered_func_data.ica/
 	done	
 	
 	#copy for individual fMRI runs
-	for fmri in $fMRINames; do		
+	for fmri in $fMRINames; do
 		S="$StudyFolder/$SessionCross/MNINonLinear/Results/$fmri"
 		T="$StudyFolder/$SessionLong/MNINonLinear/Results/$fmri"
 		mkdir -p "$T"/"$fmri"_hp"$HighPass".ica/mc
-		cp "$S"/"$fmri"_hp"$HighPass".ica/mc/prefiltered_func_data_mcf.par "$T"/"$fmri"_hp"$HighPass".ica/mc/		
+		cp -p "$S"/"$fmri"_hp"$HighPass".ica/mc/prefiltered_func_data_mcf.par "$T"/"$fmri"_hp"$HighPass".ica/mc/		
 	done	
 }
 

--- a/ICAFIX/ReApplyFixMultiRunPipeline.sh
+++ b/ICAFIX/ReApplyFixMultiRunPipeline.sh
@@ -191,9 +191,9 @@ function copy_to_longitudinal()
 	S="$StudyFolder/$SessionCross/MNINonLinear/Results/$ConcatName"
 	T="$StudyFolder/$SessionLong/MNINonLinear/Results/$ConcatName"
 	local file files_to_copy="Movement_Regressors_demean.txt ReclassifyAsNoise.txt ReclassifyAsSignal.txt"
-	mkdir -p $T
+	mkdir -p "$T"
 	for file in $files_to_copy; do
-		cp $S/$file $T/
+		cp "$S"/"$file" "$T"/
 	done
 	
 	local ICADir="$S/${ConcatName}_hp$HighPass.ica"

--- a/ICAFIX/ReApplyFixMultiRunPipeline.sh
+++ b/ICAFIX/ReApplyFixMultiRunPipeline.sh
@@ -227,8 +227,8 @@ function copy_to_longitudinal()
 	for fmri in $fMRINames; do		
 		S="$StudyFolder/$SessionCross/MNINonLinear/Results/$fmri"
 		T="$StudyFolder/$SessionLong/MNINonLinear/Results/$fmri"
-		mkdir -p $T/${fmri}_hp$HighPass.ica/mc
-		cp $S/${fmri}_hp$HighPass.ica/mc/prefiltered_func_data_mcf.par $T/${fmri}_hp$HighPass.ica/mc/		
+		mkdir -p "$T"/"$fmri"_hp"$HighPass".ica/mc
+		cp "$S"/"$fmri"_hp"$HighPass".ica/mc/prefiltered_func_data_mcf.par "$T"/"$fmri"_hp"$HighPass".ica/mc/		
 	done	
 }
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -677,6 +677,8 @@ if (( ! IsLongitudinal )); then
         log_Msg "mkdir ${fMRIFolder}"
         mkdir "$fMRIFolder"
     fi
+
+    ${FSLDIR}/bin/imcp "$fMRITimeSeries" "$fMRIFolder"/"$OrigTCSName"
 else
     #copy directory structure.
 	mkdir -p "$ResultsFolderLong"
@@ -703,8 +705,6 @@ fi
 
 #All code until DistortionCorrection...BBRbased.sh is only run in cross-sectional mode.
 if (( ! IsLongitudinal )); then
-    ${FSLDIR}/bin/imcp "$fMRITimeSeries" "$fMRIFolder"/"$OrigTCSName"
-
     if [[ $nEcho -gt 1 ]] ; then
         EchoDir="${fMRIFolder}/MultiEcho"
         mkdir -p "$EchoDir"

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -810,9 +810,9 @@ if (( ! IsLongitudinal )); then
 fi # if (( ! IsLongitudinal ))
 
 #Split echos. 
+tcsEchoesOrig=();sctEchoesOrig=();tcsEchoesGdc=();sctEchoesGdc=();
 if [[ ${nEcho} -gt 1 ]]; then
     log_Msg "Splitting echo(s)"
-    tcsEchoesOrig=();sctEchoesOrig=();tcsEchoesGdc=();sctEchoesGdc=();
     for iEcho in $(seq 0 $((nEcho-1))) ; do
         tcsEchoesOrig[iEcho]="${OrigTCSName}_E$(printf "%02d" "$iEcho")"
         tcsEchoesGdc[iEcho]="${NameOffMRI}_gdc_E$(printf "%02d" "$iEcho")" # Is only first echo needed for the gdc tcs?
@@ -865,6 +865,7 @@ if (( IsLongitudinal )); then
     Session="$SessionLong"
     AtlasSpaceFolder="$AtlasSpaceFolderLong"
     ResultsFolder="$ResultsFolderLong"
+    EchoDir="${fMRIFolder}/MultiEcho"
 fi
 
 #EPI Distortion Correction and EPI to T1w Registration
@@ -1113,22 +1114,22 @@ ${FSLDIR}/bin/imrm "$fMRIFolder"/"$NameOffMRI"_gdc #This can be checked with the
 ${FSLDIR}/bin/imrm "$fMRIFolder"/"$NameOffMRI"_mc #This can be checked with the unmasked spatially corrected data
 
 # clean up split echo(s)
-if [[ $nEcho -gt 1 ]]; then
-    for iEcho in $(seq 0 $((nEcho-1))) ; do
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}"
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin"
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin_mask"
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_SBRef_nonlin"
+#if [[ $nEcho -gt 1 ]]; then
+#    for iEcho in $(seq 0 $((nEcho-1))) ; do
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}"
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin"
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin_mask"
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_SBRef_nonlin"
 
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesGdc[iEcho]}"
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesGdc[iEcho]}"
 
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesOrig[iEcho]}"
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}"
-        ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}_mask"
-    done
-    ${FSLDIR}/bin/imrm "${tcsEchoes[@]}"
-    ${FSLDIR}/bin/imrm "${tcsEchoesMu[@]}"
-fi
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesOrig[iEcho]}"
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}"
+#        ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}_mask"
+#    done
+#    ${FSLDIR}/bin/imrm "${tcsEchoes[@]}"
+#    ${FSLDIR}/bin/imrm "${tcsEchoesMu[@]}"
+#fi
 
 log_Msg "Completed!"
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -1120,23 +1120,23 @@ ${FSLDIR}/bin/imrm "$fMRIFolder"/"$NameOffMRI"_mc #This can be checked with the 
 #timepoint will fail, because in longitudinal mode these intermediate files are copied over and re-used.
 
 if (( IsLongitudinal )); then 
-	#clean up split echo(s)
-	if [[ $nEcho -gt 1 ]]; then
-	   for iEcho in $(seq 0 $((nEcho-1))) ; do
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}"
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin"
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin_mask"
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_SBRef_nonlin"
+    #clean up split echo(s)
+    if [[ $nEcho -gt 1 ]]; then
+       for iEcho in $(seq 0 $((nEcho-1))) ; do
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}"
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin"
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin_mask"
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_SBRef_nonlin"
 
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesGdc[iEcho]}"
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesGdc[iEcho]}"
 
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesOrig[iEcho]}"
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}"
-		   ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}_mask"
-	   done
-	   ${FSLDIR}/bin/imrm "${tcsEchoes[@]}"
-	   ${FSLDIR}/bin/imrm "${tcsEchoesMu[@]}"
-	fi
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesOrig[iEcho]}"
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}"
+           ${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}_mask"
+       done
+       ${FSLDIR}/bin/imrm "${tcsEchoes[@]}"
+       ${FSLDIR}/bin/imrm "${tcsEchoesMu[@]}"
+    fi
 fi
 
 log_Msg "Completed!"

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -1112,6 +1112,13 @@ ${RUN} cp ${fMRIFolder}/Movement_AbsoluteRMS_mean.txt ${ResultsFolder}
 #Basic Cleanup
 ${FSLDIR}/bin/imrm ${fMRIFolder}/${NameOffMRI}_nonlin_norm
 
+# remove the link to the original time series in longitudinal session
+# to avoid potential storage issue as
+# symlinks tend to become hard copies over time.
+if (( IsLongitudinal )); then 
+    rm ${fMRIFolder}/"$OrigTCSName".nii.gz
+fi
+
 #Econ
 #${FSLDIR}/bin/imrm "$fMRIFolder"/"$OrigTCSName"
 ${FSLDIR}/bin/imrm "$fMRIFolder"/"$NameOffMRI"_gdc #This can be checked with the SBRef

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -1122,7 +1122,8 @@ ${FSLDIR}/bin/imrm "$fMRIFolder"/"$NameOffMRI"_mc #This can be checked with the 
 #clean up split echo(s)
 if [[ $nEcho -gt 1 ]]; then
 	for iEcho in $(seq 0 $((nEcho-1))) ; do	
-		# In Cross-sectional mode, if the code below is executed, running in longitudinal mode on the same timepoint will fail, because in longitudinal mode these intermediate files are copied over and re-used.
+		# In Cross-sectional mode, if the code below is executed, running in longitudinal mode on the same timepoint will fail, 
+		# because in longitudinal mode these intermediate files are copied over and re-used.
 		# For this reason, --extra-multiecho-cleanup must be set to FALSE for cross-sectional if longitudinal processing is expected.
 		if (( IsLongitudinal || ExtraMultiEchoCleanup )); then
 			${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}"

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -683,7 +683,7 @@ else
         elif [ "$fname" == "${NameOffMRI}_orig_nonlin.nii.gz" -o "$fname" == "${NameOffMRI}_nonlin.nii.gz" ]; then 
         	continue
         else
-            cp -r --preserve=timestamps "$fd" "$fMRIFolderLong/"
+            cp -r "$fd" "$fMRIFolderLong/"
         fi
     done
 fi

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -679,8 +679,11 @@ else
         #create link to the original fMRI series
         if [ "$fname" == "${NameOffMRI}_orig.nii.gz" ]; then
             ln -sf ../../"$Session"/"${NameOffMRI}"/"$fname" "$fMRIFolderLong/$fname"
+        #skip large files that will be generated
+        elif [ "$fname" == "${NameOffMRI}_orig_nonlin.nii.gz" -o "$fname" == "${NameOffMRI}_nonlin.nii.gz" ]; then 
+        	continue
         else
-            cp -r -p "$fd" "$fMRIFolderLong/"
+            cp -r --preserve=timestamps "$fd" "$fMRIFolderLong/"
         fi
     done
 fi
@@ -1117,7 +1120,7 @@ ${FSLDIR}/bin/imrm ${fMRIFolder}/${NameOffMRI}_nonlin_norm
 # to avoid potential storage issue as
 # symlinks tend to become hard copies over time.
 if (( IsLongitudinal )); then 
-    rm ${fMRIFolder}/"$OrigTCSName".nii.gz
+    rm -f ${fMRIFolder}/"$OrigTCSName".nii.gz 
 fi
 
 #Econ

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -673,6 +673,7 @@ else
     #copy directory structure.
     mkdir -p "$ResultsFolderLong"
     fMRIFolderLong="$Path"/"$SessionLong"/"$NameOffMRI"
+    mkdir -p "$fMRIFolderLong"
     for fd in "$fMRIFolder"/*; do
         fname="$(basename "$fd")"
         #create link to the original fMRI series

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -442,9 +442,9 @@ if (( IsLongitudinal )); then
         log_Err_Abort "the --longitudinal-session must be specified and folder must exist in longitudinal mode"
     fi
     T1wCross2LongXfm=$Path/$SessionLong/T1w/xfms/T1w_cross_to_T1w_long.mat
-    if [ ! -f "$T1wCross2LongXfm" ]; then 
+    if [ ! -f "$T1wCross2LongXfm" ]; then
         log_Err_Abort "Longitudinal session $SessionLong: cross-sectional to longitudinal transform $T1wCross2LongXfm does not exist. Has longtudinal PostFreesurfer been run?"
-    fi 
+    fi
     if [ -n "$fMRIReference" ] && [ "$fMRIReference" != "NONE" ]; then
         log_Warn "fmri reference is used during the initial cross-sectional run on a timepoint, but irrelevant (and therefore the argument is ignored) during the subsequent longitudinal call on the same timepoint."
     fi
@@ -664,14 +664,14 @@ ResultsFolder=$ResultsFolderCross
 function cp_link
 {
     local src="$1" dst="$2"
-    if [ -L "$src" ]; then 
-        cp -a $src $dst 
+    if [ -L "$src" ]; then
+        cp -a $src $dst
     else
         ln -sf $src $dst
     fi
 }
 
-if (( ! IsLongitudinal )); then 
+if (( ! IsLongitudinal )); then
     mkdir -p ${T1wFolder}/Results/${NameOffMRI}
     if [ ! -e "$fMRIFolder" ] ; then
         log_Msg "mkdir ${fMRIFolder}"
@@ -684,10 +684,10 @@ else
     for fd in "$fMRIFolder"/*; do
         fname="$(basename "$fd")"
         #to save space, create or copy link to the original fMRI series
-        if [ "$fname" == "${NameOffMRI}_orig.nii.gz" ]; then 
+        if [ "$fname" == "${NameOffMRI}_orig.nii.gz" ]; then
             cp_link "$fd" "$fMRIFolderLong/$fname"
         #skip _nonlin fMRI series which is re-generated in longitudinal OneStepResample
-        elif [ "$fname" == "${NameOffMRI}_orig_nonlin.nii.gz" ]; then 
+        elif [ "$fname" == "${NameOffMRI}_orig_nonlin.nii.gz" ]; then
             continue
         else
             cp -r -a "$fd" "$fMRIFolderLong/"
@@ -702,7 +702,7 @@ if [[ $nEcho -gt 1 ]] ; then
 fi
 
 #All code until DistortionCorrection...BBRbased.sh is only run in cross-sectional mode.
-if (( ! IsLongitudinal )); then 
+if (( ! IsLongitudinal )); then
     ${FSLDIR}/bin/imcp "$fMRITimeSeries" "$fMRIFolder"/"$OrigTCSName"
 
     if [[ $nEcho -gt 1 ]] ; then
@@ -727,7 +727,6 @@ if (( ! IsLongitudinal )); then
     fi
 
     # --- Copy over scout (own or reference if specified), create fake if none exists
-
     if [ "$fMRIReference" != "NONE" ]; then
         # --- copy over existing scout images
         log_Msg "Copying Scout from Reference fMRI"
@@ -740,7 +739,7 @@ if (( ! IsLongitudinal )); then
 
         mkdir -p ${ResultsFolder}
         ${FSLDIR}/bin/imcp ${ReferenceResultsFolder}/"${fMRIReference}_SBRef" ${ResultsFolder}/"${NameOffMRI}_SBRef"
-    else    
+    else
         # --- Create fake "Scout" if it doesn't exist
         if [ $fMRIScout = "NONE" ] ; then
             ${RUN} ${FSLDIR}/bin/fslroi "$fMRIFolder"/"$OrigTCSName" "$fMRIFolder"/"$OrigScoutName" 0 1
@@ -766,7 +765,7 @@ if (( ! IsLongitudinal )); then
             "$yorient" != "Posterior-to-Anterior" || \
             "$zorient" != "Inferior-to-Superior" ]] ; then
             reorient=TRUE
-        else 
+        else
             reorient=FALSE
         fi
 
@@ -786,7 +785,6 @@ if (( ! IsLongitudinal )); then
             fi
         fi
     fi
-
 
     #Gradient Distortion Correction of fMRI
     log_Msg "Gradient Distortion Correction of fMRI"
@@ -827,7 +825,7 @@ if (( ! IsLongitudinal )); then
     fi
 fi # if (( ! IsLongitudinal ))
 
-#Split echos. 
+#Split echos.
 tcsEchoesOrig=();sctEchoesOrig=();tcsEchoesGdc=();sctEchoesGdc=();
 if [[ ${nEcho} -gt 1 ]]; then
     log_Msg "Splitting echo(s)"
@@ -852,7 +850,7 @@ else
     sctEchoesGdc[0]="${ScoutName}_gdc"
 fi
 
-if (( ! IsLongitudinal )); then 
+if (( ! IsLongitudinal )); then
     log_Msg "mkdir -p ${fMRIFolder}/MotionCorrection"
     mkdir -p "$fMRIFolder"/MotionCorrection
 
@@ -868,8 +866,8 @@ if (( ! IsLongitudinal )); then
         "$fMRIReferenceReg"
 fi
 
-# In longitudinal mode, the rest of this script re-runs the same code as in cross-sectional. 
-# For that to function correctly, we need all relevant directories to 
+# In longitudinal mode, the rest of this script re-runs the same code as in cross-sectional.
+# For that to function correctly, we need all relevant directories to
 # point to the longitudinal session.
 # Note that FreeSurferSubjectID is not used in longitudinal mode and doesn't point to the correct longitudinal freesurfer folder.
 
@@ -880,11 +878,11 @@ if (( IsLongitudinal )); then
     Session="$SessionLong"
     AtlasSpaceFolder="$AtlasSpaceFolderLong"
     ResultsFolder="$ResultsFolderLong"
-	
+
     if [[ $nEcho -gt 1 ]] ; then
         EchoDir="${fMRIFolder}/MultiEcho"
         mkdir -p "$EchoDir"
-    fi	
+    fi
 fi
 
 #EPI Distortion Correction and EPI to T1w Registration
@@ -899,7 +897,7 @@ if [ $fMRIReference = "NONE" ] ; then
     fi
     log_Msg "mkdir -p ${DCFolder}"
     mkdir -p ${DCFolder}
-    
+
     ${RUN} ${PipelineScripts}/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh \
         --workingdir=${DCFolder} \
         --scoutin="${fMRIFolder}/${sctEchoesGdc[0]}" \
@@ -980,7 +978,7 @@ for iEcho in $(seq 0 $((nEcho-1))) ; do
         --fmrirefpath=${fMRIReferencePath} \
         --fmrirefreg=${fMRIReferenceReg} \
         --wb-resample=${useWbResample}
-    
+
     tscArgs="$tscArgs -volume ${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin.nii.gz"
     sctArgs="$sctArgs -volume ${fMRIFolder}/${tcsEchoesOrig[iEcho]}_SBRef_nonlin.nii.gz"
 done
@@ -1051,7 +1049,7 @@ ${RUN} ${PipelineScripts}/IntensityNormalization.sh \
     --fmrimask=${fMRIMask}
 
 
-if [[ ${nEcho} -gt 1 ]]; then 
+if [[ ${nEcho} -gt 1 ]]; then
     log_Msg "Creating echoMeans"
     # Calculate echoMeans of intensity normalized result
     tcsEchoes=(); tcsEchoesMu=();args=""
@@ -1134,16 +1132,16 @@ ${FSLDIR}/bin/imrm "$fMRIFolder"/"$NameOffMRI"_mc #This can be checked with the 
 
 #clean up split echo(s)
 if [[ $nEcho -gt 1 ]]; then
-	for iEcho in $(seq 0 $((nEcho-1))) ; do	
+	for iEcho in $(seq 0 $((nEcho-1))) ; do
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}"
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesOrig[iEcho]}"
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}"
-		
+
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin"
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_nonlin_mask"
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesOrig[iEcho]}_SBRef_nonlin"
 
-		${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesGdc[iEcho]}"		
+		${FSLDIR}/bin/imrm "${fMRIFolder}/${tcsEchoesGdc[iEcho]}"
 		${FSLDIR}/bin/imrm "${fMRIFolder}/${sctEchoesGdc[iEcho]}_mask"
 	done
 	${FSLDIR}/bin/imrm "${tcsEchoes[@]}"

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -671,7 +671,7 @@ if (( ! IsLongitudinal )); then
     ${FSLDIR}/bin/imcp "$fMRITimeSeries" "$fMRIFolder"/"$OrigTCSName"
 else
     #copy directory structure.
-	mkdir -p "$ResultsFolderLong"
+    mkdir -p "$ResultsFolderLong"
     fMRIFolderLong="$Path"/"$SessionLong"/"$NameOffMRI"
     for fd in "$fMRIFolder"/*; do
         fname="$(basename "$fd")"
@@ -880,7 +880,7 @@ if [ $fMRIReference = "NONE" ] ; then
     log_Msg "EPI Distortion Correction and EPI to T1w Registration"
 
     if [ -e ${DCFolder} -a ${IsLongitudinal} == "0" ] ; then
-       ${RUN} rm -r ${DCFolder}
+        ${RUN} rm -r ${DCFolder}
     fi
     log_Msg "mkdir -p ${DCFolder}"
     mkdir -p ${DCFolder}

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -661,16 +661,6 @@ ResultsFolderCross="$AtlasSpaceFolder"/"$ResultsFolder"/"$NameOffMRI"
 ResultsFolderLong="$AtlasSpaceFolderLong"/"$ResultsFolder"/"$NameOffMRI"
 ResultsFolder=$ResultsFolderCross
 
-function cp_link
-{
-    local src="$1" dst="$2"
-    if [ -L "$src" ]; then
-        cp -a $src $dst
-    else
-        ln -sf $src $dst
-    fi
-}
-
 if (( ! IsLongitudinal )); then
     mkdir -p ${T1wFolder}/Results/${NameOffMRI}
     if [ ! -e "$fMRIFolder" ] ; then
@@ -685,14 +675,11 @@ else
     fMRIFolderLong="$Path"/"$SessionLong"/"$NameOffMRI"
     for fd in "$fMRIFolder"/*; do
         fname="$(basename "$fd")"
-        #to save space, create or copy link to the original fMRI series
+        #create link to the original fMRI series
         if [ "$fname" == "${NameOffMRI}_orig.nii.gz" ]; then
-            cp_link "$fd" "$fMRIFolderLong/$fname"
-        #skip _nonlin fMRI series which is re-generated in longitudinal OneStepResample
-        elif [ "$fname" == "${NameOffMRI}_orig_nonlin.nii.gz" ]; then
-            continue
+            ln -sf ../../"$Session"/"${NameOffMRI}"/"$fname" "$fMRIFolderLong/$fname"
         else
-            cp -r -a "$fd" "$fMRIFolderLong/"
+            cp -r -p "$fd" "$fMRIFolderLong/"
         fi
     done
 fi


### PR DESCRIPTION
I. Enables longitudinal mode in the ICAFIX pipeline. Only supports multi-run mode. To use:

1) Run all cross-sectional ICAFIX pipelines on each timepoint
2) Longitudinal timepoints require the same sequence of longitudinal pipelines to be run as a pre-requisite, i.e. longitudinal FreeSurfer, PostFreeSurfer, fMRIVolume, and fMRISurface. Then, run ReApplyFixMultiRun pipeline on each longitudinal timepoint, setting the optional --is-longitudinal and --longitudinal-session flags. 

II. Fixes issues to correctly run fMRIVolume pipeline in longitudinal mode on multi-echo runs.  