### PR TITLE
Never run hp in fix_3_clean for multirun fix

### DIFF
--- a/ICAFIX/hcp_fix_multi_run
+++ b/ICAFIX/hcp_fix_multi_run
@@ -1063,6 +1063,7 @@ sed '1d;$d' ${melview} > ${melview//.txt/.wb_annsub.csv} # create workbench form
 # running stages separately doesn't create .fix file with noise component indices, so create it from the melview file
 grep -h Noise "${melview}" | cut -d',' -f1 | tr '\n' ' ' > ${concatfmrihp}.ica/.fix
 
+AlreadyHP="-1" #Don't run highpass on concatenated data (since hp was done on the individual runs)
 case ${MatlabMode} in
     0)
         compiledScript="$HCPPIPEDIR"/ICAFIX/scripts/Compiled_fix_3_clean/run_fix_3_clean.sh

--- a/ICAFIX/hcp_fix_multi_run
+++ b/ICAFIX/hcp_fix_multi_run
@@ -1066,7 +1066,7 @@ grep -h Noise "${melview}" | cut -d',' -f1 | tr '\n' ' ' > ${concatfmrihp}.ica/.
 case ${MatlabMode} in
     0)
         compiledScript="$HCPPIPEDIR"/ICAFIX/scripts/Compiled_fix_3_clean/run_fix_3_clean.sh
-        matlab_cmd=("${compiledScript}" "${MATLAB_COMPILER_RUNTIME}" "${concatfmrihp}.ica/.fix" "0" "${doMotionRegression}" "${hp}" "${Caret7_Command}")
+        matlab_cmd=("${compiledScript}" "${MATLAB_COMPILER_RUNTIME}" "${concatfmrihp}.ica/.fix" "0" "${doMotionRegression}" "${AlreadyHP}" "${Caret7_Command}")
         log_Msg "Run compiled MATLAB with command..."
         log_Msg "${matlab_cmd[*]}"
         "${matlab_cmd[@]}"
@@ -1074,7 +1074,7 @@ case ${MatlabMode} in
     1 | 2)
         # Use interpreted MATLAB or Octave
         # ${hp} needs to be passed in as a string, to handle the hp=pd* case
-        matlab_code="${ML_PATHS} fix_3_clean('${concatfmrihp}.ica/.fix', 0, ${doMotionRegression}, ${hp}, '${Caret7_Command}');"
+        matlab_code="${ML_PATHS} fix_3_clean('${concatfmrihp}.ica/.fix', 0, ${doMotionRegression}, ${AlreadyHP}, '${Caret7_Command}');"
         log_Msg "Run interpreted MATLAB/Octave (${matlab_interpreter[*]}) with code..."
         log_Msg "$matlab_code"
         "${matlab_interpreter[@]}" <<<"${matlab_code}"


### PR DESCRIPTION
Replace my previous PR with this one. Somehow, when I made fix_3_clean stand alone, I fed it $hp rather than $AlreadyHP. Was not detected because it doesn't matter for hp=0 (typical use case). Now fix_3_clean.m never uses hp. 