### PR TITLE
Bugfix longitudinal example

### DIFF
--- a/Examples/Scripts/DeDriftAndResamplePipelineBatch-long.sh
+++ b/Examples/Scripts/DeDriftAndResamplePipelineBatch-long.sh
@@ -4,7 +4,6 @@ get_batch_options() {
     local arguments=("$@")
 
     command_line_specified_study_folder=""
-    command_line_specified_subj=""
     command_line_specified_run_local="FALSE"
 
     local index=0
@@ -134,10 +133,6 @@ MyelinTargetFile="${MSMAllTemplates}/Q1-Q6_RelatedParcellation210.MyelinMap_BC_M
 
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
-fi
-
-if [ -n "${command_line_specified_subj}" ]; then
-    Subjlist="${command_line_specified_subj}"
 fi
 
 # Log the originating call


### PR DESCRIPTION
Fix undefined loop variable in longitudinal batch example.

The loop variable `i` was never defined when accessing Templates array, causing the script to fail or use incorrect templates for subjects.

This assumes Templates and Subjlist arrays are meant to be parallel (subject i uses template i). I believe this is the intention, by example of other scripts in the same directory.