### PR TITLE
pd bug fix

### DIFF
--- a/ICAFIX/ReApplyFixMultiRunPipeline.sh
+++ b/ICAFIX/ReApplyFixMultiRunPipeline.sh
@@ -727,7 +727,7 @@ case ${MatlabMode} in
 	1 | 2)
 		# Use interpreted MATLAB or Octave
 
-		matlab_code="${ML_PATHS} fix_3_clean('${fixlist}',${aggressive},${MotionRegression},${AlreadyHP},'${Caret7_Command}',${DoVol});"
+		matlab_code="${ML_PATHS} fix_3_clean('${fixlist}',${aggressive},${MotionRegression},'${AlreadyHP}','${Caret7_Command}',${DoVol});"
 		
 		log_Msg "Run interpreted MATLAB/Octave (${matlab_interpreter[*]}) with code..."
 		log_Msg "${matlab_code}"

--- a/ICAFIX/hcp_fix_multi_run
+++ b/ICAFIX/hcp_fix_multi_run
@@ -1074,7 +1074,7 @@ case ${MatlabMode} in
     1 | 2)
         # Use interpreted MATLAB or Octave
         # ${hp} needs to be passed in as a string, to handle the hp=pd* case
-        matlab_code="${ML_PATHS} fix_3_clean('${concatfmrihp}.ica/.fix', 0, ${doMotionRegression}, ${hp}, '${Caret7_Command}');"
+        matlab_code="${ML_PATHS} fix_3_clean('${concatfmrihp}.ica/.fix', 0, ${doMotionRegression}, '${hp}', '${Caret7_Command}');"
         log_Msg "Run interpreted MATLAB/Octave (${matlab_interpreter[*]}) with code..."
         log_Msg "$matlab_code"
         "${matlab_interpreter[@]}" <<<"${matlab_code}"

--- a/ICAFIX/scripts/fix_3_clean.m
+++ b/ICAFIX/scripts/fix_3_clean.m
@@ -73,7 +73,9 @@ function fix_3_clean(fixlist,aggressive,domot,hp,WBC,DOvol)
   %     path(path,CIFTI);
   %   end
     BO=ciftiopen('Atlas.dtseries.nii',WBC);
-    meanBO=mean(BO.cdata,2); 
+    if ~(isfloat(hp) && hp==-1)
+      meanBO=mean(BO.cdata,2); 
+    end
     if ~isempty(regexp(hp,'^pd\d+$','once')) % polynomial detrending
       BO.cdata=detrend(BO.cdata',str2double(hp(3:end)))';  BO.cdata=BO.cdata+repmat(meanBO,1,size(BO.cdata,2));
     else


### PR DESCRIPTION
Modified fix_3_clean.m and the wrappers that call it (hcp_fix_multi_run and ReApplyFixMultiRunPipeline.sh) take $hp as a string, and handle pd# (polynomial detrend) cases. I did not recompile the matlab, but the compiled mode sections of the wrappers do not need to be changed because in compiled mode all arguments are passed as strings anyway. @coalsont, could you please recompile the matlab, assuming all else looks good?