### PR TITLE
Longitudinal tICA

### DIFF
--- a/Examples/Scripts/RunTICAPipeline_PrecomputedTICA_SubjectCleanBatch-long.sh
+++ b/Examples/Scripts/RunTICAPipeline_PrecomputedTICA_SubjectCleanBatch-long.sh
@@ -139,7 +139,7 @@ function identify_timepoints
     for visit in ${PossibleVisits[*]}; do
         tp="${subject}_${visit}"
         if [ -d "$StudyFolder/$tp" ] && ! [[ " ${ExcludeVisits[*]+${ExcludeVisits[*]}} " =~ [[:space:]]"$tp"[[:space:]] ]]; then
-             if (( n==0 )); then 
+             if (( n==0 )); then
                     tplist="$tp"
              else
                     tplist="$tplist@$tp"
@@ -167,7 +167,7 @@ main() {
 
     # general settings
     # ICA mode
-    # ICA mode is hard-coded to be REUSE_ICA, which is mandatory in longitudinal mode.
+    # ICA mode is hard-coded to be REUSE_TICA, which is mandatory in longitudinal mode.
     # ICAmode="REUSE_TICA"
 
     # set how many subjects to do in parallel (local, not cluster-distributed) during individual projection and cleanup, defaults to all detected physical cores, '-1'
@@ -187,10 +187,10 @@ main() {
 
     # set list of fMRI on which ICA+FIX has been run, use @ to separate runs (not from the precomputed data)
     fMRINames="rfMRI_REST1_AP@rfMRI_REST1_PA@tfMRI_VISMOTOR_PA@tfMRI_CARIT_PA@tfMRI_FACENAME_PA@rfMRI_REST2_AP@rfMRI_REST2_PA"
-    
+
     # fMRI names to extract. Required in longitudinal mode; must match (in longitudinal mode) cortical registration (MSMAll) extract names.
     extractfMRINames="rfMRI_REST1_AP@rfMRI_REST1_PA@rfMRI_REST2_AP@rfMRI_REST2_PA"
-    
+
     # fMRI name to extract. Required in longitudinal mode. Must match (in longitudinal mode) cortical registration (MSMAll) extract name.
     extractfMRIOut="rfMRI_REST"
 
@@ -255,7 +255,7 @@ main() {
         echo "queueing with fsl_sub to to $QUEUE"
         queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE")
     fi
-    
+
     #iterate over subjects
     for i in ${!Subjlist[@]}; do
         Subject="${Subjlist[i]}"
@@ -275,7 +275,7 @@ main() {
             --out-group-name="$GroupAverageName" \
             --fmri-resolution="$fMRIResolution" \
             --surf-reg-name="$RegName" \
-            --ica-mode="REUSE_ICA" \
+            --ica-mode="REUSE_TICA" \
             --num-wishart="$numWisharts" \
             --low-res="$LowResMesh" \
             --low-sica-dims="$LowsICADims" \

--- a/Examples/Scripts/RunTICAPipeline_PrecomputedTICA_SubjectCleanBatch-long.sh
+++ b/Examples/Scripts/RunTICAPipeline_PrecomputedTICA_SubjectCleanBatch-long.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+
+set -eu
+
+# this is an example script to run the tICA pipeline to clean a batch of subjects with group sICA and group tICA results that are both generated from a previous computation
+# steps that aren't needed for this mode are automaticaly skipped inside the pipeline
+# please make sure that precomputed group sICA and group tICA exist
+# please make sure that ICA-FIX, MSMAll and MakeAverageDataset are done properly matching the input arguments before running this tICA pipeline
+
+# Global default values
+DEFAULT_STUDY_FOLDER="${HOME}/data/Pipelines_ExampleData" # location of Subject folders (named by subjectID)
+# example subjects including 175 7T HCP subjects, separated by @
+# space separated subject list
+DEFAULT_SUBJECT_LIST="HCA6002236 HCA6002237"
+# list of longitudinal sessions suffices
+DEFAULT_POSSIBLE_VISITS="V1_MR V2_MR V3_MR"
+DEFAULT_TEMPLATE_LIST="HCA6002236_V1_V2_V3 HCA6002237_V1_V2_V3"
+DEFAULT_ENVIRONMENT_SCRIPT="$DEFAULT_STUDY_FOLDER/scripts/SetUpHCPPipeline-long.sh"
+DEFAULT_GROUP_NAME="HCA1798_MSMAll" # the group average name, which must be specified the same in MakeAverageDataset before running this tICA script
+DEFAULT_REG_NAME="MSMAll" # the registration string corresponding to the input files, which must be specified the same in MSMAll pipeline before running this tICA script
+DEFAULT_MATLAB_MODE=1 # MatlabMode
+DEFAULT_RUN_LOCAL=0
+DEFAULT_QUEUE="short.q"
+#DEFAULT_QUEUE="hcp_priority.q"
+
+get_options() {
+    local scriptName=$(basename "$0")
+    local arguments=("$@")
+
+    # initialize global variables
+    StudyFolder="${DEFAULT_STUDY_FOLDER}"
+    Subjlist=(${DEFAULT_SUBJECT_LIST})
+    TemplateList=($DEFAULT_TEMPLATE_LIST)
+    PossibleVisits=($DEFAULT_POSSIBLE_VISITS)
+    EnvironmentScript="${DEFAULT_ENVIRONMENT_SCRIPT}"
+    GroupAverageName="${DEFAULT_GROUP_NAME}"
+    RegName="${DEFAULT_REG_NAME}"
+    MatlabMode="${DEFAULT_MATLAB_MODE}"
+    RunLocal="${DEFAULT_RUN_LOCAL}"
+    QUEUE="${DEFAULT_QUEUE}"
+
+    # parse arguments
+    local index argument
+    local numArgs=${#arguments[@]}
+
+    for ((index = 0; index < ${#arguments[@]}; ++index))
+    do
+        argument="${arguments[index]}"
+
+        case "${argument}" in
+            --StudyFolder=*)
+                StudyFolder="${argument#*=}"
+                ;;
+            --Subject=*)
+                Subjlist="${argument#*=}"
+                ;;
+            --EnvironmentScript=*)
+                EnvironmentScript="${argument#*=}"
+                ;;
+            --GroupAverageName=*)
+                GroupAverageName="${argument#*=}"
+                ;;
+            --RegName=*)
+                RegName="${argument#*=}"
+                ;;
+            --MatlabMode=*)
+                MatlabMode="${argument#*=}"
+                ;;
+            --runlocal | --RunLocal)
+                RunLocal=1
+                ;;
+            --queue=*)
+                QUEUE="${argument#*=}"
+                ;;
+            *)
+                echo "ERROR: Unrecognized Option: ${argument}"
+                exit 1
+                ;;
+        esac
+    done
+
+    # check required parameters
+    if [[ "$StudyFolder" == "" ]]
+    then
+        echo "ERROR: StudyFolder not specified"
+        exit 1
+    fi
+
+    if [[ "$Subjlist" == "" ]]
+    then
+        echo "ERROR: Subjlist not specified"
+        exit 1
+    fi
+
+    if [[ "$EnvironmentScript" == "" ]]
+    then
+        echo "ERROR: EnvironmentScript not specified"
+        exit 1
+    fi
+
+    if [[ "$GroupAverageName" == "" ]]
+    then
+        echo "ERROR: GroupAverageName not specified"
+        exit 1
+    fi
+
+    if [[ "$RegName" == "" ]]
+    then
+        echo "ERROR: RegName not specified"
+        exit 1
+    fi
+
+    if [[ "$MatlabMode" == "" ]]
+    then
+        echo "ERROR: MatlabMode not specified"
+        exit 1
+    fi
+
+    # report options
+    echo "-- ${scriptName}: Specified Command-Line Options: -- Start --"
+    echo "   StudyFolder: ${StudyFolder}"
+    echo "   Subjlist: ${Subjlist}"
+    echo "   EnvironmentScript: ${EnvironmentScript}"
+    echo "   GroupAverageName: ${GroupAverageName}"
+    echo "   RegName: ${RegName}"
+    echo "   MatlabMode: ${MatlabMode}"
+    echo "-- ${scriptName}: Specified Command-Line Options: -- End --"
+
+}
+
+function identify_timepoints
+{
+    local subject=$1
+    local tplist=""
+    local tp visit n
+
+    #build the list of timepoints
+    n=0
+    for visit in ${PossibleVisits[*]}; do
+        tp="${subject}_${visit}"
+        if [ -d "$StudyFolder/$tp" ] && ! [[ " ${ExcludeVisits[*]+${ExcludeVisits[*]}} " =~ [[:space:]]"$tp"[[:space:]] ]]; then
+             if (( n==0 )); then 
+                    tplist="$tp"
+             else
+                    tplist="$tplist@$tp"
+             fi
+        fi
+        ((n++))
+    done
+    echo $tplist
+}
+
+#
+# Function Description
+#	Main processing of this script
+#
+#	Gets user specified command line options and runs tICA group processing (please make sure the ICA-FIX, MSMAll and MakeAverageDataset are finished before running this script)
+#
+
+main() {
+
+    # get command line options
+    get_options "$@"
+
+    # set up pipeline environment variables and software
+    source "${EnvironmentScript}"
+
+    # general settings
+    # set the ICA mode
+    # NEW - estimate a new sICA and a new tICA
+    # REUSE_SICA_ONLY - reuse an existing sICA and estimate a new tICA
+    # INITIALIZE_TICA - reuse an existing sICA and use an existing tICA to start the estimation
+    # REUSE_TICA - reuse an existing sICA and an existing tICA"
+    ICAmode="REUSE_TICA"
+
+    # set how many subjects to do in parallel (local, not cluster-distributed) during individual projection and cleanup, defaults to all detected physical cores, '-1'
+    parLimit=-1
+
+    # general inputs
+    # key arguments under 'REUSE_TICA' mode that are different from the full run example
+    # set the group folder containing an existing tICA cleanup to make use of for REUSE or INITIALIZE modes
+    precomputeTICAFolder="<tICA precompute dir>/HCA1798_MSMAll"
+    # set the output fMRI name used in the previously computed tICA
+    precomputeTICAfMRIName="fMRI_CONCAT_ALL"
+    # set the group name used during the previously computed tICA
+    precomputeGroupName="HCA1798_MSMAll"
+    # set the corresponding dimensionality instead of icaDim's estimate
+    sICADim="86"
+    # end of key arguments for general inputs under 'REUSE_TICA' mode
+
+    # set list of fMRI on which ICA+FIX has been run, use @ to separate runs (not from the precomputed data)
+    fMRINames="rfMRI_REST1_AP@rfMRI_REST1_PA@tfMRI_VISMOTOR_PA@tfMRI_CARIT_PA@tfMRI_FACENAME_PA@rfMRI_REST2_AP@rfMRI_REST2_PA"
+    
+    # fMRI names to extract. Required in longitudinal mode; must match (in longitudinal mode) cortical registration (MSMAll) extract names.
+    extractfMRINames="rfMRI_REST1_AP@rfMRI_REST1_PA@rfMRI_REST2_AP@rfMRI_REST2_PA"
+    
+    # fMRI name to extract. Required in longitudinal mode. Must match (in longitudinal mode) cortical registration (MSMAll) extract name.
+    extractfMRIOut="rfMRI_REST"
+
+    # set the output fMRI for the output folder and the other output tICA files (not from the precomputed data)
+    OutputfMRIName="fMRI_CONCAT_ALL"
+
+    # set the MR concat fMRI name, if multi-run FIX was used, you must specify the concat name with this option, otherwise use an empty string (not from the precomputed data)
+    MRFixConcatName="fMRI_CONCAT_ALL"
+
+    # set the file name component representing the preprocessing already done, e.g. '_Atlas_MSMAll_hp0_clean' (not from the precomputed data)
+    fMRIProcSTRING="_Atlas_MSMAll_hp0_clean"
+
+    # set temporal highpass full-width (2*sigma) to use, should be the same from running FIX (not from the precomputed data)
+    HighPass="0"
+
+    # set the resolution of data, like '2' or '1.60' or '2.40' (not from the precomputed data)
+    fMRIResolution="2"
+
+    # set the number of Wishart filtering used in icaDim, since it's under 'REUSE_TICA' mode, please match this value with that from the precomputation (from the precomputed data)
+    # 6 for HCP-style data of ~2000k-5000k timepoints
+    # 5 for HCP-style data of <2000k timepoints
+    numWisharts="6"
+
+    # set the mesh resolution, like '32' for 32k_fs_LR (not from the precomputed data)
+    LowResMesh="32"
+
+    # set the output spectra size for sICA individual projection, RunsXNumTimePoints, like '4800' for 'rfMRI_REST' with four runs or '3880' for 'tfMRI_Concat' with full task concat (not from the precomputed data)
+    sessionExpectedTimepoints="2721"
+    # end of general inputs
+
+    # step0: MIGP inputs, since it's under 'REUSE_TICA' mode, MIGP will be skipped
+
+    # step1: GroupSICA inputs, since it's under 'REUSE_TICA' mode, GroupSICA will be skipped
+
+    # step2: indProjSICA inputs
+    # set the low sICA dimensionalities to use for determining weighting for individual projection, defaults to '7@8@9@10@11@12@13@14@15@16@17@18@19@20@21'
+    LowsICADims="7@8@9@10@11@12@13@14@15@16@17@18@19@20@21"
+
+    # step3: ConcatGroupSICA inputs
+    # hardcoded conventions are used
+
+    # step4: ComputeGroupTICA inputs
+    # hardcoded conventions are used
+
+    # step5: indProjTICA inputs
+    # hardcoded conventions are used
+
+    # step6: ComputeTICAFeatures inputs, since it's under 'REUSE_TICA' mode, ComputeTICAFeatures will be skipped
+
+    # step7: ClassifyTICA inputs
+    # not integrated yet
+
+    # step8: CleanData inputs
+    # set whether the input data used the legacy bias correction (not from the precomputed data)
+    FixLegacyBiasString="NO"
+
+    if ((RunLocal)) || [[ "$QUEUE" == "" ]]
+    then
+        echo "running locally"
+        queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
+    else
+        echo "queueing with fsl_sub to to $QUEUE"
+        queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE")
+    fi
+    
+    #iterate over subjects
+    for i in ${!Subjlist[@]}; do
+        Subject="${Subjlist[i]}"
+        echo "Subject: ${Subject}"
+        TemplateLong="${TemplateList[i]}"
+        #extract the list of sessions for the current subject.
+        Timepoint_list_cross_at_separated=$(identify_timepoints "$Subject")
+
+        # tICA pipeline
+        "${queuing_command[@]}" "$HCPPIPEDIR"/tICA/tICAPipeline.sh --study-folder="$StudyFolder" \
+            --session-list="${Timepoint_list_cross_at_separated}" \
+            --fmri-names="$fMRINames" \
+            --output-fmri-name="$OutputfMRIName" \
+            --mrfix-concat-name="$MRFixConcatName" \
+            --proc-string="$fMRIProcSTRING" \
+            --melodic-high-pass="$HighPass" \
+            --out-group-name="$GroupAverageName" \
+            --fmri-resolution="$fMRIResolution" \
+            --surf-reg-name="$RegName" \
+            --ica-mode="$ICAmode" \
+            --num-wishart="$numWisharts" \
+            --low-res="$LowResMesh" \
+            --low-sica-dims="$LowsICADims" \
+            --session-expected-timepoints="$sessionExpectedTimepoints" \
+            --fix-legacy-bias="$FixLegacyBiasString" \
+            --parallel-limit="$parLimit" \
+            --matlab-run-mode="$MatlabMode" \
+            --sicadim-override="$sICADim" \
+            --precomputed-clean-folder="$precomputeTICAFolder" \
+            --precomputed-clean-fmri-name="$precomputeTICAfMRIName" \
+            --precomputed-group-name="$precomputeGroupName" \
+            --extract-fmri-name-list="$extractfMRINames" \
+            --extract-fmri-out="$extractfMRIOut" \
+            --is-longitudinal="TRUE" \
+            --longitudinal-template="$TemplateLong" \
+            --longitudinal-subject="$Subject" \
+            --longitudinal-extract-all="TRUE"
+    done
+}
+
+#
+# Invoke the main function to get things started
+#
+main "$@"

--- a/Examples/Scripts/RunTICAPipeline_PrecomputedTICA_SubjectCleanBatch-long.sh
+++ b/Examples/Scripts/RunTICAPipeline_PrecomputedTICA_SubjectCleanBatch-long.sh
@@ -166,12 +166,9 @@ main() {
     source "${EnvironmentScript}"
 
     # general settings
-    # set the ICA mode
-    # NEW - estimate a new sICA and a new tICA
-    # REUSE_SICA_ONLY - reuse an existing sICA and estimate a new tICA
-    # INITIALIZE_TICA - reuse an existing sICA and use an existing tICA to start the estimation
-    # REUSE_TICA - reuse an existing sICA and an existing tICA"
-    ICAmode="REUSE_TICA"
+    # ICA mode
+    # ICA mode is hard-coded to be REUSE_ICA, which is mandatory in longitudinal mode.
+    # ICAmode="REUSE_TICA"
 
     # set how many subjects to do in parallel (local, not cluster-distributed) during individual projection and cleanup, defaults to all detected physical cores, '-1'
     parLimit=-1
@@ -278,7 +275,7 @@ main() {
             --out-group-name="$GroupAverageName" \
             --fmri-resolution="$fMRIResolution" \
             --surf-reg-name="$RegName" \
-            --ica-mode="$ICAmode" \
+            --ica-mode="REUSE_ICA" \
             --num-wishart="$numWisharts" \
             --low-res="$LowResMesh" \
             --low-sica-dims="$LowsICADims" \

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -22,9 +22,10 @@ opts_AddMandatory '--session-list' 'SesslistRaw' 'HCA6002236_V1_MR@HCA6002236_V2
 opts_AddMandatory '--template-long' 'TemplateLong' 'ID' 'Longitudinal template ID'
 opts_AddMandatory '--extract-fmri-name-list' 'concatNamesToUse' 'name@name@name...' "list of fMRI run names to concatenate into the --extract-fmri-out output after tICA cleanup"
 opts_AddMandatory '--highpass' 'HighPass' 'hp value' 'High pass used with these data'
-opts_AddMandatory '--extract-fmri-out' 'extractNameOut' 'name' "fMRI name for concatenated extracted runs, requires --extract-fmri-name-list"
+opts_AddMandatory '--extract-fmri-name' 'extractNameOut' 'name' "fMRI name for concatenated extracted runs.
+Must match the one used in cortical registration."
 opts_AddOptional  '--reg-name' 'RegName' 'registration algorithm' "Cortical registration algorithm used [MSMAll]" "MSMAll"
-opts_AddOptional  '--extract-fmri-out-all' 'extractNameAll' 'name' "Concatenated run label. If specified, concatenate all runs specified by --fmri-names, for all timepoints." ""
+opts_AddOptional  '--fmri-name-concat-all' 'extractNameAll' 'name' "Concatenated output run label. If specified, must match the one used in multi-run FIX and cortical registration." ""
 opts_AddOptional  '--fmri-names' 'fMRINames' 'rfMRI_REST1_LR@rfMRI_REST1_RL...' "list of all fmri run names separated by @. Required with --extract-fmri-out-all" ""
 
 opts_ParseArguments "$@"
@@ -35,28 +36,29 @@ then
 fi
 
 if [[ "$extractNameAll" != "" && "$fMRINames" == "" ]]; then 
-    log_Err_Abort "-fmri-names is required with --extract-fmri-out-all"
+    log_Err_Abort "--fmri-names is required with --fmri-name-concat-all"
 fi
 
 #display the parsed/default values
 opts_ShowValues
 
 #do work
-TemplateDir="$StudyFolder"/"$Subject.$TemplateLong"
+TemplateDir="$StudyFolder"/"$Subject.long.$TemplateLong"
 
 function makeTemplateConcatRuns {
     local fMRIStr="$1" sessionsStr="$2" template="$3" nameOut="$4" 
     local fMRIs sessions
     IFS=@ read -r -a fMRIs <<< "${fMRIStr}"
     IFS=@ read -r -a sessions <<< "${sessionsStr}"
+    local numSessions="${#sessions[@]}"
     local OutDir="$TemplateDir/MNINonLinear/Results/$nameOut"
     mkdir -p "$OutDir"
     
-    #commands to create output files
-    local vn_average_cifti="wb_command -cifti-average $OutDir/${nameOut}_Atlas_"$RegName"_hp${HighPass}_clean_tclean_vn.dscalar.nii" 
-    local vn_average_nifti="fslmerge -t  "$OutDir"/"$nameOut"_hp"$HighPass"_clean_tclean_vn.nii.gz" #average of the _vn from all timepoints
-    local ts_concat_cifti="wb_command -cifti-merge "$nameOut"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_v1.dtseries.nii"
-    local ts_concat_nifti="fslmerge -t "$OutDir"/"$nameOut"_clean_tclean_v1.nii" #average nifti timeseries
+    #per fMRI run lists for concat/merge commands
+    local vn_average_cifti_array
+    local vn_average_nifti_array #average of the _vn from all timepoints
+    local ts_concat_cifti_array
+    local ts_concat_nifti_array #average nifti timeseries
     
     #loop variables 
     local session sessionLong resultsDir fmri fmri_rt
@@ -66,59 +68,56 @@ function makeTemplateConcatRuns {
         sessionLong="$session.long.$template"
         echo "Timepoint: $sessionLong"
         resultsDir="$StudyFolder"/"$sessionLong"/MNINonLinear/Results
+
+        # Average vn's in the atlas and native spaces. We assume that $nameOut exists in $sessionLong tICA output
+        vn_average_cifti_array+=(-cifti "$resultsDir/$nameOut/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii")
+        vn_average_nifti_array+=("$resultsDir/$nameOut/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz")
+        
         for fmri in ${fMRIs[*]}; do
             #demean each fmri and save to temporary file - cifti
             fmri_rt=$resultsDir/"$fmri/$fmri"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean
-            #DEBUG - uncomment
-            # wb_command -cifti-reduce "$fmri_rt".dtseries.nii MEAN "$fmri_rt"_mean.dscalar.nii
-            # wb_command -cifti-math '(TS - M) / VN' "$fmri_rt"_demean.dtseries.nii \
-                # -var TS "$fmri_rt".dtseries.nii -var M "$fmri_rt"_mean.dscalar.nii -select 1 1 -repeat \
-                # -var VN $resultsDir/"$fmri/$fmri"_Atlas_"$RegName"_hp"$HighPass"_vn.dscalar.nii -select 1 1 -repeat 
-
-            #rm "$fmri_rt"_mean.dscalar.nii
-            ts_concat_cifti="$ts_concat_cifti -cifti "$fmri_rt"_demean.dtseries.nii"
+            wb_command -cifti-reduce "$fmri_rt".dtseries.nii MEAN "$fmri_rt"_mean.dscalar.nii
+            wb_command -cifti-math '(TS - M) / VN' "$fmri_rt"_demean.dtseries.nii \
+                -var TS "$fmri_rt".dtseries.nii\
+                -var M "$fmri_rt"_mean.dscalar.nii -select 1 1 -repeat \
+                -var VN $resultsDir/"$fmri/$fmri"_Atlas_"$RegName"_hp"$HighPass"_vn.dscalar.nii -select 1 1 -repeat 
+            rm "$fmri_rt"_mean.dscalar.nii
+            ts_concat_cifti_array+=(-cifti "${fmri_rt}_demean.dtseries.nii")
             
             #demean each fmri and save to temporary file - nifti
-            fmri_rt=$resultsDir/"$fmri/$fmri"_hp"$HighPass"_clean_tclean            
-            #fslmaths "$fmri_rt".nii.gz -Tmean -mul -1 -add "$fmri_rt".nii.gz -div $resultsDir/"$fmri/$fmri"_hp"$HighPass"_vn.nii.gz "$fmri_rt"_demean.nii
-            ts_concat_nifti="$ts_concat_nifti ${fmri_rt}_demean.nii.gz"
-
-            #average vn's in atlas and native space
-            vn_average_cifti="$vn_average_cifti -cifti $resultsDir/$fmri/${fmri}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii"
-            vn_average_nifti="$vn_average_nifti $resultsDir/$fmri/${fmri}_hp${HighPass}_clean_tclean_vn.nii.gz"
+            fmri_rt=$resultsDir/"$fmri/$fmri"_hp"$HighPass"_clean_tclean
+            fslmaths "$fmri_rt".nii.gz -Tmean -mul -1 -add "$fmri_rt".nii.gz -div $resultsDir/"$fmri/$fmri"_hp"$HighPass"_vn.nii.gz "$fmri_rt"_demean.nii
+            ts_concat_nifti_array+=("${fmri_rt}_demean.nii.gz")
         done
     done
-    #run concat/average commands
-    #DEBUG - uncomment
-    #$ts_concat_cifti
-    #$ts_concat_nifti
-    echo $vn_average_cifti
-    $vn_average_cifti
-    echo $vn_average_nifti
-    $vn_average_nifti
-    #multiply by average _vn file
-    echo "multiply by average _vn - cifti" #DEBUG
-    wb_command -cifti-math "TS * VN" $OutDir/${nameOut}_Atlas_"$RegName"_hp${HighPass}"_clean_tclean.dtseries.nii.gz" \
-        -var TS "$nameOut"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_v1.dtseries.nii \
-        -var VN "$OutDir/${nameOut}"_Atlas_"$RegName"_hp${HighPass}_vn.dscalar.nii -select 1 1 -repeat
-    echo "multiply by average _vn - nifti" #DEBUG
-    fslmaths "$OutDir"/"$nameOut"_clean_tclean_v1.nii -mul "$OutDir"/"$nameOut"_hp"$HighPass"_clean_tclean_vn.nii.gz \
-        "$OutDir"/"$nameOut"_clean_tclean.nii.gz
-        
-    echo "completed tICAMakeCleanLongitudinalTemplate.sh"
-    exit 0 #DEBUG
+
+    # run concat/average commands
+    wb_command -cifti-merge "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_v1.dtseries.nii" "${ts_concat_cifti_array[@]}"
+    fslmerge -t "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_v1.nii" "${ts_concat_nifti_array[@]}"
+    wb_command -cifti-average "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii" "${vn_average_cifti_array[@]}"
+    fslmerge -t  "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn_all.nii.gz" "${vn_average_nifti_array[@]}"
+    fslmaths "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn_all.nii.gz" -Tmean "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz"
+    rm "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn_all.nii.gz"
+
+    # multiply by average _vn files
+    # multiply by average _vn - cifti
+    wb_command -cifti-math "TS * VN" "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean.dtseries.nii" \
+       -var TS "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_v1.dtseries.nii" \
+       -var VN "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii" -select 1 1 -repeat
+    # multiply by average _vn - nifti
+    fslmaths "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_v1.nii.gz" -mul "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz" \
+       "$OutDir/${nameOut}_hp${HighPass}_clean_tclean.nii.gz"
+    
     #clean up
-    rm "$nameOut"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_v1.dtseries.nii \
-        "$OutDir"/"$nameOut"_clean_tclean_v1.nii
-        #"$OutDir/${nameOut}"_Atlas_"$RegName"_hp${HighPass}_vn.dscalar.nii \
-        #"$OutDir"/"$nameOut"_clean_tclean_vn.nii.gz
+    rm -f "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_v1.dtseries.nii" \
+        "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_v1.nii.gz"
         
     for session in ${sessions[*]}; do
-        sessionLong="$Session.long.$template"
-        resultsDir="$StudyFolder"/"$sessionLong"/MNINonLinear/Results
+        sessionLong="$session.long.$template"
+        resultsDir="$StudyFolder/$sessionLong/MNINonLinear/Results"
         for fmri in ${fMRIs[*]}; do
-            rm $resultsDir/"$fmri/$fmri"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_demean.dtseries.nii
-            rm $resultsDir/"$fmri/$fmri"_hp"$HighPass"_clean_tclean_demean.nii
+            rm -f "$resultsDir/$fmri/${fmri}_Atlas_${RegName}_hp${HighPass}_clean_tclean_demean.dtseries.nii" \
+                "$resultsDir/$fmri/${fmri}_hp${HighPass}_clean_tclean_demean.nii.gz"
         done
     done
 }
@@ -127,6 +126,7 @@ function makeTemplateConcatRuns {
 makeTemplateConcatRuns "$concatNamesToUse" "$SesslistRaw" "$TemplateLong" "$extractNameOut"
 
 #optionally, create outputs from all time series.
-if [[ "$extractfMRIOutAll" != "" ]]; then 
-    makeTemplateConcatRuns "$fMRINames" "$SesslistRaw" "$TemplateLong" "$extractNameOutAll"
+if [[ "$extractNameAll" != "" ]]; then 
+    makeTemplateConcatRuns "$fMRINames" "$SesslistRaw" "$TemplateLong" "$extractNameAll"
 fi
+echo "completed tICAMakeCleanLongitudinalTemplate.sh"

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -75,7 +75,7 @@ function makeTemplateConcatRuns {
         #reset session starting frame
         frame_ind1=0
         
-        for fmri in ${fMRIs[@]}; do
+        for fmri in "${fMRIs[@]}"; do
             fmri_rt=$resultsDir/"$fmri/${fmri}_Atlas_${RegName}_hp${HighPass}_clean_tclean"
             NumTPs=$(wb_command -file-information "$fmri_rt.dtseries.nii" -only-number-of-maps)
             frame_ind2=$(( frame_ind1 + NumTPs ))

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -63,7 +63,7 @@ function makeTemplateConcatRuns {
     #loop variables 
     local session sessionLong resultsDir fmri fmri_rt frame_ind1 frame_ind2 NumTPs temp_demean1_v1 temp_demean1 temp_demean2_v1 temp_demean2
     
-    for session in ${sessions[*]}; do
+    for session in "${sessions[@]}"; do
         sessionLong="$session.long.$template"
         echo "Timepoint: $sessionLong"
         resultsDir="$StudyFolder"/"$sessionLong"/MNINonLinear/Results

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -17,11 +17,110 @@ source "$HCPPIPEDIR/global/scripts/tempfiles.shlib" "$@"
 opts_SetScriptDescription "creates tICA cleaned data for all longitudinal sessions in template directory"
 
 opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder that contains all sessions"
+opts_AddMandatory '--subject' 'subject ID' 'str' 'longitudinal subject ID'
 opts_AddMandatory '--session-list' 'SesslistRaw' 'HCA6002236_V1_MR@HCA6002236_V2_MR...' "list of longitudinal timepoint/session IDs separated by @s."
-opts_AddMandatory '--fmri-names' 'fMRINames' 'rfMRI_REST1_LR@rfMRI_REST1_RL...' "list of all fmri run names separated by @s"
+opts_AddMandatory '--template-long' 'TemplateLong' 'Longitudinal template ID'
+opts_AddMandatory '--extract-fmri-name-list' 'concatNamesToUse' 'name@name@name...' "list of fMRI run names to concatenate into the --extract-fmri-out output after tICA cleanup"
+opts_AddMandatory '--highpass' 'HighPass' 'hp value' 'High pass used with these data [0]' "0"
+opts_AddMandatory '--extract-fmri-out' 'extractNameOut' 'name' "fMRI name for concatenated extracted runs, requires --extract-fmri-name-list"
+opts_AddOptional  '--reg-name' 'RegName' 'registration algorithm' "Cortical registration algorithm used [MSMAll]" "MSMAll"
+opts_AddOptional '--extract-fmri-out-all' 'extractNameAll' 'name' "Concatenated run label. If specified, concatenate all runs specified by --fmri-names, for all timepoints." ""
+opts_AddOptional '--fmri-names' 'fMRINames' 'rfMRI_REST1_LR@rfMRI_REST1_RL...' "list of all fmri run names separated by @s. Required with --extract-fmri-out-all" ""
 
-opts_AddOptional '--extract-fmri-name-list' 'concatNamesToUse' 'name@name@name...' "list of fMRI run names to concatenate into the --extract-fmri-out output after tICA cleanup"
-opts_AddOptional '--extract-fmri-out' 'extractNameOut' 'name' "fMRI name for concatenated extracted runs, requires --extract-fmri-name-list"
-opts_AddOptional '--extract-fmri-out-only' 'ExtractfMRIOnly' 'TRUE or FALSE'  'Only output timepoints specified in --extract-frmi-name-list and --extract-fmri-out' 'FALSE'
+opts_ParseArguments "$@"
 
-ExtractfMRIOnly=$(opts_StringToBool "$ExtractfMRIOnly")
+if ((pipedirguessed))
+then
+    log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
+fi
+
+if [[ "$extractNameAll" != "" && "$fMRINames" == "" ]]; then 
+    log_Err_Abort "-fmri-names is required with --extract-fmri-out-all"
+fi
+
+#display the parsed/default values
+opts_ShowValues
+
+#do work
+TemplateDir="$StudyFolder"/"$Subject.$TemplateLong"
+
+function makeTemplateConcatRuns{
+    local fMRIStr="$1" sessionsStr="$2" template="$3" nameOut="$4" 
+    local fMRIs sessions
+    IFS=@ read -r -a fMRIs <<< "${fMRIStr}"
+    IFS=@ read -r -a sessionsStr <<< "${sessions}"
+    local OutDir="$TemplateDir/MNINonLinear/Results/$nameOut"
+    mkdir -p $OutDir
+    
+    #commands to create output files
+    local vn_average_cifti="wb_command -cifti-average $OutDir/${nameOut}_Atlas_"$RegName"_hp${HighPass}_clean_tclean_vn.dscalar.nii" 
+    local vn_average_nifti="fslmerge -t  "$OutDir"/"$nameOut"_hp"$HighPass"_clean_tclean_vn.nii.gz" #average of the _vn from all timepoints
+    local ts_concat_cifti="wb_command -cifti-merge "$nameOut"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_v1.dtseries.nii"
+    local ts_concat_nifti="fslmerge -t "$OutDir"/"$nameOut"_clean_tclean_v1.nii" #average nifti timeseries
+    
+    #loop variables 
+    local session sessionLong resultsDir fmri fmri_rt
+    
+    local ts_all_dtseries_clean #concatenated runs from all timepoints in order after demeaning, dividing by _vn and muliplying by the average _vn
+    for session in "${sessions[*]}"; do
+        sessionLong="$Session.long.$template"
+        resultsDir="$StudyFolder"/"$SessionLong"/MNINonLinear/Results
+        for fmri in "${fMRIs[*]}"; do
+
+            #demean each fmri and save to temporary file - cifti
+            fmri_rt=$resultsDir/"$fmri"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean
+            wb_command -cifti-reduce "$fmri_rt".dtseries.nii MEAN "$fmri_rt"_mean.dscalar.nii
+            wb_command -cifti-math '(D - M) / VN' "$fmri_rt"_demean.dtseries.nii\
+                -var D "$fmri_rt".dtseries.nii -var M "$fmri_rt"_mean.dscalar.nii \
+                -var VN $resultsDir/"$fmri"_Atlas_"$RegName"_hp"$HighPass"_vn.dscalar.nii
+
+            rm "$fmri_rt"_mean.dscalar.nii
+            wb_command -cifti-math 'TS / VN' 
+            ts_concat_cifti="$ts_concat_cifti -cifti "$fmri_rt"_demean.dtseries.nii"
+            
+            #demean each fmri and save to temporary file - nifti
+            fmri_rt=$resultsDir/"$fmri"_hp"$HighPass"_clean_tclean
+            fslmaths "$fmri_rt".nii.gz -Tmean -mul -1 -add "$fmri_rt".nii.gz -div $resultsDir/"$fmri"_hp"$HighPass"_vn.nii.gz "$fmri_rt"_demean.nii
+            ts_concat_nifti="$ts_concat_nifti ${fmri_rt}_demean.nii.gz"
+
+            #average vn's in atlas and native space
+            vn_average_cifti="$vn_average_cifti $resultsDir/$fmri/${fmri}_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_vn.dscalar.nii"
+            vn_average_nifti="$vn_average_nifti $resultsDir"/$fmri/${fmri}_hp"$HighPass"_clean_tclean_vn.nii.gz
+        done
+    done
+    #run concat commands
+    "$ts_concat_cifti"
+    "$ts_concat_nifti"
+    "$vn_average_cifti"
+    "$vn_average_nifti"
+    #multiply by average _vn file
+    wb_command -cifti-math "TS * VN" $OutDir/${nameOut}_Atlas_"$RegName"_hp${HighPass}"_clean_tclean.dtseries.nii.gz" \
+        -var TS "$nameOut"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_v1.dtseries.nii \
+        -var VN "$OutDir/${nameOut}"_Atlas_"$RegName"_hp${HighPass}_vn.dscalar.nii
+    
+    fslmaths "$OutDir"/"$nameOut"_clean_tclean_v1.nii -mul "$OutDir"/"$nameOut"_hp"$HighPass"_clean_tclean_vn.nii.gz \
+        "$OutDir"/"$nameOut"_clean_tclean.nii.gz
+        
+    #clean up
+    rm "$nameOut"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_v1.dtseries.nii \
+        "$OutDir"/"$nameOut"_clean_tclean_v1.nii
+        #"$OutDir/${nameOut}"_Atlas_"$RegName"_hp${HighPass}_vn.dscalar.nii \
+        #"$OutDir"/"$nameOut"_clean_tclean_vn.nii.gz
+        
+    for session in "${sessions[*]}"; do
+        sessionLong="$Session.long.$template"
+        resultsDir="$StudyFolder"/"$SessionLong"/MNINonLinear/Results
+        for fmri in "${fMRIs[*]}"; do
+            rm $resultsDir/"$fmri"_Atlas_"$RegName"_hp"$HighPass"_clean_tclean_demean.dtseries.nii
+            rm $resultsDir/"$fmri"_hp"$HighPass"_clean_tclean_demean.nii
+        done
+    done
+}
+
+#create outputs from the selected time series across all timepoints.
+makeTemplateConcatRuns "$concatNamesToUse" "$SesslistRaw" "$TemplateLong" "$extractNameOut"
+
+#optionally, create outputs from all time series.
+if [[ "$extractfMRIOutAll" != "" ]]; then 
+    makeTemplateConcatRuns "$fMRINames" "$SesslistRaw" "$TemplateLong" "$extractNameOutAll"
+fi

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -25,8 +25,8 @@ opts_AddMandatory '--highpass' 'HighPass' 'hp value' 'High pass used with these 
 opts_AddMandatory '--extract-fmri-name' 'extractNameOut' 'name' "fMRI name for concatenated extracted runs.
 Must match the one used in cortical registration."
 opts_AddOptional  '--reg-name' 'RegName' 'registration algorithm' "Cortical registration algorithm used [MSMAll]" "MSMAll"
-opts_AddOptional  '--fmri-name-concat-all' 'extractNameAll' 'name' "Concatenated output run label. If specified, must match the one used in multi-run FIX and cortical registration." ""
-opts_AddOptional  '--fmri-names' 'fMRINames' 'rfMRI_REST1_LR@rfMRI_REST1_RL...' "list of all fmri run names separated by @. Required with --extract-fmri-out-all" ""
+opts_AddOptional  '--fmri-name-concat-all' 'extractNameAll' 'name' "Concatenated output run label. If specified, must match the one used in multi-run FIX and cortical registration.  Requires --fmri-names."
+opts_AddOptional  '--fmri-names' 'fMRINames' 'rfMRI_REST1_LR@rfMRI_REST1_RL...' "when using --fmri-name-concat-all, specify the list of MR FIX run names separated by @ here"
 
 opts_ParseArguments "$@"
 

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -35,14 +35,14 @@ then
     log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
 fi
 
-if [[ "$extractNameAll" != "" && "$fMRINames" == "" ]]; then 
-    log_Err_Abort "--fmri-names is required with --fmri-name-concat-all"
-fi
-
 #display the parsed/default values
 opts_ShowValues
 
 #do work
+if [[ "$extractNameAll" != "" && "$fMRINames" == "" ]]; then 
+    log_Err_Abort "--fmri-names is required with --fmri-name-concat-all"
+fi
+
 TemplateDir="$StudyFolder"/"$Subject.long.$TemplateLong"
 
 function makeTemplateConcatRuns {
@@ -55,10 +55,10 @@ function makeTemplateConcatRuns {
     mkdir -p "$OutDir"
     
     #per fMRI run lists for concat/merge commands
-    local vn_average_cifti_array
-    local vn_average_nifti_array #average of the _vn from all timepoints
-    local ts_concat_cifti_array
-    local ts_concat_nifti_array #average nifti timeseries
+    local vn_average_cifti_array=()
+    local vn_average_nifti_array=() #average of the _vn from all timepoints
+    local ts_concat_cifti_array=()
+    local ts_concat_nifti_array=() #average nifti timeseries
     
     #loop variables 
     local session sessionLong resultsDir fmri fmri_rt frame_ind1 frame_ind2 NumTPs

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eu
+
+pipedirguessed=0
+if [[ "${HCPPIPEDIR:-}" == "" ]]
+then
+    pipedirguessed=1
+    #fix this if the script is more than one level below HCPPIPEDIR
+    export HCPPIPEDIR="$(dirname -- "$0")/.."
+fi
+
+source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
+source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
+source "$HCPPIPEDIR/global/scripts/tempfiles.shlib" "$@"
+
+#description to use in usage - syntax of parameters is now explained automatically
+opts_SetScriptDescription "creates tICA cleaned data for all longitudinal sessions in template directory"
+
+opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder that contains all sessions"
+opts_AddMandatory '--session-list' 'SesslistRaw' 'HCA6002236_V1_MR@HCA6002236_V2_MR...' "list of longitudinal timepoint/session IDs separated by @s."
+opts_AddMandatory '--fmri-names' 'fMRINames' 'rfMRI_REST1_LR@rfMRI_REST1_RL...' "list of all fmri run names separated by @s"
+
+opts_AddOptional '--extract-fmri-name-list' 'concatNamesToUse' 'name@name@name...' "list of fMRI run names to concatenate into the --extract-fmri-out output after tICA cleanup"
+opts_AddOptional '--extract-fmri-out' 'extractNameOut' 'name' "fMRI name for concatenated extracted runs, requires --extract-fmri-name-list"
+opts_AddOptional '--extract-fmri-out-only' 'ExtractfMRIOnly' 'TRUE or FALSE'  'Only output timepoints specified in --extract-frmi-name-list and --extract-fmri-out' 'FALSE'
+
+ExtractfMRIOnly=$(opts_StringToBool "$ExtractfMRIOnly")

--- a/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
+++ b/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh
@@ -82,44 +82,32 @@ function makeTemplateConcatRuns {
             
             # 1. cifti: Extract demeaned tcleaned fMRI run, divide by vn
             tempfiles_create temp_demean_XXXXX.dtseries.nii temp_demean1
-            #wb_command -cifti-merge "${fmri_rt}_demean.dtseries.nii" \
             wb_command -cifti-merge "$temp_demean1" \
                 -cifti "$resultsDir/${nameOut}/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean.dtseries.nii" \
                 -index $(( frame_ind1 + 1 ))  \
                 -up-to $(( frame_ind2 ))
             
-            tempfile_create temp_demean_v1_XXXXX.dtseries.nii temp_demean1_v1
-            #wb_command -cifti-math 'TS / VN' "${fmri_rt}_demean_v1.dtseries.nii" \
-            #-var TS "${fmri_rt}_demean.dtseries.nii" \
+            tempfiles_create temp_demean_v1_XXXXX.dtseries.nii temp_demean1_v1
             wb_command -cifti-math 'TS / VN' "$temp_demean1_v1" \
                 -var TS "$temp_demean1" \
                 -var VN "$resultsDir/${nameOut}/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii" -select 1 1 -repeat
-            #ts_concat_cifti_array+=(-cifti "${fmri_rt}_demean_v1.dtseries.nii")
-            ts_concat_cifti_array+=(-cifti "$temp_demean_v1")
-            #clean up
-            #rm -f "${fmri_rt}_demean.dtseries.nii"
+            ts_concat_cifti_array+=(-cifti "$temp_demean1_v1")
 
             # 2. NIFTI processing
             fmri_rt="$resultsDir/$fmri/${fmri}_hp${HighPass}_clean_tclean"
             #extract NIFTI time series and divide by average cleaned session's vn
-            tempfile_create temp_demean_XXXXX.nii temp_demean2
-            #wb_command -volume-merge "${fmri_rt}_demean.nii" \
+            tempfiles_create temp_demean_XXXXX.nii temp_demean2
             wb_command -volume-merge "$temp_demean2" \
                 -volume "$resultsDir/${nameOut}/${nameOut}_hp${HighPass}_clean_tclean.nii.gz" \
                 -subvolume $(( frame_ind1 + 1 )) \
                 -up-to $(( frame_ind2 ))
-            tempfile_create temp_demean2_v1_XXXXX.nii temp_demean2_v1
-            #wb_command -volume-math 'TS / VN' "${fmri_rt}_demean_v1.nii" \
-            #-var TS "${fmri_rt}_demean.nii" \
+            tempfiles_create temp_demean2_v1_XXXXX.nii temp_demean2_v1
             wb_command -volume-math 'TS / VN' "$temp_demean2_v1" \
                 -var TS "$temp_demean2" \
                 -var VN "$resultsDir/${nameOut}/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz" -repeat
             
-            #ts_concat_nifti_array+=(-volume "${fmri_rt}_demean_v1.nii")
             ts_concat_nifti_array+=(-volume "$temp_demean2_v1")
-            #clean up
-            #rm -f "${fmri_rt}_demean.nii"
-            
+
             # 3. Update the starting frame
             frame_ind1="$frame_ind2"
         done
@@ -127,51 +115,26 @@ function makeTemplateConcatRuns {
     local concat_cifti_v1 concat_nifti_v1 concat_nifti_vn
 
     # concatenate time series across sessions and runs
-    tempfile_create temp_concat_cifti_v1_XXXXX.dtseries.nii concat_cifti_v1
-    #wb_command -cifti-merge "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_v1.dtseries.nii" "${ts_concat_cifti_array[@]}"
+    tempfiles_create temp_concat_cifti_v1_XXXXX.dtseries.nii concat_cifti_v1
     wb_command -cifti-merge "$concat_cifti_v1" "${ts_concat_cifti_array[@]}"
-    tempfile_create temp_concat_nifti_v1_XXXXX.nii concat_nifti_v1
-    #wb_command -volume-merge "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_v1.nii" "${ts_concat_nifti_array[@]}"
+    tempfiles_create temp_concat_nifti_v1_XXXXX.nii concat_nifti_v1
     wb_command -volume-merge "$concat_nifti_v1" "${ts_concat_nifti_array[@]}"
     
     # average vn's across sessions
     wb_command -cifti-average "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii" "${vn_average_cifti_array[@]}"
-    tempfile_create temp_concat_nifti_vn_XXXXX.nii.gz concat_nifti_vn
+    tempfiles_create temp_concat_nifti_vn_XXXXX.nii.gz concat_nifti_vn
     wb_command -volume-merge "$concat_nifti_vn" "${vn_average_nifti_array[@]}"
-    #wb_command -volume-merge "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn_all.nii.gz" "${vn_average_nifti_array[@]}"
     wb_command -volume-reduce "$concat_nifti_vn" MEAN "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz"
-    #wb_command -volume-reduce "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn_all.nii.gz" MEAN "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz"
 
     # multiply by average _vn - cifti
     wb_command -cifti-math "TS * VN" "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean.dtseries.nii" \
        -var TS "$concat_cifti_v1" \
        -var VN "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii" -select 1 1 -repeat
 
-    #wb_command -cifti-math "TS * VN" "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean.dtseries.nii" \
-    #   -var TS "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_v1.dtseries.nii" \
-    #   -var VN "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_vn.dscalar.nii" -select 1 1 -repeat
-
     # multiply by average _vn - nifti
     wb_command -volume-math "TS * VN" "$OutDir/${nameOut}_hp${HighPass}_clean_tclean.nii.gz" \
         -var TS "$concat_nifti_v1" \
         -var VN "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz" -repeat
-    #wb_command -volume-math "TS * VN" "$OutDir/${nameOut}_hp${HighPass}_clean_tclean.nii.gz" \
-    #    -var TS "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_v1.nii" \
-    #    -var VN "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn.nii.gz" -repeat
-
-    #clean up
-    #rm -f "$OutDir/${nameOut}_Atlas_${RegName}_hp${HighPass}_clean_tclean_v1.dtseries.nii" \
-    #    "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_v1.nii" \
-    #    "$OutDir/${nameOut}_hp${HighPass}_clean_tclean_vn_all.nii.gz"
-        
-    #for session in ${sessions[*]}; do
-    #    sessionLong="$session.long.$template"
-    #    resultsDir="$StudyFolder/$sessionLong/MNINonLinear/Results"
-    #    for fmri in ${fMRIs[*]}; do
-    #        rm -f "$resultsDir/$fmri/${fmri}_Atlas_${RegName}_hp${HighPass}_clean_tclean_demean_v1.dtseries.nii" \
-    #            "$resultsDir/$fmri/${fmri}_hp${HighPass}_clean_tclean_demean_v1.nii"
-    #    done
-    #done
 }
 
 #create outputs for the selected time series across all timepoints.

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -49,7 +49,7 @@ opts_AddOptional '--ica-mode' 'ICAmode' 'string' "whether to use parts of a prev
 NEW - estimate a new sICA and a new tICA
 REUSE_SICA_ONLY - reuse an existing sICA and estimate a new tICA
 INITIALIZE_TICA - reuse an existing sICA and use an existing tICA to start the estimation
-REUSE_TICA - reuse an existing sICA and an existing tICA (this mode is recommended for longitudinal processing)" \
+REUSE_TICA - reuse an existing sICA and an existing tICA (this mode is mandatory for longitudinal processing)" \
     'NEW'
 #TSC: this is the output group folder, one above MNINonLinear
 opts_AddConfigOptional '--precomputed-clean-folder' 'precomputeTICAFolder' 'precomputeTICAFolder' 'folder' "group folder containing an existing tICA cleanup to make use of for REUSE or INITIALIZE modes"
@@ -162,7 +162,7 @@ fi
 
 if [[ "$IsLongitudinal" == "1" ]]; then
     if [[ "$ICAmode" != "REUSE_ICA" ]]; then
-        log_Warn "mode other than REUSE_ICA is not recommended for longitudinal processing"
+        log_Err "mode other than REUSE_ICA is not supported in longitudinal processing"
     fi
     if [[ "$TemplateLong" == "" || "$Subject" == "" || "$extractNameOut" == "" ]]; then 
         log_Err_Abort "--extract-fmri-out, --longitudinal-template and --longitudinal-subject are required in longitudinal mode."

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -49,7 +49,7 @@ opts_AddOptional '--ica-mode' 'ICAmode' 'string' "whether to use parts of a prev
 NEW - estimate a new sICA and a new tICA
 REUSE_SICA_ONLY - reuse an existing sICA and estimate a new tICA
 INITIALIZE_TICA - reuse an existing sICA and use an existing tICA to start the estimation
-REUSE_TICA - reuse an existing sICA and an existing tICA" \
+REUSE_TICA - reuse an existing sICA and an existing tICA (this mode is recommended for longitudinal processing)" \
     'NEW'
 #TSC: this is the output group folder, one above MNINonLinear
 opts_AddConfigOptional '--precomputed-clean-folder' 'precomputeTICAFolder' 'precomputeTICAFolder' 'folder' "group folder containing an existing tICA cleanup to make use of for REUSE or INITIALIZE modes"
@@ -161,6 +161,9 @@ then
 fi
 
 if [[ "$IsLongitudinal" == "1" ]]; then
+    if [[ "$ICAmode" != "REUSE_ICA" ]]; then
+        log_Warn "mode other than REUSE_ICA is not recommended for longitudinal processing"
+    fi
     if [[ "$TemplateLong" == "" || "$Subject" == "" || "$extractNameOut" == "" ]]; then 
         log_Err_Abort "--extract-fmri-out, --longitudinal-template and --longitudinal-subject are required in longitudinal mode."
     fi

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -160,7 +160,7 @@ then
     signalTxtName="ReCleanSignal.txt"
 fi
 
-if [[ "$IsLongitudinal" == "1" ]]; then
+if ((IsLongitudinal)); then
     if [[ "$ICAmode" != "REUSE_ICA" ]]; then
         log_Err_Abort "mode other than REUSE_ICA is not supported in longitudinal processing"
     fi

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -161,13 +161,13 @@ then
 fi
 
 if ((IsLongitudinal)); then
-    if [[ "$ICAmode" != "REUSE_ICA" ]]; then
-        log_Err_Abort "mode other than REUSE_ICA is not supported in longitudinal processing"
+    if [[ "$ICAmode" != "REUSE_TICA" ]]; then
+        log_Err_Abort "mode other than REUSE_TICA is not supported in longitudinal processing"
     fi
-    if [[ "$TemplateLong" == "" || "$Subject" == "" || "$extractNameOut" == "" ]]; then 
+    if [[ "$TemplateLong" == "" || "$Subject" == "" || "$extractNameOut" == "" ]]; then
         log_Err_Abort "--extract-fmri-out, --longitudinal-template and --longitudinal-subject are required in longitudinal mode."
     fi
-    if ((ExtractAllRunsLong)); then 
+    if ((ExtractAllRunsLong)); then
         extractNameAllLong="$MRFixConcatName"
     fi
     IFS='@' read -a SesslistCross <<<"$SesslistRaw"
@@ -175,7 +175,7 @@ if ((IsLongitudinal)); then
     for sess in "${SesslistCross[@]}"; do
         Sesslist+=("${sess}.long.$TemplateLong")
     done
-else 
+else
     IFS='@' read -a Sesslist <<<"$SesslistRaw"
 fi
 
@@ -275,7 +275,7 @@ then
     then
         log_Err_Abort "you must specify --precomputed-clean-folder, --precomputed-clean-fmri-name and --precomputed-group-name when using --ica-mode=$ICAmode"
     fi
-    
+
     tICACleaningFolder="$precomputeTICAFolder"
     tICACleaningfMRIName="$precomputeTICAfMRIName"
     tICACleaningGroupAverageName="$precomputeGroupName"
@@ -408,15 +408,15 @@ do
             then
                 tICADim="$sICAActualDim"
             fi
-            
+
             #now we have the dimensionality, set the output string
             OutputString="$OutputfMRIName"_d"$sICAActualDim"_WF"$numWisharts"_"$tICACleaningGroupAverageName""$extraSuffixSTRING"
-            
+
             ;;
         (indProjSICA)
             #generate volume template cifti
             #use parallel and do sessions separately first to reduce memory (some added IO)
-            
+
             #in REUSE_TICA mode, VolumeTemplateFile may point to an existing file in the precomputed folder, don't try to write to it if so
             #side effect: only computes the brainmask on first run in REUSE_TICA mode when resolution doesn't match
             if [[ "$tICAmode" != "USE" || ! -f "$VolumeTemplateFile" ]]
@@ -435,7 +435,7 @@ do
                 tempfiles_add "${StudyFolder}/${GroupAverageName}/MNINonLinear/brain_mask_all_${OutputfMRIName}.${fMRIResolution}.nii.gz" \
                     "${StudyFolder}/${GroupAverageName}/MNINonLinear/${GroupAverageName}_CIFTIVolumeTemplate_${OutputfMRIName}.${fMRIResolution}.txt" \
                     "${StudyFolder}/${GroupAverageName}/MNINonLinear/brain_mask_label_${OutputfMRIName}.${fMRIResolution}.nii.gz"
-                    
+
                     #"${StudyFolder}/${GroupAverageName}/MNINonLinear/brain_mask_max_${OutputfMRIName}.${fMRIResolution}.nii.gz" \ should be kept for feature processing
                 wb_command -volume-merge "${StudyFolder}/${GroupAverageName}/MNINonLinear/brain_mask_all_${OutputfMRIName}.${fMRIResolution}.nii.gz" \
                     "${mergeArgs[@]}"
@@ -452,7 +452,7 @@ do
                     -volume "${StudyFolder}/${GroupAverageName}/MNINonLinear/brain_mask_max_${OutputfMRIName}.${fMRIResolution}.nii.gz" \
                         "${StudyFolder}/${GroupAverageName}/MNINonLinear/brain_mask_label_${OutputfMRIName}.${fMRIResolution}.nii.gz"
             fi
-            
+
             for Session in "${Sesslist[@]}"
             do
                 if [[ "$MRFixConcatName" != "" ]]
@@ -533,7 +533,7 @@ do
                 #current mixing matrix naming convention is in ComputeGroupTICA.sh/m
                 #"sICADim" is the --ica-dim argument, which is actually the tICA dim
                 #OutputFolder="$OutGroupFolder/MNINonLinear/Results/$fMRIConcatName/tICA_d$sICAdim"
-                
+
                 #tICAmixNamePart = 'melodic_mix';
                 #nlfunc = 'tanh';
 
@@ -557,9 +557,9 @@ do
                 #    dlmwrite([OutputFolder '/' tICAmixNamePart nameParamPart], tICAmix, '\t');
                 tica_cmd+=(--tICA-mixing-matrix="$tICACleaningFolder/MNINonLinear/Results/$tICACleaningfMRIName/tICA_d$tICADim/melodic_mix_${tICADim}_tanhF")
             fi
-            
+
             "${tica_cmd[@]}"
-            
+
             ;;
         (indProjTICA)
             for Session in "${Sesslist[@]}"
@@ -697,7 +697,7 @@ then
     opts_conf_WriteConfig "$confoutfile"
 fi
 
-if (( IsLongitudinal )); then 
+if (( IsLongitudinal )); then
     #Split, group variance normalize and concatenate cleaned timeseries across all sessions, storing in longitudinal template output.
     #Also create averages across sessions for cleaned variance.
     "$HCPPIPEDIR"/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh \

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -162,17 +162,17 @@ fi
 
 if [[ "$IsLongitudinal" == "1" ]]; then
     if [[ "$ICAmode" != "REUSE_ICA" ]]; then
-        log_Err "mode other than REUSE_ICA is not supported in longitudinal processing"
+        log_Err_Abort "mode other than REUSE_ICA is not supported in longitudinal processing"
     fi
     if [[ "$TemplateLong" == "" || "$Subject" == "" || "$extractNameOut" == "" ]]; then 
         log_Err_Abort "--extract-fmri-out, --longitudinal-template and --longitudinal-subject are required in longitudinal mode."
     fi
-    if [[ "$ExtractAllRunsLong" == "1" ]]; then 
+    if ((ExtractAllRunsLong)); then 
         extractNameAllLong="$MRFixConcatName"
     fi
     IFS='@' read -a SesslistCross <<<"$SesslistRaw"
     Sesslist=()
-    for sess in ${SesslistCross[@]}; do
+    for sess in "${SesslistCross[@]}"; do
         Sesslist+=("${sess}.long.$TemplateLong")
     done
 else 


### PR DESCRIPTION
Longitudinal adaptation of tICA pipeline. The main difference with the base version is the new script tICAMakeCleanLongitudinalTemplate.sh called in the end of tICAPipeline.sh. This script extracts cleaned fMRI runs from each of the sessions, normalizes variance, re-concatenates across all runs and sessions, and multiplies by session-averaged sICA and tICA cleaned variance. The output is stored under the longitudinal template MNINonLinear/Results folder.