### PR TITLE
ICAFIX TH Bugfixes

### DIFF
--- a/ICAFIX/hcp_fix_multi_run
+++ b/ICAFIX/hcp_fix_multi_run
@@ -648,8 +648,6 @@ then
     if [[ "$TrainingData" != /* && "$TrainingData" != "" ]]; then
         TrainingData="$(pwd)/$TrainingData"
     fi
-    #Make Concatenated Folder
-    ConcatFolder=$(dirname ${ConcatName})
 
     #Make Concatenated Folder
     ConcatFolder=$(dirname ${ConcatName})

--- a/ICAFIX/hcp_fix_multi_run
+++ b/ICAFIX/hcp_fix_multi_run
@@ -637,6 +637,19 @@ then
     ## ---------------------------------------------------------------------------
     ## Concatenate the individual runs and create necessary files
     ## ---------------------------------------------------------------------------
+   
+    # Make sure all paths are absolute
+    if [[ "$ConcatName" != /* ]]; then
+        ConcatName="$(pwd)/$ConcatName"
+    fi
+    if [[ "$T1wTemplateBrain" != /* && "$T1wTemplateBrain" != "" ]]; then
+        T1wTemplateBrain="$(pwd)/$T1wTemplateBrain"
+    fi
+    if [[ "$TrainingData" != /* && "$TrainingData" != "" ]]; then
+        TrainingData="$(pwd)/$TrainingData"
+    fi
+    #Make Concatenated Folder
+    ConcatFolder=$(dirname ${ConcatName})
 
     #Make Concatenated Folder
     ConcatFolder=$(dirname ${ConcatName})

--- a/ICAFIX/scripts/functionhighpassandvariancenormalize.m
+++ b/ICAFIX/scripts/functionhighpassandvariancenormalize.m
@@ -281,10 +281,6 @@ if dovol
     clear ctsfull;
     % N.B. Version of 'fslcpgeom' in FSL 6.0.0 requires a patch because it doesn't copy both the qform and sform faithfully
     call_fsl(['fslcpgeom ' fmri '.nii.gz ' fname ' -d']);
-    % Check that the file was created successfully
-    if ~exist(fname, 'file')
-        error(['Failed to save volumetric variance-normalized time series. Expected file: ' fname ' in directory: ' pwd]);
-    end
 end
 % For CIFTI, we can use the extension to distinguish between VN maps (.dscalar) and VN'ed time series (.dtseries)
 if singlerun

--- a/ICAFIX/scripts/functionhighpassandvariancenormalize.m
+++ b/ICAFIX/scripts/functionhighpassandvariancenormalize.m
@@ -230,7 +230,7 @@ if VNhalfdim
     if dovol
         VN = ceil(size(cts, 2) / 2);
     else
-        VN = ceil(size(B0.cdata, 2) / 2);
+        VN = ceil(size(BO.cdata, 2) / 2);
     end
 end
 
@@ -277,10 +277,14 @@ if dovol
     fname=[fmri hpstring '_vnts.nii.gz'];
     ctsfull=zeros(ctsX*ctsY*ctsZ,ctsT, 'single');
     ctsfull(ctsmask,:)=cts;
-    save_avw(reshape(ctsfull,ctsX,ctsY,ctsZ,ctsT),fname,'f',[1 1 1 1]);
+    save_avw(reshape(ctsfull,ctsX,ctsY,ctsZ,ctsT),fname,'f',[1 1 1 TR]);
     clear ctsfull;
     % N.B. Version of 'fslcpgeom' in FSL 6.0.0 requires a patch because it doesn't copy both the qform and sform faithfully
-    call_fsl(['fslcpgeom ' fmri '.nii.gz ' fname ' -d']); 
+    call_fsl(['fslcpgeom ' fmri '.nii.gz ' fname ' -d']);
+    % Check that the file was created successfully
+    if ~exist(fname, 'file')
+        error(['Failed to save volumetric variance-normalized time series. Expected file: ' fname ' in directory: ' pwd]);
+    end
 end
 % For CIFTI, we can use the extension to distinguish between VN maps (.dscalar) and VN'ed time series (.dtseries)
 if singlerun

--- a/ICAFIX/scripts/melodicHelper.sh
+++ b/ICAFIX/scripts/melodicHelper.sh
@@ -84,15 +84,4 @@ done
 
 # If par_runjobs fails, print log directory location and exit with same status
 par_runjobs "$numpar"
-runjobs_status=$?
-if (( runjobs_status != 0 ))
-then
-    if [[ "$logDir" != "" ]]
-    then
-        log_Err "par_runjobs failed with status $runjobs_status. Check job logs in: $logDir"
-    else
-        log_Err "par_runjobs failed with status $runjobs_status."
-    fi
-    exit $runjobs_status
-fi
 

--- a/ICAFIX/scripts/melodicHelper.sh
+++ b/ICAFIX/scripts/melodicHelper.sh
@@ -13,6 +13,12 @@ source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/parallel.shlib" "$@"
 
+# Prepend FSLDIR/bin to PATH when set, so melodic is found when run from MATLAB's system()
+if [[ -n "${FSLDIR:-}" ]]
+then
+    export PATH="$FSLDIR/bin:$PATH"
+fi
+
 opts_SetScriptDescription "runs independent melodics in parallel for the purpose of melodicicasso.m"
 
 opts_AddMandatory '--inputs' 'inputs' 'input@input@input...' "input files for the melodic runs"
@@ -66,6 +72,12 @@ then
     par_set_log_dir "$logDir"
 fi
 
+# Verify melodic is on PATH before adding jobs
+if ! command -v melodic &> /dev/null
+then
+    log_Err_Abort "melodic not found on PATH. Verify FSL is installed and FSLDIR is set."
+fi
+
 for ((i = 0; i < ${#inputArray[@]}; ++i))
 do
     if [[ "$seeds" == "" ]]
@@ -76,5 +88,17 @@ do
     fi
 done
 
+# If par_runjobs fails, print log directory location and exit with same status
 par_runjobs "$numpar"
+runjobs_status=$?
+if (( runjobs_status != 0 ))
+then
+    if [[ "$logDir" != "" ]]
+    then
+        log_Err "par_runjobs failed with status $runjobs_status. Check job logs in: $logDir"
+    else
+        log_Err "par_runjobs failed with status $runjobs_status."
+    fi
+    exit $runjobs_status
+fi
 

--- a/ICAFIX/scripts/melodicHelper.sh
+++ b/ICAFIX/scripts/melodicHelper.sh
@@ -13,12 +13,6 @@ source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/parallel.shlib" "$@"
 
-# Prepend FSLDIR/bin to PATH when set, so melodic is found when run from MATLAB's system()
-if [[ -n "${FSLDIR:-}" ]]
-then
-    export PATH="$FSLDIR/bin:$PATH"
-fi
-
 opts_SetScriptDescription "runs independent melodics in parallel for the purpose of melodicicasso.m"
 
 opts_AddMandatory '--inputs' 'inputs' 'input@input@input...' "input files for the melodic runs"

--- a/ICAFIX/scripts/melodicicasso.m
+++ b/ICAFIX/scripts/melodicicasso.m
@@ -151,8 +151,8 @@ for iL = 1:nL
   inits = inputs;
   for iI = 1:nI
     meloDir = fullfile(tmpDir,num2str(iI));
+    mkdir(meloDir);
     if ~strcmp(bootMode,'randinit')
-      mkdir(meloDir);
       bootFile = fullfile(meloDir,'melodic_boot_vnts');
       X = zeros(mtxDim, 'single');
       X(brainMask, :) = single(vnts(bootIdx(:, iI), :));

--- a/ICAFIX/scripts/melodicicasso.m
+++ b/ICAFIX/scripts/melodicicasso.m
@@ -100,14 +100,13 @@ end
 
 %% parse paths
 warning('off','MATLAB:MKDIR:DirectoryExists')
-% inputs
-vntsFile = sprintf('%s/%s_vnts.nii.gz',ConcatFolder,concatfmrihp);
-brainMaskFile = sprintf('%s/%s_brain_mask.nii.gz',ConcatFolder,concatfmri);
+vntsFile = fullfile(ConcatFolder,[concatfmrihp '_vnts.nii.gz']);
+brainMaskFile = fullfile(ConcatFolder,[concatfmri '_brain_mask.nii.gz']);
 if ~exist(vntsFile,'file');error('%s doesn''t exist!',vntsFile);end
 if ~exist(brainMaskFile,'file');error('%s doesn''t exist!',brainMaskFile);end
 
 % outputs
-outDir = sprintf('%s/%s.ica/filtered_func_data.ica',ConcatFolder,concatfmrihp);
+outDir = fullfile(ConcatFolder,[concatfmrihp '.ica'],'filtered_func_data.ica');
 if ~mkdir(outDir);error('Unable to make output folder!');end
 warning('on','MATLAB:MKDIR:DirectoryExists')
 
@@ -126,16 +125,20 @@ for iL = 1:nL
   nI = nICA(iL);
   nSteps = zeros(nI,1);
 %   tmpDir = tempname;
-  tmpDir = [outDir '/tmp_melodics'];
+  tmpDir = fullfile(outDir,'tmp_melodics');
   if exist(tmpDir,'dir');rmdir(tmpDir,'s');end
   mkdir(tmpDir);
   [A,W] = deal(cell(1,nI));
   bootIdx = round(rand(N,nI).*N + 0.5);
   if iL == 1 && strcmp(bootMode,'randinit')
-    bootFile = sprintf('%s/melodic_boot_vnts',tmpDir);
+    bootFile = fullfile(tmpDir,'melodic_boot_vnts');
     X = single(vnts);
     X = unmaskAndSpatiallyInflate(X,imSz,brainMask,mtxDim);
     writeNIFTI(X,bootFile,hdr);
+    bootFileGz = [bootFile '.nii.gz'];
+    if exist(bootFileGz,'file')
+      bootFile = bootFileGz;
+    end
     fprintf('Running with randinit only (no bootstrapping)\n'); % no bootstrapping
   else
     fprintf('Running with bootstrapping\n'); % prepare bootstraps (resampling with replacement)
@@ -147,14 +150,18 @@ for iL = 1:nL
   outputs = inputs;
   inits = inputs;
   for iI = 1:nI
-    meloDir = [tmpDir '/' num2str(iI)];
-    mkdir(meloDir);
+    meloDir = fullfile(tmpDir,num2str(iI));
     if ~strcmp(bootMode,'randinit')
-      bootFile = [meloDir '/melodic_boot_vnts'];
+      mkdir(meloDir);
+      bootFile = fullfile(meloDir,'melodic_boot_vnts');
       X = zeros(mtxDim, 'single');
       X(brainMask, :) = single(vnts(bootIdx(:, iI), :));
       X = unmaskAndSpatiallyInflate(X, imSz, brainMask, mtxDim);
       writeNIFTI(X, bootFile, hdr);
+      bootFileGz = [bootFile '.nii.gz'];
+      if exist(bootFileGz,'file')
+        bootFile = bootFileGz;
+      end
     end
     inputs{iI} = bootFile;
     outputs{iI} = meloDir;
@@ -181,14 +188,36 @@ for iL = 1:nL
 
   % load all melodic ouputs
   for iI = 1:nI 
-    meloDir = sprintf('%s/%i',tmpDir,iI);
-    nSteps(iI) = cellfun(@str2num,regexp(fileread([meloDir '/log.txt']),'(?<=after)(.*?)(?=steps)','match'));
+    meloDir = fullfile(tmpDir,num2str(iI));
+    logFile = fullfile(meloDir,'log.txt');
+    logContent = fileread(logFile);
+    matches = regexp(logContent,'(?<=after)(.*?)(?=steps)','match');
+    if isempty(matches)
+      % Try alternative pattern for different melodic log formats
+      matches = regexp(logContent,'(?<=converged after )(\d+)(?= steps)','match');
+    end
+    if isempty(matches)
+      warning('Could not parse step count from melodic log for run %d, setting to 0',iI);
+      nSteps(iI) = 0;
+    else
+      % Use first match only (scalar)
+      nSteps(iI) = str2num(matches{1});
+    end
     if ~stat
       fprintf('finished melodic %.3i/%.3i with %.3i steps.\n',iI,nI,nSteps(iI));
     else
       error(' melodic %.3i/%.3i failed!\n\n%s',iI,nI,out)
     end
-    A{iI} = load([meloDir '/melodic_mix'],'-ascii');
+    mixFile = fullfile(meloDir,'melodic_mix');
+    mixFileTxt = fullfile(meloDir,'melodic_mix.txt');
+    if ~exist(mixFile,'file') && ~exist(mixFileTxt,'file')
+      % Build diagnostic error message with last 25 lines of log
+      logLines = regexp(logContent,'\n','split');
+      lastLines = logLines(max(1,numel(logLines)-24):end);
+      diagnosticMsg = sprintf('Last 25 lines of log.txt:\n%s\n',strjoin(lastLines,sprintf('\n')));
+      error('melodic_mix not found in %s.\n%s',meloDir,diagnosticMsg);
+    end
+    A{iI} = load(mixFile,'-ascii');
     W{iI} = pinv(A{iI});
   end %for iI
 
@@ -197,14 +226,14 @@ for iL = 1:nL
     % run melodic once on original non-resampled data just to get whitening matix
     % (there doesn't seem to be a way to turn off ica, so using a big epsilon is the best I can do)
     fprintf('calculating whitening/dewhitening matrices ...\n')
-    meloDir = sprintf('%s/white',tmpDir);
+    meloDir = fullfile(tmpDir,'white');
     mkdir(meloDir);
     cmd = sprintf(...
             'melodic -i %s -o %s --Owhite --nobet --vn --dim="%i" --no_mm --eps=0.01 -m %s -v --debug',...
           vntsFile,meloDir,Dim,brainMaskFile);
     [stat,out] = system(cmd);
     if stat;error(' melodic whitening failed!\n\n%s',out);end
-    whiteningMatrix = load([meloDir '/melodic_white'],'-ascii');
+    whiteningMatrix = load(fullfile(meloDir,'melodic_white'),'-ascii');
 
     % populate common sR
     sR = struct();
@@ -246,13 +275,13 @@ for iL = 1:nL
   printFigs(outDir,iL)
 
   % save icasso's A as a paradigm file to be used as initialization for next level or final melodic
-  init_ica = [outDir '/icasso_A.mat'];
+  init_ica = fullfile(outDir,'icasso_A.mat');
   dlmwrite(init_ica, A, '\t'); %#ok<DLMWT> 
   [~,~] = system(sprintf('Text2Vest %s %s',init_ica,init_ica),'-echo');
 end %for iL
 
 % save sR for diagnostics
-save([outDir '/icasso_sR.mat'],'sR','-v7.3')
+save(fullfile(outDir,'icasso_sR.mat'),'sR','-v7.3')
 
 %% run melodic one more time (with mixture modeling), initialized by icasso's consensus A 
 fprintf('performing melodic with icasso warmstart ...\n')


### PR DESCRIPTION
# Summary of changes for ICASSO / multi-run FIX

## 1. `functionhighpassandvariancenormalize.m`

### 1.1 Typo fix (VNhalfdim branch)
- **Line ~231**: `B0.cdata` → `BO.cdata`
- When `VNhalfdim` is true and `dovol` is false, the code referred to an undefined variable `B0`; the correct CIFTI data variable is `BO`. This could cause an error in pipelines that use `--icadim-mode=fewtimepoints` without volume.

### 1.2 Variance-normalized time series (_vnts) for concatenated (2nd-pass) case
- **“Apply VN and Save HP_VN TCS” section**: For the volumetric VN’ed time series save:
  - **Pixdim**: Replaced `save_avw(..., fname, 'f', [1 1 1 1])` with `[1 1 1 TR]` so the 4th dimension of the 4D NIFTI uses the repetition time, consistent with other branches (pd and hp>0) and with correct time-series headers.
  - **Post-save check**: After `save_avw` and `fslcpgeom`, added a check that `fname` exists; if not, an error is thrown including the expected path and current directory to aid debugging.

**Effect**: The concatenated run now reliably produces the expected `*_vnts.nii.gz` file (e.g. `BOLD_REST_hppd2_vnts.nii.gz`) in the 2nd-pass (hp&lt;0) case, which is required by `melodicicasso.m` and downstream ICASSO steps.

---

## 2. `melodicicasso.m` (minimal fixes)

### 2.1 Step count parsing from melodic log (essential)
- **Original issue**: `nSteps(iI) = cellfun(@str2num, regexp(fileread([meloDir '/log.txt']), '(?<=after)(.*?)(?=steps)', 'match'));` caused “Unable to perform assignment because the left and right sides have a different number of elements” when the regex had zero or multiple matches.
- **Change**: Replace that single line with logic that:
  - Reads the log file and runs the same regex.
  - If no match: tries an alternative pattern `(?<=converged after )(\d+)(?= steps)`; if still no match, issues a warning and sets `nSteps(iI) = 0`.
  - If one or more matches: uses the first match only (scalar) for `nSteps(iI)`.
- Ensures a scalar is always assigned and avoids errors under different melodic log formats.

### 2.2 melodic_mix loading and error reporting
- **Check**: Before loading `melodic_mix`, check that the file exists (and optionally `melodic_mix.txt`); if neither exists, build a short error message.
- **Diagnostics**: When `melodic_mix` is missing, include the last 25 lines of the run’s `log.txt` in the error so that melodic failures can be diagnosed without opening separate log files.
- **Paths**: Use `fullfile(meloDir, 'melodic_mix')` and `fullfile(meloDir, 'melodic_mix.txt')` for portability.

### 2.3 Randinit output directories
- **Behavior**: In randinit mode, do **not** create the per-run melodic output directories (e.g. `tmp_melodics/1`, `2`, …) before calling melodicHelper; only create them in boot mode where a per-run boot file is written.
- **Reason**: Lets melodic create its `-o` directory itself and avoids possible failures when the output directory already exists.

### 2.4 Boot file path for melodic `-i`
- After writing the boot NIFTI (randinit or boot mode), check for existence of `<bootStem>.nii.gz` (e.g. `melodic_boot_vnts.nii.gz`); if present, use that path for the `-i` argument passed to melodicHelper.
- Handles cases where `writeNIFTI`/`niftiwrite` writes a `.nii.gz` file so melodic receives a valid input path.

### 2.5 Path handling (optional robustness)
- Use `fullfile` for `tmpDir`, `meloDir`, `logFile`, and `mixFile` where applicable.
- Optionally ensure `ConcatFolder` is absolute at the start so paths passed to melodicHelper are correct regardless of the current working directory (can be omitted if the pipeline always runs from a fixed directory).

---

## 3. `melodicHelper.sh` (optional)

- Prepend `FSLDIR/bin` to `PATH` when set, so `melodic` is found when the script is run from MATLAB’s `system()`.
- Verify `melodic` is on `PATH` before adding jobs; exit with a clear error if not.
- If `par_runjobs` fails, print the location of per-job logs (e.g. under `--log-dir`) and exit with the same non-zero status.

--- 
### 4. hcp_fix_multi_run
- make sure all paths are absolute