### PR TITLE
+Move longitudinal FreeSurfer outputs to longitudinal session folders…

### DIFF
--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -418,6 +418,21 @@ post_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PostEdd
 log_Msg "post_eddy_cmd: ${post_eddy_cmd[*]}"
 "${post_eddy_cmd[@]}"
 
+# Clean up large diffusion files. Skip symlinks
+if (( IsLongitudinal )); then 
+    patterns_to_clean=(
+        'rawdata/Pos_[1-9]\.nii\.gz'
+        'rawdata/Neg_[1-9]\.nii\.gz'
+        'eddy/Pos_Neg\.nii\.gz'
+        'eddy/eddy_unwarped_images\.nii\.gz' 
+        'data/data\.nii\.gz'
+        'data/warped/data_warped\.nii\.gz' 
+    )
+    for pattern in "${patterns_to_clean[@]}"; do
+        find "${StudyFolder}/${DWIName}" -type f -regex "${StudyFolder}/${DWIName}/${pattern}" -delete
+    done
+fi
+
 log_Msg "Completed!"
 exit 0
 

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -418,19 +418,9 @@ post_eddy_cmd=("${HCPPIPEDIR}/DiffusionPreprocessing/DiffPreprocPipeline_PostEdd
 log_Msg "post_eddy_cmd: ${post_eddy_cmd[*]}"
 "${post_eddy_cmd[@]}"
 
-# Clean up large diffusion files. Skip symlinks
+# Clean up diffusion files in raw space for longitudinal runs
 if (( IsLongitudinal )); then 
-    patterns_to_clean=(
-        'rawdata/Pos_[1-9]\.nii\.gz'
-        'rawdata/Neg_[1-9]\.nii\.gz'
-        'eddy/Pos_Neg\.nii\.gz'
-        'eddy/eddy_unwarped_images\.nii\.gz' 
-        'data/data\.nii\.gz'
-        'data/warped/data_warped\.nii\.gz' 
-    )
-    for pattern in "${patterns_to_clean[@]}"; do
-        find "${StudyFolder}/${DWIName}" -type f -regex "${StudyFolder}/${DWIName}/${pattern}" -delete
-    done
+    rm -rf "${StudyFolder}/${DWIName}"
 fi
 
 log_Msg "Completed!"

--- a/DiffusionPreprocessing/DiffPreprocPipeline.sh
+++ b/DiffusionPreprocessing/DiffPreprocPipeline.sh
@@ -178,13 +178,13 @@ opts_AddMandatory '--path' 'StudyFolder' 'Path' "path to session's data folder"
 
 opts_AddMandatory '--session' 'Session' 'session ID' "" "--subject"
 
-opts_AddMandatory '--PEdir' 'PEdir' '1 or 2' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA"
+opts_AddOptional '--PEdir' 'PEdir' '1 or 2' "Phase encoding direction specifier: 1=LR/RL, 2=AP/PA. Required in cross-sectional mode. Not used in longitudinal mode."
 
-opts_AddMandatory '--posData' 'PosInputImages' 'data_RL1@data_RL2@...data_RLn' "An @ symbol separated list of data with 'positive' phase  encoding direction; e.g., data_RL1@data_RL2@...data_RLn, or data_PA1@data_PA2@...data_PAn"
+opts_AddOptional '--posData' 'PosInputImages' 'data_RL1@data_RL2@...data_RLn' "An @ symbol separated list of data with 'positive' phase  encoding direction; e.g., data_RL1@data_RL2@...data_RLn, or data_PA1@data_PA2@...data_PAn. Mandatory for cross-sectional mode, not used in longitudinal mode."
 
-opts_AddMandatory '--negData' 'NegInputImages' 'data_LR1@data_LR2@...data_LRn' "An @ symbol separated list of data with 'negative' phase encoding direction; e.g., data_LR1@data_LR2@...data_LRn, or data_AP1@data_AP2@...data_APn"
+opts_AddOptional '--negData' 'NegInputImages' 'data_LR1@data_LR2@...data_LRn' "An @ symbol separated list of data with 'negative' phase encoding direction; e.g., data_LR1@data_LR2@...data_LRn, or data_AP1@data_AP2@...data_APn. Mandatory for cross-sectional mode, not used in longitudinal mode."
 
-opts_AddOptional '--echospacing-seconds' 'echospacingsec' 'Number in sec' "Echo spacing in seconds, REQUIRED (or deprecated millisec option)"
+opts_AddOptional '--echospacing-seconds' 'echospacingsec' 'Number in sec' "Echo spacing in seconds, REQUIRED in cross-sectional mode (or deprecated millisec option). Not used in longitudinal mode."
 opts_AddOptional '--echospacing' 'echospacing' 'Number in millisec' "DEPRECATED: please use --echospacing-seconds"
 
 opts_AddMandatory '--gdcoeffs' 'GdCoeffs' 'Path' "Path to file containing coefficients that describe spatial variations of the scanner gradients. Applied *after* 'eddy'. Use --gdcoeffs=NONE if not available."
@@ -211,7 +211,7 @@ To get an argument like '-flag value' (where there is no '=' between the flag an
   --extra-eddy-arg=-flag --extra-eddy-arg=value"
 
 ## This is an extremely confusing flag should rework it to just use-gpu?
-opts_AddOptional '--gpu' 'gpuString' 'Boolean' "Specify whether to use the non-GPU-enabled version of eddy. Defaults to using the GPU-enabled version of eddy i.e. True." "True"
+opts_AddOptional '--gpu' 'gpuString' 'Boolean' "Specify whether to use the non-GPU-enabled version of eddy. Defaults to using the GPU-enabled version of eddy i.e. True. Not used in longitudinal mode." "True"
 
 opts_AddOptional '--cuda-version' 'cuda_version' 'X.Y' " If using the GPU-enabled version of eddy then this option can be used to specify which eddy_cuda binary version to use. If specified, FSLDIR/bin/eddy_cudaX.Y will be used."
 
@@ -252,15 +252,26 @@ then
     TopupConfig="${HCPPIPEDIR_Config}/b02b0.cnf"
 fi
 
-#resolve echo spacing being required and exclusivity
-if [[ "$echospacing" == "" && "$echospacingsec" == "" ]]
-then
-    log_Err_Abort "You must specify --echospacing-seconds or --echospacing"
-fi
+IsLongitudinal=$(opts_StringToBool "$IsLongitudinal")
 
-if [[ "$echospacing" != "" && "$echospacingsec" != "" ]]
-then
-    log_Err_Abort "You must not specify both --echospacing-seconds and --echospacing"
+if (( IsLongitudinal == 0 )); then 
+    if [ -z "$PEdir" -o -z "$PosInputImages" -o -z "$NegInputImages" ]; then 
+        log_Err_Abort "--PEdir, --posData, --negData must be specified in cross-sectional mode"
+    fi
+    #resolve echo spacing being required and exclusivity
+    if [[ "$echospacing" == "" && "$echospacingsec" == "" ]]
+    then
+        log_Err_Abort "You must specify --echospacing-seconds or --echospacing"
+    fi
+
+    if [[ "$echospacing" != "" && "$echospacingsec" != "" ]]
+    then
+        log_Err_Abort "You must not specify both --echospacing-seconds and --echospacing"
+    fi
+else
+    if [ -n "$gpuString" ]; then 
+        log_Warn "--gpu is not used in longitudinal mode"
+    fi
 fi
 
 #internally, PreEddy script expects milliseconds
@@ -311,7 +322,6 @@ if ((SelectBestB0)); then
 fi
 
 #parse longitudinal arguments
-IsLongitudinal=$(opts_StringToBool "$IsLongitudinal")
 T1wCross2LongXfm=""
 
 if (( IsLongitudinal )); then

--- a/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
+++ b/DiffusionPreprocessing/scripts/DiffusionToStructural.sh
@@ -75,6 +75,8 @@ if (( ! IsLongitudinal )); then
 	${FSLDIR}/bin/convert_xfm -omat "$WorkingDirectory"/str2diff.mat -inverse "$WorkingDirectory"/diff2str.mat
 else
 	${FSLDIR}/bin/convert_xfm -omat "$WorkingDirectory"/diff2str_long.mat -concat "$T1wCross2LongXfm" "$WorkingDirectory"/diff2str.mat	
+	#this may be needed if "$WorkingDirectory"/diff2str.mat is a symlink pointing to a read-only file
+	rm -f "$WorkingDirectory"/diff2str.mat
 	cp "$WorkingDirectory"/diff2str_long.mat "$WorkingDirectory"/diff2str.mat
 fi
 

--- a/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
+++ b/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
@@ -67,9 +67,6 @@ PRINTCOM=""
 #	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir96_LR.nii.gz
 #	${StudyFolder}/${Subject}/unprocessed/3T/Diffusion/${SessionID}_3T_DWI_dir97_LR.nii.gz
 
-#Change Scan Settings: Echo Spacing and PEDir to match your images
-#These are set to match the HCP Protocol by default
-
 #If using gradient distortion correction, use the coefficents from your scanner
 #The HCP gradient distortion coefficents are only available through Siemens
 #Gradient distortion in standard scanners like the Trio is much less than for the HCP Skyra.
@@ -88,40 +85,6 @@ for i in "${!Subjects[@]}"; do
 		echo "Processing Timepoint: ${TimepointLong}"
 	    #Input Variables
 	    RawDataDir="$StudyFolder/$TimepointCross/unprocessed/Diffusion" #Folder where unprocessed diffusion data are
-
-	    # PosData is a list of files (separated by ‘@‘ symbol) having the same phase encoding (PE) direction 
-	    # and polarity. Similarly for NegData, which must have the opposite PE polarity of PosData.
-	    # The PosData files will come first in the merged data file that forms the input to ‘eddy’.
-	    # The particular PE polarity assigned to PosData/NegData is not relevant; the distortion and eddy 
-	    # current correction will be accurate either way.
-	    #
-	    # NOTE that PosData defines the reference space in 'topup' and 'eddy' AND it is assumed that
-	    # each scan series begins with a b=0 acquisition, so that the reference space in both
-	    # 'topup' and 'eddy' will be defined by the same (initial b=0) volume.
-	    #
-	    # On Siemens scanners, we typically use 'R>>L' ("RL") as the 'positive' direction for left-right
-	    # PE data, and 'P>>A' ("PA") as the 'positive' direction for anterior-posterior PE data.
-	    # And conversely, "LR" and "AP" are then the 'negative' direction data.
-	    # However, see preceding comment that PosData defines the reference space; so if you want the
-	    # first temporally acquired volume to define the reference space, then that series needs to be
-	    # the first listed series in PosData.
-	    #
-	    # Note that only volumes (gradient directions) that have matched Pos/Neg pairs are ultimately
-	    # propagated to the final output, *and* these pairs will be averaged to yield a single
-	    # volume per pair. This reduces file size by 2x (and thence speeds subsequent processing) and
-	    # avoids having volumes with different SNR features/ residual distortions.
-	    # [This behavior can be changed via the --combine-data-flag if necessary].
-	  
-	  	#Not needed in longitudinal mode
-  	    #PosData="${RawDataDir}/${TimepointCross}_dMRI_dir98_PA.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_PA.nii.gz"
-	    #NegData="${RawDataDir}/${TimepointCross}_dMRI_dir98_AP.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_AP.nii.gz"
-	  
-	    # "Effective" Echo Spacing of dMRI image (now specified in seconds for the dMRI processing)
-	    # EchoSpacing = 1/(BWPPPE * ReconMatrixPE)
-	    #   where BWPPPE is the "BandwidthPerPixelPhaseEncode" = DICOM field (0019,1028) for Siemens, and
-	    #   ReconMatrixPE = size of the reconstructed image in the PE dimension
-	    # In-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
-	    # all potentially need to be accounted for (which they are in Siemen's reported BWPPPE)
 
 	    # Gradient distortion correction
 	    # Set to NONE to skip gradient distortion correction

--- a/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
+++ b/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
@@ -122,10 +122,6 @@ for i in "${!Subjects[@]}"; do
 	    #   ReconMatrixPE = size of the reconstructed image in the PE dimension
 	    # In-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
 	    # all potentially need to be accounted for (which they are in Siemen's reported BWPPPE)
-		#Not needed in longitudinal mode
-	    #EchoSpacingSec=0.00078
-	  
-	    #PEdir=2 #Use 1 for Left-Right Phase Encoding, 2 for Anterior-Posterior
 
 	    # Gradient distortion correction
 	    # Set to NONE to skip gradient distortion correction

--- a/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
+++ b/Examples/Scripts/DiffusionPreprocessingBatch-long.sh
@@ -40,9 +40,6 @@ function identify_timepoints
     echo $tplist
 }
 
-
-
-
 #Assume that submission nodes have OPENMP enabled (needed for eddy - at least 8 cores suggested for HCP data)
 #NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
 #DO NOT include "-q " at the beginning
@@ -115,8 +112,9 @@ for i in "${!Subjects[@]}"; do
 	    # avoids having volumes with different SNR features/ residual distortions.
 	    # [This behavior can be changed via the --combine-data-flag if necessary].
 	  
-  	    PosData="${RawDataDir}/${TimepointCross}_dMRI_dir98_PA.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_PA.nii.gz"
-	    NegData="${RawDataDir}/${TimepointCross}_dMRI_dir98_AP.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_AP.nii.gz"
+	  	#Not needed in longitudinal mode
+  	    #PosData="${RawDataDir}/${TimepointCross}_dMRI_dir98_PA.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_PA.nii.gz"
+	    #NegData="${RawDataDir}/${TimepointCross}_dMRI_dir98_AP.nii.gz@${RawDataDir}/${TimepointCross}_dMRI_dir99_AP.nii.gz"
 	  
 	    # "Effective" Echo Spacing of dMRI image (now specified in seconds for the dMRI processing)
 	    # EchoSpacing = 1/(BWPPPE * ReconMatrixPE)
@@ -124,9 +122,10 @@ for i in "${!Subjects[@]}"; do
 	    #   ReconMatrixPE = size of the reconstructed image in the PE dimension
 	    # In-plane acceleration, phase oversampling, phase resolution, phase field-of-view, and interpolation
 	    # all potentially need to be accounted for (which they are in Siemen's reported BWPPPE)
-	    EchoSpacingSec=0.00078
+		#Not needed in longitudinal mode
+	    #EchoSpacingSec=0.00078
 	  
-	    PEdir=2 #Use 1 for Left-Right Phase Encoding, 2 for Anterior-Posterior
+	    #PEdir=2 #Use 1 for Left-Right Phase Encoding, 2 for Anterior-Posterior
 
 	    # Gradient distortion correction
 	    # Set to NONE to skip gradient distortion correction
@@ -143,11 +142,8 @@ for i in "${!Subjects[@]}"; do
 	    fi
 
 	    "${queuing_command[@]}" "${HCPPIPEDIR}"/DiffusionPreprocessing/DiffPreprocPipeline.sh \
-		  --posData="${PosData}" --negData="${NegData}" \
 		  --path="${StudyFolder}" --session="${TimepointCross}" \
-		  --echospacing-seconds="${EchoSpacingSec}" --PEdir="${PEdir}" \
 		  --gdcoeffs="${Gdcoeffs}" \
-		  --gpu=FALSE  \
 		  --is-longitudinal=TRUE \
 		  --longitudinal-session="$TimepointLong" \
   		  --printcom="$PRINTCOM"		  

--- a/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch-long.sh
+++ b/Examples/Scripts/GenericfMRIVolumeProcessingPipelineBatch-long.sh
@@ -131,10 +131,7 @@ for i in "${!Subjects[@]}"; do
 	for TimepointCross in "${Timepoint_list_cross[@]}"; do
 		echo "${SCRIPT_NAME}: Processing Timepoint: ${TimepointCross}"
 		TimepointLong=${TimepointCross}.long.${TemplateLong}
-		
-		#symlink unprocessed data to the longitudinal session.
-		echo ln -sfr "${StudyFolder}/${TimepointCross}/unprocessed" "${StudyFolder}/${TimepointLong}/unprocessed"
-		
+				
 		if (( $? )); then 
 			echo "ERROR: linking fMRI raw data to longitudinal session failed."
 			exit -1

--- a/FreeSurfer/LongitudinalFreeSurferPipeline.sh
+++ b/FreeSurfer/LongitudinalFreeSurferPipeline.sh
@@ -351,12 +351,17 @@ if (( end_stage > 0 )); then
   par_finalize_stage $parallel_mode $max_jobs
 fi
 
-#clean up symlinks 
+#clean up symlinks and organize longitudinal session folder structure
 for Session in ${Sessions} ; do
-  unlink "${TemplateT1wDir}/${Session}"
+  rm -f "${TemplateT1wDir}/${Session}"
+  LongSession=${Session}.long.${TemplateID}
+  LongSessionT1wDir="$StudyFolder/${LongSession}/T1w"
+  mkdir -p "$LongSessionT1wDir"
+  mv "${TemplateT1wDir}/${LongSession}" "${LongSessionT1wDir}"/
 done
+
 #this symlink isn't used downstream
-unlink "${TemplateT1wDir}/fsaverage"
+rm -f "${TemplateT1wDir}/fsaverage"
 
 # ----------------------------------------------------------------------
 log_Msg "Completed main functionality"

--- a/FreeSurfer/LongitudinalFreeSurferPipeline.sh
+++ b/FreeSurfer/LongitudinalFreeSurferPipeline.sh
@@ -277,7 +277,8 @@ if (( start_stage < 1 )); then
     Source="${StudyFolder}/${Session}/T1w/${Session}"
     Target="${TemplateT1wDir}/${Session}"
     log_Msg "Creating a link: ${Source} => ${Target}"
-    ln -sf ${Source} ${Target}
+    #symlinks review: changed from absolute to relative. 
+    ( cd "${TemplateT1wDir}" && ln -sf "../../${Session}/T1w/$Session" "$Session" )
   done
 
   # ----------------------------------------------------------------------

--- a/FreeSurfer/LongitudinalFreeSurferPipeline.sh
+++ b/FreeSurfer/LongitudinalFreeSurferPipeline.sh
@@ -356,6 +356,7 @@ for Session in ${Sessions} ; do
   rm -f "${TemplateT1wDir}/${Session}"
   LongSession=${Session}.long.${TemplateID}
   LongSessionT1wDir="$StudyFolder/${LongSession}/T1w"
+  rm -rf "$LongSessionT1wDir"
   mkdir -p "$LongSessionT1wDir"
   mv "${TemplateT1wDir}/${LongSession}" "${LongSessionT1wDir}"/
 done

--- a/FreeSurfer/LongitudinalFreeSurferPipeline.sh
+++ b/FreeSurfer/LongitudinalFreeSurferPipeline.sh
@@ -321,7 +321,7 @@ if (( end_stage > 0 )); then
     log_Msg "Running longitudinal recon all for session: ${Session}"
     recon_all_cmd="recon-all.v6.hires"
     recon_all_cmd+=" -sd ${TemplateT1wDir}"
-    recon_all_cmd+=" -long ${Session} ${TemplateID} -all"
+    recon_all_cmd+=" -long ${Session} ${TemplateID} -all -conf2hires"
     
     recon_all_cmd+=" $extra_reconall_args_long "
     T2w=${StudyFolder}/${Session}/T1w/T2w_acpc_dc_restore.nii.gz

--- a/FreeSurfer/LongitudinalFreeSurferPipeline.sh
+++ b/FreeSurfer/LongitudinalFreeSurferPipeline.sh
@@ -267,15 +267,15 @@ log_Msg "extra_reconall_args_base: $extra_reconall_args_base"
 log_Msg "extra_reconall_args_long: $extra_reconall_args_long"
 log_Msg "After delimiter substitution, Sessions: ${Sessions}"
 
-LongDIR="${StudyFolder}/${SubjectID}.long.${TemplateID}/T1w"
-mkdir -p "${LongDIR}"
+TemplateT1wDir="${StudyFolder}/${SubjectID}.long.${TemplateID}/T1w"
+mkdir -p "${TemplateT1wDir}"
 
 if (( start_stage < 1 )); then 
 
   #prepare session folder structure
   for Session in ${Sessions} ; do
     Source="${StudyFolder}/${Session}/T1w/${Session}"
-    Target="${LongDIR}/${Session}"
+    Target="${TemplateT1wDir}/${Session}"
     log_Msg "Creating a link: ${Source} => ${Target}"
     ln -sf ${Source} ${Target}
   done
@@ -287,7 +287,7 @@ if (( start_stage < 1 )); then
   # note that -conf2hires option is not supported for longitudinal base template as of Freesurfer 6,
   # although it is supported for longitudinal timepoints
   recon_all_cmd="recon-all.v6.hires"
-  recon_all_cmd+=" -sd ${LongDIR}"
+  recon_all_cmd+=" -sd ${TemplateT1wDir}"
   recon_all_cmd+=" -base ${TemplateID}"
   for Session in ${Sessions} ; do
     recon_all_cmd+=" -tp ${Session}"
@@ -319,8 +319,8 @@ if (( end_stage > 0 )); then
   for Session in ${Sessions} ; do
     log_Msg "Running longitudinal recon all for session: ${Session}"
     recon_all_cmd="recon-all.v6.hires"
-    recon_all_cmd+=" -sd ${LongDIR}"
-    recon_all_cmd+=" -long ${Session} ${TemplateID} -all -conf2hires"
+    recon_all_cmd+=" -sd ${TemplateT1wDir}"
+    recon_all_cmd+=" -long ${Session} ${TemplateID} -all"
     
     recon_all_cmd+=" $extra_reconall_args_long "
     T2w=${StudyFolder}/${Session}/T1w/T2w_acpc_dc_restore.nii.gz
@@ -349,6 +349,13 @@ if (( end_stage > 0 )); then
   #Finalize jobs in this stage.
   par_finalize_stage $parallel_mode $max_jobs
 fi
+
+#clean up symlinks 
+for Session in ${Sessions} ; do
+  unlink "${TemplateT1wDir}/${Session}"
+done
+#this symlink isn't used downstream
+unlink "${TemplateT1wDir}/fsaverage"
 
 # ----------------------------------------------------------------------
 log_Msg "Completed main functionality"

--- a/FreeSurfer/LongitudinalFreeSurferPipeline.sh
+++ b/FreeSurfer/LongitudinalFreeSurferPipeline.sh
@@ -321,7 +321,7 @@ if (( end_stage > 0 )); then
     log_Msg "Running longitudinal recon all for session: ${Session}"
     recon_all_cmd="recon-all.v6.hires"
     recon_all_cmd+=" -sd ${TemplateT1wDir}"
-    recon_all_cmd+=" -long ${Session} ${TemplateID} -all -conf2hires"
+    recon_all_cmd+=" -long ${Session} ${TemplateID} -all"
     
     recon_all_cmd+=" $extra_reconall_args_long "
     T2w=${StudyFolder}/${Session}/T1w/T2w_acpc_dc_restore.nii.gz

--- a/FreeSurfer/custom/conf2hires
+++ b/FreeSurfer/custom/conf2hires
@@ -280,6 +280,7 @@ foreach hemi ($hemilist)
   end
   # Create symbolic links
   pushd $sdir
+    #symlinks review: all relative, should be OK
   ln -sf $hemi.white.rawavg.conf $hemi.white |& tee -a $LF
   if(! $#MMode) then
     ln -sf $hemi.pial.rawavg.conf  $hemi.pial |& tee -a $LF
@@ -299,9 +300,11 @@ if($#MMode) then
   # Long: create a symlink to long mm input if needed. Normal stream
   # does not copy or link the multimodal input. Should probably
   # overwrite what is there to force update.
+  # symlinks review: this is absolute link. Kept as is, needs attention.
   if(! -e $MM && $longitudinal) then
     set MMcross = ${SUBJECTS_DIR}/${tpNid}/mri/orig/${MMode}raw.mgz
     cd orig
+    # symlinks review: relative, OK
     set cmd = (ln -sf $MMcross ${MMode}raw.mgz)
     echo $cmd | tee -a $LF
     ln -sf $MMcross ${MMode}raw.mgz |& tee -a $LF
@@ -372,6 +375,7 @@ if($#MMode) then
   echo $cmd | tee -a $LF
   $cmd |& tee -a $LF
   if($status) goto error_exit;
+  #symlinks review: relative, OK
   ln -sf conf.${MMode}.mgz ${MMode}.mgz
 
   # Now place the pial using the ${MMode}

--- a/FreeSurfer/custom/conf2hires
+++ b/FreeSurfer/custom/conf2hires
@@ -304,7 +304,6 @@ if($#MMode) then
   if(! -e $MM && $longitudinal) then
     set MMcross = ${SUBJECTS_DIR}/${tpNid}/mri/orig/${MMode}raw.mgz
     cd orig
-    # symlinks review: relative, OK
     set cmd = (ln -sf $MMcross ${MMode}raw.mgz)
     echo $cmd | tee -a $LF
     ln -sf $MMcross ${MMode}raw.mgz |& tee -a $LF

--- a/ICAFIX/PostFix.sh
+++ b/ICAFIX/PostFix.sh
@@ -122,7 +122,7 @@ esac
 # ------------------------------------------------------------------------------
 #  Create symlinks, but only if file doesn't already exist in ResultsFolder
 # ------------------------------------------------------------------------------
-
+# symlinks review: relative, ok
 create_symlink_if_appropriate() {
     
     local file="${1}"
@@ -363,6 +363,7 @@ cat "${TemplateSceneSingleScreen}" | sed s/SubjectID/${Subject}/g | sed s/fMRINa
 # need to be preserved (but with a warning generated)!
 # If file exists as a symlink, force creation of a new symlink pointing to the FIXFolder files
 file=ReclassifyAsSignal.txt
+#symlinks review: relative links created by this function, ok
 create_symlink_if_appropriate "${file}" "${ResultsFolder}" "${FIXFolder}"
 file=ReclassifyAsNoise.txt
 create_symlink_if_appropriate "${file}" "${ResultsFolder}" "${FIXFolder}"

--- a/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
+++ b/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
@@ -136,9 +136,6 @@ if (( ! TemplateProcessing )); then
         rm -rf "$tp_folder_hcp"
     fi
     mv "$tp_folder_fslong" "$tp_folder_hcp"
-    if (( $? )); then 
-       	log_Err_Abort "Could not move $tp_folder_fslong to $tp_folder_hcp"
-    fi
 
 fi
 

--- a/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
+++ b/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
@@ -114,34 +114,6 @@ else
     echo "Timepoint_cross: $Timepoint_cross"
 fi
 
-#########################################################################################
-# Organizing and cleaning up the folder structure
-#########################################################################################
-if (( ! TemplateProcessing )); then
-
-    LongDIR="${StudyFolder}/${Subject}.long.${Template}/T1w"
-
-    log_Msg "Organizing the folder structure for: ${Timepoint_cross}"
-
-    TargetDIR="${StudyFolder}/${Timepoint_cross}.long.${Template}/T1w"
-    mkdir -p "${TargetDIR}"
-
-    # tp_folder_fslong stores folder where longitudinal FreeSurfer stores timepoint output natively.
-    # Example of how it would look like, given Template=123456_V1_V2, Subject=123456, Timepoint=123456_V1:
-    # $tp_folder_fslong=$StudyFolder/123456.long.123456_V1_V2/T1w/123456_V1.long.123456_V1_V2
-    tp_folder_fslong="${LongDIR}/${Timepoint_cross}.long.${Template}"
-    if [ ! -d "$tp_folder_fslong" ]; then
-    	log_Err_Abort "Folder $tp_folder_fslong does not exist, was longitudinal FreeSurfer run?"        
-
-    # tp_folder_hcp contains target timepoint folder in HCP pipelines.
-    # $tp_folder_hcp=$StudyFolder/123456_V1.long.123456_V1_V2/T1w/123456_V1.long.123456_V1_V2
-    tp_folder_hcp="${TargetDIR}/${Timepoint_cross}.long.${Template}"
-    if [ -d "$tp_folder_hcp" ]; then 
-        rm -rf "$tp_folder_hcp"
-    fi
-    mv "$tp_folder_fslong" "$tp_folder_hcp"
-fi
-
 ############################################################################################################
 # The next block computes the transform from T1w_acpc_dc (cross) to T1w_acpc_dc (long_template).
 Timepoint_long=$Timepoint_cross.long.$Template

--- a/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
+++ b/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
@@ -122,7 +122,7 @@ if (( ! TemplateProcessing )); then
     LongDIR="${StudyFolder}/${Subject}.long.${Template}/T1w"
 
     log_Msg "Organizing the folder structure for: ${Timepoint_cross}"
-    # create the symlink
+
     TargetDIR="${StudyFolder}/${Timepoint_cross}.long.${Template}/T1w"
     mkdir -p "${TargetDIR}"
 
@@ -132,13 +132,14 @@ if (( ! TemplateProcessing )); then
     fi
 
     tp_folder_hcp="${TargetDIR}/${Timepoint_cross}.long.${Template}"
-    ln -sf "$tp_folder_fslong" "$tp_folder_hcp"
-    if [ ! -d "$tp_folder_hcp" ]; then
-    	log_Err_Abort "Could not create required symlink from $tp_folder_fslong to $tp_folder_hcp"
+    if [ -d "$tp_folder_hcp" ]; then 
+        rm -rf "$tp_folder_hcp"
+    fi
+    mv "$tp_folder_fslong" "$tp_folder_hcp"
+    if (( $? )); then 
+       	log_Err_Abort "Could not move $tp_folder_fslong to $tp_folder_hcp"
     fi
 
-    # remove the symlink in the subject's folder
-    rm -rf "${LongDIR}/${Timepoint_cross}"
 fi
 
 ############################################################################################################

--- a/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
+++ b/PostFreeSurfer/PostFreeSurferPipelineLongPrep.sh
@@ -126,17 +126,20 @@ if (( ! TemplateProcessing )); then
     TargetDIR="${StudyFolder}/${Timepoint_cross}.long.${Template}/T1w"
     mkdir -p "${TargetDIR}"
 
+    # tp_folder_fslong stores folder where longitudinal FreeSurfer stores timepoint output natively.
+    # Example of how it would look like, given Template=123456_V1_V2, Subject=123456, Timepoint=123456_V1:
+    # $tp_folder_fslong=$StudyFolder/123456.long.123456_V1_V2/T1w/123456_V1.long.123456_V1_V2
     tp_folder_fslong="${LongDIR}/${Timepoint_cross}.long.${Template}"
     if [ ! -d "$tp_folder_fslong" ]; then
-    	log_Err_Abort "Folder $tp_folder_fslong does not exist, was longitudinal FreeSurfer run?"
-    fi
+    	log_Err_Abort "Folder $tp_folder_fslong does not exist, was longitudinal FreeSurfer run?"        
 
+    # tp_folder_hcp contains target timepoint folder in HCP pipelines.
+    # $tp_folder_hcp=$StudyFolder/123456_V1.long.123456_V1_V2/T1w/123456_V1.long.123456_V1_V2
     tp_folder_hcp="${TargetDIR}/${Timepoint_cross}.long.${Template}"
     if [ -d "$tp_folder_hcp" ]; then 
         rm -rf "$tp_folder_hcp"
     fi
     mv "$tp_folder_fslong" "$tp_folder_hcp"
-
 fi
 
 ############################################################################################################
@@ -408,7 +411,7 @@ if (( TemplateProcessing ==  1 )); then
             rm -rf "$AtlasSpaceFolder_timepoint/xfms"
         fi
         mkdir -p "${AtlasSpaceFolder_timepoint}"
-        ln -sf "${AtlasSpaceFolder_template}/xfms" "${AtlasSpaceFolder_timepoint}/"
+        cp -r "${AtlasSpaceFolder_template}/xfms" "${AtlasSpaceFolder_timepoint}/"
 
         #one mask for all timepoints.
         cp "${AtlasSpaceFolder_template}/$T1wImageBrainMask".nii.gz "$Timepoint_brain_mask_MNI"

--- a/PostFreeSurfer/scripts/CreateMyelinMaps.sh
+++ b/PostFreeSurfer/scripts/CreateMyelinMaps.sh
@@ -100,7 +100,7 @@ esac
 log_Msg "RegName: ${RegName}"
 
 NonHumanSpecies=0
-if [ "$Species" != "human" ]; then NonHumanSpecies=1; fi
+if [ "$Species" != "Human" ]; then NonHumanSpecies=1; fi
 
 # -- check for presence of T2w image
 if [ -z "$IsLongitudinal" ]; then IsLongitudinal=0; fi

--- a/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh
+++ b/PostFreeSurfer/scripts/FreeSurfer2CaretConvertAndRegisterNonlinear.sh
@@ -452,9 +452,9 @@ for Hemisphere in L R ; do
                 cp -r "$AtlasSpaceFolder"/"$NativeFolder"/MSMSulc $experiment_root/MNINonLinear/$NativeFolder/
 
                 #copy the output of MSMSulc to each of the timepoint native folders
-                for file in "$AtlasSpaceFolder"/"$NativeFolder"/${Session}.long.${LongitudinalTemplate}.*${RegName}.*; do
+                for file in "$AtlasSpaceFolder"/"$NativeFolder"/${Session}.*${RegName}.*; do
                     file_base=$(basename $file)
-                    new_file=${file_base/${Session}.long.$LongitudinalTemplate/$timepoint.long.$LongitudinalTemplate}
+                    new_file=${file_base/${Session}/$timepoint.long.$LongitudinalTemplate}
                     cp $file $experiment_root/MNINonLinear/$NativeFolder/$new_file
                 done
             done

--- a/PostFreeSurfer/scripts/GenerateStructuralScenes.sh
+++ b/PostFreeSurfer/scripts/GenerateStructuralScenes.sh
@@ -146,6 +146,7 @@ function copyTemplateFiles {
         if ((verbose)); then
             echo "Copying template files to $targetDir as symlinks"
         fi
+        #symlinks review: absolute path, not changed, needs attention.
         for FIL in "$templateDir"/S1200.{MyelinMap,sulc}* "$templateDir"/../MNI152_T1_0.8mm.nii.gz; do
             FN=$(basename "$FIL")
             ln -s "$FIL" "$targetDir/$FN"

--- a/PostFreeSurfer/scripts/GenerateStructuralScenes.sh
+++ b/PostFreeSurfer/scripts/GenerateStructuralScenes.sh
@@ -146,7 +146,6 @@ function copyTemplateFiles {
         if ((verbose)); then
             echo "Copying template files to $targetDir as symlinks"
         fi
-        #symlinks review: absolute path, not changed, needs attention.
         for FIL in "$templateDir"/S1200.{MyelinMap,sulc}* "$templateDir"/../MNI152_T1_0.8mm.nii.gz; do
             FN=$(basename "$FIL")
             ln -s "$FIL" "$targetDir/$FN"

--- a/TaskfMRIAnalysis/TaskfMRILevel3.sh
+++ b/TaskfMRIAnalysis/TaskfMRILevel3.sh
@@ -279,6 +279,7 @@ for Analysis in ${Analyses} ; do
 	        echo "ERROR: ${copedir} does not exist"
 	        exit -1
 	      fi
+        #symlinks review: absolute link, needs attention.
         ln -s ${copedir} ${LevelThreeFEATDir}/${Analysis}/${i}/${j}
       else
 	      echo "ERROR: $Analysis not a valid analysis mode"

--- a/TaskfMRIAnalysis/scripts/makeSubjectTaskSummary.sh
+++ b/TaskfMRIAnalysis/scripts/makeSubjectTaskSummary.sh
@@ -253,6 +253,7 @@ for Analysis in ${Analyses} ; do
 			echo "ERROR: Cannot find Contrasts list at ${LevelTwoFEATDir}/Contrasts.txt. Verify that Level1 and Level2 analyses completed correctly." >> ${SummaryDirectory}/TaskfMRIAnalysisSummary.txt
 			log_Err_Abort "ERROR: Cannot find Contrasts list at ${LevelTwoFEATDir}/Contrasts.txt. Verify that Level1 and Level2 analyses completed correctly."
 		else
+			#symlinks review: absolute link, needs attention.
 			ln -svf ${LevelTwoFEATDir}/Contrasts.txt ${SummaryDirectory}/Contrasts.txt
 		fi
 		
@@ -271,6 +272,7 @@ for Analysis in ${Analyses} ; do
 					fi
 					cifti_out=${SummaryDirectory}/${Analysis}/cope${copeCounter}.feat/${File}.${Extension}
 					# create symlink to summary directory
+					#symlinks review: absolute, needs attention. This one may be converted cleanly to relative.
 					ln -svf $cifti_in $cifti_out
 				else
 					# file is missing, write cope number and contrast name to log
@@ -305,6 +307,7 @@ for Analysis in ${Analyses} ; do
 		if [[ "$Analysis" = "GrayordinatesStats" || "$Analysis" = "ParcellatedStats" ]] ; then
 			${CARET7DIR}/wb_command -cifti-convert -to-nifti ${LevelOneFEATDir}/${Analysis}/res4d.${Extension} $tmpdir/res4d.nii.gz
 		else
+			#symlinks review: absolute link, needs attention.
 			ln -svf ${LevelOneFEATDir}/${Analysis}/res4d.nii.gz $tmpdir/res4d.nii.gz
 		fi
 		fslmaths $tmpdir/res4d.nii.gz -Tstd -bin $tmpdir/mask.nii.gz;
@@ -354,6 +357,7 @@ for Analysis in ${Analyses} ; do
 					fi
 					cifti_out=${SummaryDirectory}/${Analysis}/cope${copeCounter}.feat/${File}1.${Extension}
 					# create symlink to summary directory
+					# symlinks review: absolute, needs attention. May be converted to relative.
 					ln -svf $cifti_in $cifti_out
 					echo "${Analysis}: NOTE ${File}${copeCounter} ($Contrast) copied from Level1 $shortName" >> ${SummaryDirectory}/TaskfMRIAnalysisSummary.txt
 				else

--- a/TaskfMRIAnalysis/scripts/makeSubjectTaskSummary.sh
+++ b/TaskfMRIAnalysis/scripts/makeSubjectTaskSummary.sh
@@ -253,6 +253,7 @@ for Analysis in ${Analyses} ; do
 			echo "ERROR: Cannot find Contrasts list at ${LevelTwoFEATDir}/Contrasts.txt. Verify that Level1 and Level2 analyses completed correctly." >> ${SummaryDirectory}/TaskfMRIAnalysisSummary.txt
 			log_Err_Abort "ERROR: Cannot find Contrasts list at ${LevelTwoFEATDir}/Contrasts.txt. Verify that Level1 and Level2 analyses completed correctly."
 		else
+			rm -f ${SummaryDirectory}/Contrasts.txt
 			cp ${LevelTwoFEATDir}/Contrasts.txt ${SummaryDirectory}/Contrasts.txt
 		fi
 		

--- a/TaskfMRIAnalysis/scripts/makeSubjectTaskSummary.sh
+++ b/TaskfMRIAnalysis/scripts/makeSubjectTaskSummary.sh
@@ -253,8 +253,7 @@ for Analysis in ${Analyses} ; do
 			echo "ERROR: Cannot find Contrasts list at ${LevelTwoFEATDir}/Contrasts.txt. Verify that Level1 and Level2 analyses completed correctly." >> ${SummaryDirectory}/TaskfMRIAnalysisSummary.txt
 			log_Err_Abort "ERROR: Cannot find Contrasts list at ${LevelTwoFEATDir}/Contrasts.txt. Verify that Level1 and Level2 analyses completed correctly."
 		else
-			#symlinks review: absolute link, needs attention.
-			ln -svf ${LevelTwoFEATDir}/Contrasts.txt ${SummaryDirectory}/Contrasts.txt
+			cp ${LevelTwoFEATDir}/Contrasts.txt ${SummaryDirectory}/Contrasts.txt
 		fi
 		
 		copeCounter=1;

--- a/TransmitBias/TransmitBiasLong.sh
+++ b/TransmitBias/TransmitBiasLong.sh
@@ -67,7 +67,7 @@ opts_AddOptional '--low-res-mesh' 'LowResMesh' 'number' "resolution of grayordin
 #MFG: T1w/ outputs should use transmit resolution, MNINonLinear/ use grayordinates
 #MFG: should add default of 2 to PostFS if we have a default here
 opts_AddOptional '--grayordinates-res' 'grayordRes' 'number' "resolution used in PostFreeSurfer for grayordinates, default '2'" '2'
-opts_AddOptional '--transmit-res' 'transmitRes' 'number' "resolution to use for transmit field, default equal to --grayordinates-res"
+opts_AddOptional '--transmit-res' 'transmitRes' 'number' "resolution to use for transmit field, default equal to --grayordinates-res" ''
 opts_AddOptional '--myelin-mapping-fwhm' 'MyelinMappingFWHM' 'number' "fwhm value to use in -myelin-style, default 5" '5'
 opts_AddOptional '--old-myelin-mapping' 'oldmappingStr' 'TRUE or FALSE' "if myelin mapping was done using version 1.2.3 or earlier of wb_command, set this to true" 'false'
 opts_AddOptional '--matlab-run-mode' 'MatlabMode' '0, 1, or 2' "defaults to 1
@@ -87,6 +87,8 @@ if ((pipedirguessed))
 then
     log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
 fi
+
+if [ -z "$transmitRes" ]; then transmitRes="$grayordRes"; fi
 
 if [ -n "$LogDir" ]; then 
   mkdir -p "$LogDir"

--- a/TransmitBias/scripts/PseudoTransmit_IndividualAlignRawAndInitialMaps.sh
+++ b/TransmitBias/scripts/PseudoTransmit_IndividualAlignRawAndInitialMaps.sh
@@ -91,11 +91,12 @@ mkdir -p "$WorkingDIR"/xfms
 for fMRIName in "${fMRINamesArray[@]}"
 do
     #deal with naming convention mismatch in SBRef by making links to all 3 with consistent names
-    ln -sf "$StudyFolder"/"$Session"/"$fMRIName"/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseOne_gdc_dc_jac.nii.gz "$WorkingDIR"/"$fMRIName"_PhaseOne_gdc_dc_jac.nii.gz
-    ln -sf "$StudyFolder"/"$Session"/"$fMRIName"/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseTwo_gdc_dc_jac.nii.gz "$WorkingDIR"/"$fMRIName"_PhaseTwo_gdc_dc_jac.nii.gz
+    #symlinks review: converted the three below to relative symlinks.
+    ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseOne_gdc_dc_jac.nii.gz" "${fMRIName}_PhaseOne_gdc_dc_jac.nii.gz" )
+    ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseTwo_gdc_dc_jac.nii.gz" "${fMRIName}_PhaseTwo_gdc_dc_jac.nii.gz" )
     
     #didn't have _gdc in the name, so add it
-    ln -sf "$StudyFolder"/"$Session"/"$fMRIName"/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/SBRef_dc_jac.nii.gz "$WorkingDIR"/"$fMRIName"_SBRef_gdc_dc_jac.nii.gz
+    ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/SBRef_dc_jac.nii.gz" "${fMRIName}_SBRef_gdc_dc_jac.nii.gz" )
 done
 
 function ReuseBBR4Longitudinal {

--- a/TransmitBias/scripts/PseudoTransmit_IndividualAlignRawAndInitialMaps.sh
+++ b/TransmitBias/scripts/PseudoTransmit_IndividualAlignRawAndInitialMaps.sh
@@ -92,8 +92,8 @@ for fMRIName in "${fMRINamesArray[@]}"
 do
     #deal with naming convention mismatch in SBRef by making links to all 3 with consistent names
     #symlinks review: converted the three below to relative symlinks.
-    ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseOne_gdc_dc_jac.nii.gz" "${fMRIName}_PhaseOne_gdc_dc_jac.nii.gz" )
-    ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseTwo_gdc_dc_jac.nii.gz" "${fMRIName}_PhaseTwo_gdc_dc_jac.nii.gz" )
+    ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseOne_gdc_dc_jac.nii.gz" "$WorkingDIR"/"${fMRIName}_PhaseOne_gdc_dc_jac.nii.gz"
+    ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseTwo_gdc_dc_jac.nii.gz" "$WorkingDIR"/"${fMRIName}_PhaseTwo_gdc_dc_jac.nii.gz"
     
     #didn't have _gdc in the name, so add it
     ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/SBRef_dc_jac.nii.gz" "${fMRIName}_SBRef_gdc_dc_jac.nii.gz" )

--- a/TransmitBias/scripts/PseudoTransmit_IndividualAlignRawAndInitialMaps.sh
+++ b/TransmitBias/scripts/PseudoTransmit_IndividualAlignRawAndInitialMaps.sh
@@ -96,7 +96,7 @@ do
     ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/PhaseTwo_gdc_dc_jac.nii.gz" "$WorkingDIR"/"${fMRIName}_PhaseTwo_gdc_dc_jac.nii.gz"
     
     #didn't have _gdc in the name, so add it
-    ( cd "$WorkingDIR" && ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/SBRef_dc_jac.nii.gz" "${fMRIName}_SBRef_gdc_dc_jac.nii.gz" )
+    ln -sf "../../$fMRIName/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased/FieldMap/SBRef_dc_jac.nii.gz" "$WorkingDIR"/"${fMRIName}_SBRef_gdc_dc_jac.nii.gz"
 done
 
 function ReuseBBR4Longitudinal {

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -511,7 +511,7 @@ T1wImage="T1w_acpc_dc"
 T1wRestoreImage="T1w_acpc_dc_restore"
 T1wRestoreImageBrain="T1w_acpc_dc_restore_brain"
 T1wFolder="T1w" #Location of T1w images
-AtlasSpaceFolder="MNINonLinear"
+AtlasSpaceFolderBase="MNINonLinear"
 ResultsFolder="Results"
 BiasField="BiasField_acpc_dc"
 BiasFieldMNI="BiasField"
@@ -538,7 +538,7 @@ SessionFolderLong="$Path"/"$SessionLong"
 
 #note, this file doesn't exist yet, gets created by ComputeSpinEchoBiasField.sh during DistortionCorrectionAnd...
 #this name specifically gets passed to fslmaths, and the script blindly puts _dilated on it, so don't use an extension
-sebasedBiasFieldMNI="$SessionFolder/$AtlasSpaceFolder/Results/$NameOffMRI/${NameOffMRI}_sebased_bias"
+sebasedBiasFieldMNI="$SessionFolder/$AtlasSpaceFolderBase/Results/$NameOffMRI/${NameOffMRI}_sebased_bias"
 
 fMRIFolder="$Path"/"$Session"/"$NameOffMRI"
 
@@ -642,7 +642,7 @@ else
   log_Msg "Using reference image from ${fMRIReferencePath}"
   fMRIReferenceImage="$fMRIReferencePath"/"$ScoutName"_gdc
   fMRIReferenceImageMask="$fMRIReferencePath"/"$ScoutName"_gdc_mask
-  ReferenceResultsFolder="$Path"/"$Session"/"$AtlasSpaceFolder"/"$ResultsFolder"/"$fMRIReference"
+  ReferenceResultsFolder="$Path"/"$Session"/"$AtlasSpaceFolderBase"/"$ResultsFolder"/"$fMRIReference"
 
   if [ "$fMRIReferencePath" = "$fMRIFolder" ] ; then
     log_Err_Abort "Specified fMRI reference (--fmriref=${fMRIReference}) is the same as the current fMRI (--fmriname=${NameOffMRI})!"
@@ -707,13 +707,13 @@ T1wFolderLong="$Path"/"$SessionLong"/"$T1wFolder"
 T1wFolder=$T1wFolderCross
 
 
-AtlasSpaceFolderCross="$Path"/"$Session"/"$AtlasSpaceFolder"
-AtlasSpaceFolderLong="$Path"/"$SessionLong"/"$AtlasSpaceFolder"
-AtlasSpaceFolder=$AtlasSpaceFolderCross
+AtlasSpaceFolderCross="$Path"/"$Session"/"$AtlasSpaceFolderBase"
+AtlasSpaceFolderLong="$Path"/"$SessionLong"/"$AtlasSpaceFolderBase"
+AtlasSpaceFolder="$AtlasSpaceFolderCross"
 
 ResultsFolderCross="$AtlasSpaceFolder"/"$ResultsFolder"/"$NameOffMRI"
 ResultsFolderLong="$AtlasSpaceFolderLong"/"$ResultsFolder"/"$NameOffMRI"
-ResultsFolder=$ResultsFolderCross
+ResultsFolder="$ResultsFolderCross"
 
 fMRIFolderLong="$Path"/"$SessionLong"/"$NameOffMRI"
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -1194,8 +1194,8 @@ if [[ ${nEcho} -gt 1 ]]; then
     log_Msg "Fitting T2* and combining Echoes"
 
     #symlink review: links changed to relative.
-    ( ${RUN} cd "$EchoDir" && ${RUN} ln -sf "../${NameOffMRI}_nonlin_norm.nii.gz" "${NameOffMRI}_nonlin_norm.nii.gz" )
-    ( ${RUN} cd "$EchoDir" && ${RUN} ln -sf "../${NameOffMRI}_SBRef_nonlin_norm.nii.gz" "${NameOffMRI}_SBRef_nonlin_norm.nii.gz" )
+    ${RUN} ln -sf "../${NameOffMRI}_nonlin_norm.nii.gz" "$EchoDir"/"${NameOffMRI}_nonlin_norm.nii.gz"
+    ${RUN} ln -sf "../${NameOffMRI}_SBRef_nonlin_norm.nii.gz" "$EchoDir"/"${NameOffMRI}_SBRef_nonlin_norm.nii.gz"
 
     echo ${echoTE} > ${EchoDir}/TEs.txt
 

--- a/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
+++ b/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
@@ -736,14 +736,15 @@ if [ "$RunMode" -lt 2 ] ; then
         mkdir -p "$fMRIFolderLong"
         for fd in "$fMRIFolder"/*; do
             fname="$(basename "$fd")"
-            #create link to the original fMRI series
+            #create relative link to the original fMRI series. Relative links should be ok here.
             if [ "$fname" == "${NameOffMRI}_orig.nii.gz" ]; then
                 ln -sf ../../"$Session"/"${NameOffMRI}"/"$fname" "$fMRIFolderLong/$fname"
             #skip large files that will be generated
             elif [ "$fname" == "${NameOffMRI}_orig_nonlin.nii.gz" -o "$fname" == "${NameOffMRI}_nonlin.nii.gz" ]; then
                 continue
             else
-                cp -r "$fd" "$fMRIFolderLong/"
+                cp -rL "$fd" "$fMRIFolderLong/"
+                chmod -R +w "$fMRIFolderLong/"
             fi
         done
     fi
@@ -1062,7 +1063,7 @@ if [ "$RunMode" -lt 3 ] ; then
             log_Warn "     ... removing stale link"
             rm ${DCFolder}
         fi
-        ln -s ${fMRIReferencePath}/${DCFolderName} ${DCFolder}
+        ln -sf "../fMRIReference/${DCFolderName}" "${DCFolder}"
 
         if [ $("${FSLDIR}/bin/imtest ${T1wFolder}/xfms/${fMRIReference}2str") -eq 0 ]; then
             log_Err_Abort "The expected ${T1wFolder}/xfms/${fMRIReference}2str from the reference (${fMRIReference}) does not exist!"
@@ -1192,8 +1193,9 @@ if [[ ${nEcho} -gt 1 ]]; then
     # # fit T2* and S0 then Combine Echoes
     log_Msg "Fitting T2* and combining Echoes"
 
-    ${RUN} ln -sf ${fMRIFolder}/${NameOffMRI}_nonlin_norm.nii.gz ${EchoDir}/${NameOffMRI}_nonlin_norm.nii.gz
-    ${RUN} ln -sf ${fMRIFolder}/${NameOffMRI}_SBRef_nonlin_norm.nii.gz ${EchoDir}/${NameOffMRI}_SBRef_nonlin_norm.nii.gz
+    #symlink review: links changed to relative.
+    ( ${RUN} cd "$EchoDir" && ${RUN} ln -sf "../${NameOffMRI}_nonlin_norm.nii.gz" "${NameOffMRI}_nonlin_norm.nii.gz" )
+    ( ${RUN} cd "$EchoDir" && ${RUN} ln -sf "../${NameOffMRI}_SBRef_nonlin_norm.nii.gz" "${NameOffMRI}_SBRef_nonlin_norm.nii.gz" )
 
     echo ${echoTE} > ${EchoDir}/TEs.txt
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -886,8 +886,7 @@ else # IsLongitudinal=1
 
     ${FSLDIR}/bin/convert_xfm -omat ${WD}/fMRI2str_refinement-long.mat -concat "$T1wCross2LongXfm" ${WD}/fMRI2str_refinement.mat
     #this needs for the following command to succeed if ${WD}/fMRI2str_refinement.mat is symlink pointing to read-only source.
-    rm -f ${WD}/fMRI2str_refinement.mat
-    cp ${WD}/fMRI2str_refinement-long.mat ${WD}/fMRI2str_refinement.mat
+    cp -f ${WD}/fMRI2str_refinement-long.mat ${WD}/fMRI2str_refinement.mat
 fi
 
 ${FSLDIR}/bin/convertwarp --relout --rel --warp1=${WD}/${ScoutInputFile}${ScoutExtension}2T1w_init_warp.nii.gz --ref=${T1wImage} --postmat=${WD}/fMRI2str_refinement.mat --out=${WD}/fMRI2str.nii.gz

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -884,8 +884,9 @@ if (( ! IsLongitudinal )); then
     fi
 else # IsLongitudinal=1
 
-    ${FSLDIR}/bin/convert_xfm -omat ${WD}/fMRI2str_refinement-long.mat -concat "$T1wCross2LongXfm" ${WD}/fMRI2str_refinement.mat
-    #this needs for the following command to succeed if ${WD}/fMRI2str_refinement.mat is symlink pointing to read-only source.
+    ${FSLDIR}/bin/convert_xfm -omat ${WD}/fMRI2str_refinement-long.mat -concat "$T1wCross2LongXfm" ${WD}/fMRI2str_refinement.mat    
+    #cp -f would keep existing symlink if its target is writable, but we want to create a normal file, so removing target first.
+    rm -f ${WD}/fMRI2str_refinement.mat
     cp -f ${WD}/fMRI2str_refinement-long.mat ${WD}/fMRI2str_refinement.mat
 fi
 

--- a/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
+++ b/fMRIVolume/scripts/DistortionCorrectionAndEPIToT1wReg_FLIRTBBRAndFreeSurferBBRbased.sh
@@ -885,6 +885,8 @@ if (( ! IsLongitudinal )); then
 else # IsLongitudinal=1
 
     ${FSLDIR}/bin/convert_xfm -omat ${WD}/fMRI2str_refinement-long.mat -concat "$T1wCross2LongXfm" ${WD}/fMRI2str_refinement.mat
+    #this needs for the following command to succeed if ${WD}/fMRI2str_refinement.mat is symlink pointing to read-only source.
+    rm -f ${WD}/fMRI2str_refinement.mat
     cp ${WD}/fMRI2str_refinement-long.mat ${WD}/fMRI2str_refinement.mat
 fi
 

--- a/global/scripts/createHeadMask.sh
+++ b/global/scripts/createHeadMask.sh
@@ -2,6 +2,7 @@
 set -eu
 
 ## Guess HCPPIPEDIR if not set
+pipedirguessed=0
 if [[ "${HCPPIPEDIR:-}" == "" ]]
 then
     pipedirguessed=1

--- a/tICA/scripts/tICACleanData.sh
+++ b/tICA/scripts/tICACleanData.sh
@@ -246,7 +246,7 @@ if ((DoVol))
 then
     for fmri in "${InputArray[@]}"
     do
-        fslcpgeom "$MNIFolder/Results/$fmri/${fmri}${ProcString}.nii.gz" "$MNIFolder/Results/$fmri/${fmri}${OutString}.nii.gz"        
+        fslcpgeom "$MNIFolder/Results/$fmri/${fmri}${ProcString}.nii.gz" "$MNIFolder/Results/$fmri/${fmri}${OutString}.nii.gz"
         fslcpgeom "$MNIFolder/Results/$fmri/${fmri}${ProcString}_vn.nii.gz" "$MNIFolder/Results/$fmri/${fmri}${OutString}_vn.nii.gz"
     done
 fi
@@ -261,6 +261,7 @@ then
     #extract specified runs to another concatenated file (generally intended to recreate the REST concatenated set)
     if [[ "$extractNameOut" != "" ]]
     then
+        mkdir -p "$MNIFolder/Results/$extractNameOut"
         cp "$MNIFolder/Results/$MRFixConcatName/${MRFixConcatName}_Atlas${RegString}${OutString}_vn.dscalar.nii" \
             "$MNIFolder/Results/$extractNameOut/${extractNameOut}_Atlas${RegString}${OutString}_vn.dscalar.nii"
         extractcmd=("$HCPPIPEDIR"/global/scripts/ExtractFromMRFIXConcat.sh

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -168,6 +168,7 @@ then
     signalTxtName="ReCleanSignal.txt"
 fi
 
+SesslistRawCross="$SesslistRaw"
 if ((IsLongitudinal)); then
     if [[ "$ICAmode" != "REUSE_TICA" ]]; then
         log_Err_Abort "mode other than REUSE_TICA is not supported in longitudinal processing"
@@ -183,6 +184,7 @@ if ((IsLongitudinal)); then
     for sess in "${SesslistCross[@]}"; do
         Sesslist+=("${sess}.long.$TemplateLong")
     done
+    SesslistStr="${Sesslist[@]}"; SesslistRaw="${SesslistStr// /@}"
 else
     IFS='@' read -a Sesslist <<<"$SesslistRaw"
 fi
@@ -719,6 +721,8 @@ do
                 done
                 fMRINamesForSub=$(IFS='@'; echo "${fMRIExist[*]}")
                 #for now, always do volume outputs
+                #DEBUG
+                #OutputString="fMRI_CONCAT_ALL_d86_WF6_HCA1798_MSMAll"
                 par_addjob "$HCPPIPEDIR"/tICA/scripts/tICACleanData.sh \
                     --study-folder="$StudyFolder" \
                     --subject="$Session" \
@@ -760,7 +764,7 @@ if (( IsLongitudinal )); then
     "$HCPPIPEDIR"/tICA/scripts/tICAMakeCleanLongitudinalTemplate.sh \
         --study-folder="$StudyFolder"       \
         --subject="$Subject"                \
-        --session-list="$SesslistRaw"       \
+        --session-list="$SesslistRawCross"       \
         --template-long="$TemplateLong"     \
         --extract-fmri-name-list="$concatNamesToUse" \
         --highpass="$HighPass"              \

--- a/tICA/tICAPipeline.sh
+++ b/tICA/tICAPipeline.sh
@@ -721,8 +721,6 @@ do
                 done
                 fMRINamesForSub=$(IFS='@'; echo "${fMRIExist[*]}")
                 #for now, always do volume outputs
-                #DEBUG
-                #OutputString="fMRI_CONCAT_ALL_d86_WF6_HCA1798_MSMAll"
                 par_addjob "$HCPPIPEDIR"/tICA/scripts/tICACleanData.sh \
                     --study-folder="$StudyFolder" \
                     --subject="$Session" \


### PR DESCRIPTION
See bc88380. This needs review before merging. 

+Move longitudinal FreeSurfer outputs to longitudinal session folders instead of symlinking
+remove target transform if it was created as symlink from a read-only source
+clean up large files in longitudinal diffusion output (NEEDS REVIEW)