### PR TITLE
Update HippUnfold HCP processing

### DIFF
--- a/Examples/Scripts/RunHippUnfoldHCP.sh
+++ b/Examples/Scripts/RunHippUnfoldHCP.sh
@@ -6,7 +6,8 @@ get_batch_options() {
     command_line_specified_study_folder=""
     command_line_specified_subject=""
     command_line_specified_run_local="FALSE"
-
+    command_line_specified_isolate_cache="FALSE"
+    
     local index=0
     local numArgs=${#arguments[@]}
     local argument
@@ -27,6 +28,10 @@ get_batch_options() {
                 command_line_specified_run_local="TRUE"
                 index=$(( index + 1 ))
                 ;;
+            --isolate-cache)
+                command_line_specified_isolate_cache="TRUE"
+                index=$(( index + 1 ))
+                ;;
             *)
                 echo ""
                 echo "ERROR: Unrecognized Option: ${argument}"
@@ -39,11 +44,10 @@ get_batch_options() {
 
 get_batch_options "$@"
 
-StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by SubjectID)
-
-Subjlist="100307 100610" #Space delimited list of subject IDs
-
-EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script
+StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by SubjectID) 
+Subjlist="100307 100610" #Space delimited list of subject IDs 
+#EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script 
+EnvironmentScript="/media/myelin/oren/HippUnfoldTesting/HCPpipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment
 
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
@@ -53,8 +57,14 @@ if [ -n "${command_line_specified_subject}" ]; then
     Subjlist="${command_line_specified_subject}"
 fi
 
+if [ -n "${command_line_specified_isolate_cache}" ]; then
+    IsolateCache="${command_line_specified_isolate_cache}"
+fi
+
 # Set up pipeline environment variables and software
 source "$EnvironmentScript"
+
+HippUnfoldCacheDIR="${StudyFolder}/HippUnfold/cache"
 
 # Log the originating call
 echo "$@"
@@ -75,7 +85,8 @@ for Subject in $Subjlist ; do
 
     LogDir="${StudyFolder}/${Subject}/T1w/HippUnfold/logs/HippUnfoldHCP"
     mkdir -p "$LogDir"
-
+    cd "$LogDir"
+    
     if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
         echo "About to locally run ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
         queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
@@ -90,7 +101,8 @@ for Subject in $Subjlist ; do
         "$HCPPIPEDIR"/HippUnfoldHCP/HippUnfoldHCP.sh \
         --study-folder="$StudyFolder" \
         --subject="$Subject" \
-        --runlocal="$RunLocal"
+        --isolate-cache="$IsolateCache" \
+    	--hippunfold-cache-dir="$HippUnfoldCacheDIR"
 
     # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
 

--- a/Examples/Scripts/RunHippUnfoldHCP.sh
+++ b/Examples/Scripts/RunHippUnfoldHCP.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 get_batch_options() {
     local arguments=("$@")
@@ -27,21 +27,23 @@ get_batch_options() {
                 command_line_specified_run_local="TRUE"
                 index=$(( index + 1 ))
                 ;;
-	    *)
-		echo ""
-		echo "ERROR: Unrecognized Option: ${argument}"
-		echo ""
-		exit 1
-		;;
+            *)
+                echo ""
+                echo "ERROR: Unrecognized Option: ${argument}"
+                echo ""
+                exit 1
+                ;;
         esac
     done
 }
 
 get_batch_options "$@"
 
-StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by SubjectID) 
-Subjlist="100307 100610" #Space delimited list of subject IDs 
-EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script 
+StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by SubjectID)
+
+Subjlist="100307 100610" #Space delimited list of subject IDs
+
+EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script
 
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
@@ -51,44 +53,51 @@ if [ -n "${command_line_specified_subject}" ]; then
     Subjlist="${command_line_specified_subject}"
 fi
 
-#Set up pipeline environment variables and software
+# Set up pipeline environment variables and software
 source "$EnvironmentScript"
 
 # Log the originating call
 echo "$@"
 
-#NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
-#DO NOT include "-q " at the beginning
-#default to no queue, implying run local
+# NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
+# DO NOT include "-q " at the beginning
 QUEUE=""
 #QUEUE="hcp_priority.q"
 
-########################################## INPUTS ########################################## 
+########################################## INPUTS ##########################################
 
-#Scripts called by this script do assume they run on the outputs of the PostFreeSurfer Pipeline
+# Scripts called by this script do assume they run on the outputs of the PostFreeSurfer Pipeline
 
 ######################################### DO WORK ##########################################
 
 for Subject in $Subjlist ; do
-  echo $Subject
+    echo "$Subject"
 
-  if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
-      echo "About to locally run ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
-      queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
-  else
-      echo "About to use fsl_sub to queue ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
-      queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE")
-  fi
+    LogDir="${StudyFolder}/${Subject}/T1w/HippUnfold/logs/HippUnfoldHCP"
+    mkdir -p "$LogDir"
 
-  "${queuing_command[@]}" "$HCPPIPEDIR"/HippUnfoldHCP/HippUnfoldHCP.sh \
-      --study-folder="$StudyFolder" \
-      --subject="$Subject" \
-      
-  # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
+    if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
+        echo "About to locally run ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
+        queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
+        RunLocal="TRUE"
+    else
+        echo "About to use fsl_sub to queue ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
+        RunLocal="FALSE"
+        queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE" -l "$LogDir")
+    fi
 
-  echo "set -- --study-folder=$StudyFolder \
-      --subject=$Subject" \
+    "${queuing_command[@]}" \
+        "$HCPPIPEDIR"/HippUnfoldHCP/HippUnfoldHCP.sh \
+        --study-folder="$StudyFolder" \
+        --subject="$Subject" \
+        --runlocal="$RunLocal"
 
-  echo ". ${EnvironmentScript}"
+    # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
+
+    echo "set --study-folder=$StudyFolder --subject=$Subject --runlocal=$RunLocal"
+
+    echo ". ${EnvironmentScript}"
 
 done
+
+

--- a/Examples/Scripts/RunPostHippUnfoldHCP.sh
+++ b/Examples/Scripts/RunPostHippUnfoldHCP.sh
@@ -27,21 +27,24 @@ get_batch_options() {
                 command_line_specified_run_local="TRUE"
                 index=$(( index + 1 ))
                 ;;
-	    *)
-		echo ""
-		echo "ERROR: Unrecognized Option: ${argument}"
-		echo ""
-		exit 1
-		;;
+            *)
+                echo ""
+                echo "ERROR: Unrecognized Option: ${argument}"
+                echo ""
+                exit 1
+                ;;
         esac
     done
 }
 
 get_batch_options "$@"
 
-StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by SubjectID) 
-Subjlist="100307 100610" #Space delimited list of subject IDs 
-EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script 
+StudyFolder="${HOME}/projects/Pipelines_ExampleData" #Location of Subject folders (named by SubjectID)
+
+Subjlist="100307 100610" #Space delimited list of subject IDs
+
+EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script
+
 
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
@@ -54,41 +57,44 @@ fi
 #Set up pipeline environment variables and software
 source "$EnvironmentScript"
 
-# Log the originating call
+#Log the originating call
 echo "$@"
 
 #NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
 #DO NOT include "-q " at the beginning
-#default to no queue, implying run local
 QUEUE=""
 #QUEUE="hcp_priority.q"
 
 ########################################## INPUTS ########################################## 
 
-#Scripts called by this script do assume they run on the outputs of the PostFreeSurfer Pipeline
+# Scripts called by this script do assume they run on the outputs of the PostFreeSurfer Pipeline
 
 ######################################### DO WORK ##########################################
 
 for Subject in $Subjlist ; do
   echo $Subject
 
+  LogDir="${StudyFolder}/${Subject}/T1w/HippUnfold/logs/PostHippUnfoldHCP"
+  mkdir -p "$LogDir"
+
   if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
       echo "About to locally run ${HCPPIPEDIR}/HippUnfoldHCP/PostHippUnfoldHCP.sh"
       queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
   else
       echo "About to use fsl_sub to queue ${HCPPIPEDIR}/HippUnfoldHCP/PostHippUnfoldHCP.sh"
-      queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE")
+      queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE" -l "$LogDir")
   fi
 
   "${queuing_command[@]}" "$HCPPIPEDIR"/HippUnfoldHCP/PostHippUnfoldHCP.sh \
       --study-folder="$StudyFolder" \
-      --subject="$Subject" \
-      
+      --subject="$Subject"
+
   # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
 
   echo "set -- --study-folder=$StudyFolder \
-      --subject=$Subject" \
+      --subject=$Subject"
 
   echo ". ${EnvironmentScript}"
 
 done
+

--- a/Examples/Scripts/RunPostHippUnfoldHCP.sh
+++ b/Examples/Scripts/RunPostHippUnfoldHCP.sh
@@ -1,5 +1,3 @@
-#!/bin/bash 
-
 get_batch_options() {
     local arguments=("$@")
 
@@ -45,7 +43,6 @@ Subjlist="100307 100610" #Space delimited list of subject IDs
 
 EnvironmentScript="${HOME}/projects/Pipelines/Examples/Scripts/SetUpHCPPipeline.sh" #Pipeline environment script
 
-
 if [ -n "${command_line_specified_study_folder}" ]; then
     StudyFolder="${command_line_specified_study_folder}"
 fi
@@ -54,47 +51,51 @@ if [ -n "${command_line_specified_subject}" ]; then
     Subjlist="${command_line_specified_subject}"
 fi
 
-#Set up pipeline environment variables and software
+# Set up pipeline environment variables and software
 source "$EnvironmentScript"
 
-#Log the originating call
+# Log the originating call
 echo "$@"
 
-#NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
-#DO NOT include "-q " at the beginning
+# NOTE: syntax for QUEUE has changed compared to earlier pipeline releases,
+# DO NOT include "-q " at the beginning
 QUEUE=""
 #QUEUE="hcp_priority.q"
 
-########################################## INPUTS ########################################## 
+########################################## INPUTS ##########################################
 
 # Scripts called by this script do assume they run on the outputs of the PostFreeSurfer Pipeline
 
 ######################################### DO WORK ##########################################
 
 for Subject in $Subjlist ; do
-  echo $Subject
+    echo "$Subject"
 
-  LogDir="${StudyFolder}/${Subject}/T1w/HippUnfold/logs/PostHippUnfoldHCP"
-  mkdir -p "$LogDir"
+    LogDir="${StudyFolder}/${Subject}/T1w/HippUnfold/logs/HippUnfoldHCP"
+    
+    mkdir -p "$LogDir"
+    cd "$LogDir"
+    
+    if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
+        echo "About to locally run ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
+        queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
+        RunLocal="TRUE"
+    else
+        echo "About to use fsl_sub to queue ${HCPPIPEDIR}/HippUnfoldHCP/HippUnfoldHCP.sh"
+        RunLocal="FALSE"
+        queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE" -l "$LogDir")
+    fi
 
-  if [[ "${command_line_specified_run_local}" == "TRUE" || "$QUEUE" == "" ]] ; then
-      echo "About to locally run ${HCPPIPEDIR}/HippUnfoldHCP/PostHippUnfoldHCP.sh"
-      queuing_command=("$HCPPIPEDIR"/global/scripts/captureoutput.sh)
-  else
-      echo "About to use fsl_sub to queue ${HCPPIPEDIR}/HippUnfoldHCP/PostHippUnfoldHCP.sh"
-      queuing_command=("$FSLDIR/bin/fsl_sub" -q "$QUEUE" -l "$LogDir")
-  fi
+    "${queuing_command[@]}" \
+        "$HCPPIPEDIR"/HippUnfoldHCP/HippUnfoldHCP.sh \
+        --study-folder="$StudyFolder" \
+        --subject="$Subject" \
+        --runlocal="$RunLocal"
 
-  "${queuing_command[@]}" "$HCPPIPEDIR"/HippUnfoldHCP/PostHippUnfoldHCP.sh \
-      --study-folder="$StudyFolder" \
-      --subject="$Subject"
+    # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
 
-  # The following lines are used for interactive debugging to set the positional parameters: $1 $2 $3 ...
+    echo "set --study-folder=$StudyFolder --subject=$Subject --runlocal=$RunLocal"
 
-  echo "set -- --study-folder=$StudyFolder \
-      --subject=$Subject"
-
-  echo ". ${EnvironmentScript}"
+    echo ". ${EnvironmentScript}"
 
 done
-

--- a/HippUnfoldHCP/HippUnfoldHCP.sh
+++ b/HippUnfoldHCP/HippUnfoldHCP.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 set -eu
+
 pipedirguessed=0
+
 if [[ "${HCPPIPEDIR:-}" == "" ]]
 then
-  # pipedirguessed=1
-   #fix this if the script is more than one level below HCPPIPEDIR
-   export HCPPIPEDIR="$(dirname -- "$0")/.."
+    # pipedirguessed=1
+
+    # Fix this if the script is more than one level below HCPPIPEDIR
+    export HCPPIPEDIR="$(dirname -- "$0")/.."
 fi
 
 source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
-
 
 opts_SetScriptDescription "Make some BIDS structures and run HippUnfold"
 
 opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder containing all subjects"
 opts_AddMandatory '--subject' 'Subject' 'subject ID' ""
 opts_AddOptional '--hippunfold-dir' 'HippUnfoldDIR' 'path' "location of HippUnfold outputs"
+opts_AddOptional '--runlocal' 'RunLocal' 'TRUE|FALSE' "whether running locally" "FALSE"
 
 opts_ParseArguments "$@"
 
@@ -27,96 +30,142 @@ fi
 
 opts_ShowValues
 
-T1wFolder="$StudyFolder/$Subject/T1w"       # input data
 
-if [ -z ${HippUnfoldDIR} ] ; then
-  HippUnfoldDIR="${T1wFolder}/HippUnfold"
+# ---------------------------------------------------------------------
+# Input/output directories
+# ---------------------------------------------------------------------
+
+T1wFolder="$StudyFolder/$Subject/T1w"
+
+if [[ -z "${HippUnfoldDIR:-}" ]]
+then
+    HippUnfoldDIR="${T1wFolder}/HippUnfold"
 fi
-
-HippUnfoldT1wFolder="$HippUnfoldDIR/T1w/hippunfold"
-HippUnfoldT2wFolder="$HippUnfoldDIR/T2w/hippunfold"
-HippUnfoldT1wT2wFolder="$HippUnfoldDIR/T1wT2w/hippunfold"
 
 T1wImage="$T1wFolder/T1w_acpc_dc_restore.nii.gz"
 T2wImage="$T1wFolder/T2w_acpc_dc_restore.nii.gz"
 
 
-if [ ! -f "$T1wImage" ]; then
+# ---------------------------------------------------------------------
+# Check inputs
+# ---------------------------------------------------------------------
+
+if [[ ! -f "$T1wImage" ]]
+then
     echo "Error: T1w image not found at $T1wImage" >&2
     exit 1
 fi
 
-if [ ! -f "$T2wImage" ]; then
+if [[ ! -f "$T2wImage" ]]
+then
     echo "Error: T2w image not found at $T2wImage" >&2
     exit 1
 fi
 
 
-mkdir -p "$HippUnfoldT1wFolder" "$HippUnfoldT2wFolder" "$HippUnfoldT1wT2wFolder"
+# ---------------------------------------------------------------------
+# Create HippUnfold input directory
+# ---------------------------------------------------------------------
 
-ln -sf "$T1wImage" "$HippUnfoldT1wFolder/s_${Subject}_T1w_acpc_dc_restore.nii.gz"
-ln -sf "$T2wImage" "$HippUnfoldT1wFolder/s_${Subject}_T2w_acpc_dc_restore.nii.gz"
-ln -sf "$T1wImage" "$HippUnfoldT2wFolder/s_${Subject}_T1w_acpc_dc_restore.nii.gz"
-ln -sf "$T2wImage" "$HippUnfoldT2wFolder/s_${Subject}_T2w_acpc_dc_restore.nii.gz"
-ln -sf "$T1wImage" "$HippUnfoldT1wT2wFolder/s_${Subject}_T1w_acpc_dc_restore.nii.gz"
-ln -sf "$T2wImage" "$HippUnfoldT1wT2wFolder/s_${Subject}_T2w_acpc_dc_restore.nii.gz"
+mkdir -p "$HippUnfoldDIR"
 
-log_Msg "Created folder structure under $HippUnfoldDIR and copied T1w and T2w images"
+ln -sf "$T1wImage" "$HippUnfoldDIR/s_${Subject}_T1w_acpc_dc_restore.nii.gz"
+
+ln -sf "$T2wImage" "$HippUnfoldDIR/s_${Subject}_T2w_acpc_dc_restore.nii.gz"
+
+log_Msg "Created folder structure under $HippUnfoldDIR and linked T1w and T2w images"
 log_Msg "Starting HippUnfold pipeline for subject: $Subject"
+
+
+# ---------------------------------------------------------------------
+# HippUnfold cache
+# ---------------------------------------------------------------------
+
+if [[ -z "${HIPPUNFOLD_CACHE_DIR:-}" ]]
+then
+    log_Err_Abort "HIPPUNFOLD_CACHE_DIR is not set"
+fi
 
 export APPTAINER_BINDPATH=${HIPPUNFOLD_CACHE_DIR}:${HIPPUNFOLD_CACHE_DIR}
 export APPTAINER_CACHEDIR=${HIPPUNFOLD_CACHE_DIR}/apptainer
-export APPTAINERENV_HIPPUNFOLD_CACHE_DIR=${HIPPUNFOLD_CACHE_DIR} #This one actually did something
+export APPTAINERENV_HIPPUNFOLD_CACHE_DIR=${HIPPUNFOLD_CACHE_DIR}
 
-#export HIPPUNFOLD_CACHE_DIR=${HippUnfoldDIR}/cache #Keep for QuNex?
-#export APPTAINER_BINDPATH=${StudyFolder}:${StudyFolder}
-#export APPTAINER_CACHEDIR=${HippUnfoldDIR}/apptainer
-#export APPTAINERENV_HIPPUNFOLD_CACHE_DIR=${HippUnfoldDIR}/cache #This one actually did something
-#mkdir -p ${HIPPUNFOLD_CACHE_DIR}
-#mkdir -p ${APPTAINER_CACHEDIR}
+mkdir -p "${HIPPUNFOLD_CACHE_DIR}/apptainer"
+mkdir -p "${HIPPUNFOLD_CACHE_DIR}/snakemake-conda"
 
+
+# ---------------------------------------------------------------------
+# Construct HippUnfold command
+# ---------------------------------------------------------------------
+
+CondaPrefix="${HIPPUNFOLD_CACHE_DIR}/snakemake-conda"
 
 if [[ "${HIPPUNFOLDPATH:-}" == "" ]]
 then
     hippcmd=(hippunfold --use-conda)
 else
-    hippcmd=(apptainer run --bind "$StudyFolder" -e "$HIPPUNFOLDPATH")
+    if [[ "$RunLocal" == "FALSE" ]]
+    then
+    	# Separate cache and conda directory for each subject to avoid crash due to parallel use
+	JobCache="${HIPPUNFOLD_CACHE_DIR}/job-cache/${JOB_ID:-local}_${Subject}"
+	JobCondaPrefix="${JobCache}/snakemake-conda"
+	JobCondaPkgs="${JobCache}/conda-pkgs"
+
+	mkdir -p "$JobCache"
+	mkdir -p "$JobCondaPrefix"
+	mkdir -p "$JobCondaPkgs"
+	
+	CondaPrefix="$JobCondaPrefix"
+        export APPTAINERENV_HIPPUNFOLD_CACHE_DIR="$JobCache"
+
+        hippcmd=(
+            apptainer run
+            --bind "$StudyFolder"
+            --bind "${JobCache}:${JobCache}"
+            --env HIPPUNFOLD_CACHE_DIR="$JobCache"
+            --env CONDA_PKGS_DIRS="$JobCondaPkgs"
+            -e
+            "$HIPPUNFOLDPATH"
+            hippunfold
+        )
+    else
+        hippcmd=(
+            apptainer run
+            --bind "$StudyFolder"
+            -e
+            "$HIPPUNFOLDPATH"
+            hippunfold
+        )
+    fi
 fi
 
-log_Msg "Running T1w HippUnfold for subject: $Subject"
-#Seriously: don't put a $ on {subject} and don't capitalize the S...
-"${hippcmd[@]}" "$HippUnfoldT1wFolder" "$HippUnfoldT1wFolder" participant \
-    --modality T1w \
-    --path-T1w "$HippUnfoldT1wFolder"/s_{subject}_T1w_acpc_dc_restore.nii.gz \
-    --path-T2w "$HippUnfoldT1wFolder"/s_{subject}_T2w_acpc_dc_restore.nii.gz \
-    --cores all \
-    --force-output \
-    --generate_myelin_map \
-    --output-density native 512 2k 8k 18k 
-log_Msg "T1w HippUnfold completed."
+# ---------------------------------------------------------------------
+# Run HippUnfold
+# ---------------------------------------------------------------------
 
-log_Msg "Running T2w HippUnfold for subject: $Subject"
-"${hippcmd[@]}" "$HippUnfoldT2wFolder" "$HippUnfoldT2wFolder" participant \
-    --modality T2w \
-    --path-T1w "$HippUnfoldT2wFolder"/s_{subject}_T1w_acpc_dc_restore.nii.gz \
-    --path-T2w "$HippUnfoldT2wFolder"/s_{subject}_T2w_acpc_dc_restore.nii.gz \
-    --cores all \
-    --force-output \
-    --generate_myelin_map \
-    --output-density native 512 2k 8k 18k 
-log_Msg "T2w HippUnfold completed."
+log_Msg "Running HippUnfold for subject: $Subject"
 
-log_Msg "Running T1wT2w HippUnfold for subject: $Subject"
-"${hippcmd[@]}" "$HippUnfoldT1wT2wFolder" "$HippUnfoldT1wT2wFolder" participant \
+# Do not put a $ before {subject}, and do not capitalize the s.
+
+"${hippcmd[@]}" "$HippUnfoldDIR" "$HippUnfoldDIR" participant \
     --modality T2w \
-    --path-T1w "$HippUnfoldT1wT2wFolder"/s_{subject}_T1w_acpc_dc_restore.nii.gz \
-    --path-T2w "$HippUnfoldT1wT2wFolder"/s_{subject}_T2w_acpc_dc_restore.nii.gz \
+    --path-T1w "$HippUnfoldDIR/s_{subject}_T1w_acpc_dc_restore.nii.gz" \
+    --path-T2w "$HippUnfoldDIR/s_{subject}_T2w_acpc_dc_restore.nii.gz" \
     --cores all \
     --force-output \
     --generate_myelin_map \
     --output-density native 512 2k 8k 18k \
-    --force-nnunet-model T1T2w
-log_Msg "T1wT2w HippUnfold completed."
-
+    --force-nnunet-model maguire_T2w \
+    --inner-outer-reg-smoothing 0 \
+    --conda-prefix "$CondaPrefix"
+ 
+# ---------------------------------------------------------------------
+# Remove cache directory
+# ---------------------------------------------------------------------
+   
+if [[ "$RunLocal" == "FALSE" ]]
+then
+	rm -rf "$JobCache"
+fi
+    
 log_Msg "HippUnfold pipeline completed successfully for subject: $Subject"
-

--- a/HippUnfoldHCP/HippUnfoldHCP.sh
+++ b/HippUnfoldHCP/HippUnfoldHCP.sh
@@ -1,25 +1,24 @@
 #!/bin/bash
 set -eu
-
 pipedirguessed=0
-
 if [[ "${HCPPIPEDIR:-}" == "" ]]
 then
-    # pipedirguessed=1
-
-    # Fix this if the script is more than one level below HCPPIPEDIR
-    export HCPPIPEDIR="$(dirname -- "$0")/.."
+  # pipedirguessed=1
+   #fix this if the script is more than one level below HCPPIPEDIR
+   export HCPPIPEDIR="$(dirname -- "$0")/.."
 fi
 
 source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
 source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
 
+
 opts_SetScriptDescription "Make some BIDS structures and run HippUnfold"
 
 opts_AddMandatory '--study-folder' 'StudyFolder' 'path' "folder containing all subjects"
 opts_AddMandatory '--subject' 'Subject' 'subject ID' ""
+opts_AddMandatory '--hippunfold-cache-dir' 'HippUnfoldCacheDIR' 'path' "location of HippUnfold cache"
 opts_AddOptional '--hippunfold-dir' 'HippUnfoldDIR' 'path' "location of HippUnfold outputs"
-opts_AddOptional '--runlocal' 'RunLocal' 'TRUE|FALSE' "whether running locally" "FALSE"
+opts_AddOptional '--isolate-cache' 'IsolateCache' 'TRUE|FALSE' "whether to use a separate cache for this job" "FALSE"
 
 opts_ParseArguments "$@"
 
@@ -30,25 +29,15 @@ fi
 
 opts_ShowValues
 
-
-# ---------------------------------------------------------------------
-# Input/output directories
-# ---------------------------------------------------------------------
-
 T1wFolder="$StudyFolder/$Subject/T1w"
 
-if [[ -z "${HippUnfoldDIR:-}" ]]
-then
+if [[ -z "${HippUnfoldDIR:-}" ]]; then
     HippUnfoldDIR="${T1wFolder}/HippUnfold"
 fi
 
 T1wImage="$T1wFolder/T1w_acpc_dc_restore.nii.gz"
 T2wImage="$T1wFolder/T2w_acpc_dc_restore.nii.gz"
 
-
-# ---------------------------------------------------------------------
-# Check inputs
-# ---------------------------------------------------------------------
 
 if [[ ! -f "$T1wImage" ]]
 then
@@ -70,7 +59,6 @@ fi
 mkdir -p "$HippUnfoldDIR"
 
 ln -sf "$T1wImage" "$HippUnfoldDIR/s_${Subject}_T1w_acpc_dc_restore.nii.gz"
-
 ln -sf "$T2wImage" "$HippUnfoldDIR/s_${Subject}_T2w_acpc_dc_restore.nii.gz"
 
 log_Msg "Created folder structure under $HippUnfoldDIR and linked T1w and T2w images"
@@ -81,33 +69,27 @@ log_Msg "Starting HippUnfold pipeline for subject: $Subject"
 # HippUnfold cache
 # ---------------------------------------------------------------------
 
-if [[ -z "${HIPPUNFOLD_CACHE_DIR:-}" ]]
-then
-    log_Err_Abort "HIPPUNFOLD_CACHE_DIR is not set"
-fi
+export APPTAINER_BINDPATH=${HippUnfoldCacheDIR}:${HippUnfoldCacheDIR}
+export APPTAINER_CACHEDIR=${HippUnfoldCacheDIR}/apptainer
 
-export APPTAINER_BINDPATH=${HIPPUNFOLD_CACHE_DIR}:${HIPPUNFOLD_CACHE_DIR}
-export APPTAINER_CACHEDIR=${HIPPUNFOLD_CACHE_DIR}/apptainer
-export APPTAINERENV_HIPPUNFOLD_CACHE_DIR=${HIPPUNFOLD_CACHE_DIR}
-
-mkdir -p "${HIPPUNFOLD_CACHE_DIR}/apptainer"
-mkdir -p "${HIPPUNFOLD_CACHE_DIR}/snakemake-conda"
+mkdir -p "${HippUnfoldCacheDIR}/apptainer"
+mkdir -p "${HippUnfoldCacheDIR}/snakemake-conda"
 
 
 # ---------------------------------------------------------------------
 # Construct HippUnfold command
 # ---------------------------------------------------------------------
 
-CondaPrefix="${HIPPUNFOLD_CACHE_DIR}/snakemake-conda"
+CondaPrefix="${HippUnfoldCacheDIR}/snakemake-conda"
 
 if [[ "${HIPPUNFOLDPATH:-}" == "" ]]
 then
     hippcmd=(hippunfold --use-conda)
 else
-    if [[ "$RunLocal" == "FALSE" ]]
+    if [[ "$IsolateCache" == "TRUE" ]]
     then
     	# Separate cache and conda directory for each subject to avoid crash due to parallel use
-	JobCache="${HIPPUNFOLD_CACHE_DIR}/job-cache/${JOB_ID:-local}_${Subject}"
+	JobCache="${HippUnfoldCacheDIR}/job-cache/${JOB_ID:-local}_${Subject}"
 	JobCondaPrefix="${JobCache}/snakemake-conda"
 	JobCondaPkgs="${JobCache}/conda-pkgs"
 
@@ -116,7 +98,6 @@ else
 	mkdir -p "$JobCondaPkgs"
 	
 	CondaPrefix="$JobCondaPrefix"
-        export APPTAINERENV_HIPPUNFOLD_CACHE_DIR="$JobCache"
 
         hippcmd=(
             apptainer run
@@ -145,8 +126,7 @@ fi
 
 log_Msg "Running HippUnfold for subject: $Subject"
 
-# Do not put a $ before {subject}, and do not capitalize the s.
-
+#Seriously: don't put a $ on {subject} and don't capitalize the S...
 "${hippcmd[@]}" "$HippUnfoldDIR" "$HippUnfoldDIR" participant \
     --modality T2w \
     --path-T1w "$HippUnfoldDIR/s_{subject}_T1w_acpc_dc_restore.nii.gz" \
@@ -163,7 +143,7 @@ log_Msg "Running HippUnfold for subject: $Subject"
 # Remove cache directory
 # ---------------------------------------------------------------------
    
-if [[ "$RunLocal" == "FALSE" ]]
+if [[ "$IsolateCache" == "TRUE" ]]
 then
 	rm -rf "$JobCache"
 fi

--- a/HippUnfoldHCP/PostHippUnfoldHCP.sh
+++ b/HippUnfoldHCP/PostHippUnfoldHCP.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 set -eu
+
 pipedirguessed=0
 if [[ "${HCPPIPEDIR:-}" == "" ]]
 then
-  # pipedirguessed=1
-   #fix this if the script is more than one level below HCPPIPEDIR
-   export HCPPIPEDIR="$(dirname -- "$0")/.."
+# pipedirguessed=1
+#fix this if the script is more than one level below HCPPIPEDIR
+export HCPPIPEDIR="$(dirname -- "$0")/.."
 fi
 
+#source "${HCPPIPEDIR}/global/scripts/log.shlib" "$@"            
+source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@" # Debugging functions; also sources log.shlib
 source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
-source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@"
-
 
 opts_SetScriptDescription "Make some BIDS structures and run HippUnfold"
 
@@ -23,7 +24,7 @@ opts_ParseArguments "$@"
 
 if ((pipedirguessed))
 then
-    log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
+  log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
 fi
 
 opts_ShowValues
@@ -33,317 +34,434 @@ log_Msg "Starting PostHippUnfold pipeline for subject: $Subject"
 T1wFolder="$StudyFolder/$Subject/T1w"
 AtlasFolder="$StudyFolder/$Subject/MNINonLinear"
 
-if [ -z ${PhysicalHippUnfoldDIR} ] ; then
-  PhysicalHippUnfoldDIR="${T1wFolder}/HippUnfold"
-fi 
+if [[ -z "${PhysicalHippUnfoldDIR:-}" ]] ; then
+PhysicalHippUnfoldDIR="${T1wFolder}/HippUnfold"
+fi
 
-if [ -z ${AtlasHippUnfoldDIR} ] ; then
-  AtlasHippUnfoldDIR="${AtlasFolder}/HippUnfold"
-fi 
+if [[ -z "${AtlasHippUnfoldDIR:-}" ]] ; then
+AtlasHippUnfoldDIR="${AtlasFolder}/HippUnfold"
+fi
+
+RawHippUnfoldFolder="${PhysicalHippUnfoldDIR}/sub-${Subject}"
+
+if [[ ! -d "$RawHippUnfoldFolder" ]]
+then
+echo "ERROR: HippUnfold output not found:" >&2
+echo "$RawHippUnfoldFolder" >&2
+exit 1
+fi
 
 function PALETTE {
-  File=${1}
-  Color=${2}
-  Type=${3}
-  wb_command=${4}
-  if [ ${Color} = "GRAY" ] ; then
-    command="-pos-percent 2 98 -palette-name Gray_Interp -disp-pos true -disp-neg true -disp-zero true"
-  elif [ ${Color} = "VIDEEN" ] ; then
-    command="-pos-percent 4 96 -interpolate true -palette-name videen_style -disp-pos true -disp-neg false -disp-zero false"
-  fi
-  if [ ${Type} = 'metric' ] ; then
-    ${wb_command} -metric-palette "$File" MODE_AUTO_SCALE_PERCENTAGE ${command}
-  elif [ ${Type} = 'cifti' ] ; then
-    ${wb_command} -cifti-palette "$File" MODE_AUTO_SCALE_PERCENTAGE "$File" ${command}
-  fi
+File=${1}
+Color=${2}
+Type=${3}
+wb_command=${4}
+
+if [ "${Color}" = "GRAY" ] ; then
+  command="-pos-percent 2 98 -palette-name Gray_Interp -disp-pos true -disp-neg true -disp-zero true"
+elif [ "${Color}" = "VIDEEN" ] ; then
+  command="-pos-percent 4 96 -interpolate true -palette-name videen_style -disp-pos true -disp-neg false -disp-zero false"
+fi
+
+if [ "${Type}" = "metric" ] ; then
+  ${wb_command} -metric-palette "$File" MODE_AUTO_SCALE_PERCENTAGE ${command}
+elif [ "${Type}" = "cifti" ] ; then
+  ${wb_command} -cifti-palette "$File" MODE_AUTO_SCALE_PERCENTAGE "$File" ${command}
+fi
 }
 
-for Modality in T1w T2w T1wT2w ; do
-  for Mesh in native 512 2k 8k 18k ; do #Native:??? 512=2mm 2k=1mm, 8k=0.5mm 18k=0.3mm #Was: 0p5mm 1mm 2mm
+for Mesh in native 512 2k 8k 18k ; do
 
-    PhysicalHippUnfoldFolderOut="$PhysicalHippUnfoldDIR"/"$Modality"
-    AtlasHippUnfoldolderOut="$AtlasHippUnfoldDIR"/"$Modality"
+  PhysicalHippUnfoldFolderOut="${PhysicalHippUnfoldDIR}/"
+  AtlasHippUnfoldFolderOut="${AtlasHippUnfoldDIR}/"
 
-    PhysicalHippUnfoldFolder="$PhysicalHippUnfoldFolderOut/$Mesh"
-    AtlasHippUnfoldFolder="$AtlasHippUnfoldolderOut/$Mesh"
-    
-    mkdir -p "$PhysicalHippUnfoldFolder" "$AtlasHippUnfoldFolder"
+  PhysicalHippUnfoldFolder="${PhysicalHippUnfoldFolderOut}${Mesh}"
+  AtlasHippUnfoldFolder="${AtlasHippUnfoldFolderOut}${Mesh}"
 
-    log_Msg "Processing $Modality $Mesh"
-    
-    #T1wT2w modality seems to run in BIDS "T1w" space, so let's make a separate variable for space
-    Space="$Modality"
-    if [[ "$Modality" == "T1wT2w" ]]
-    then
-      Space="T2w"
+  mkdir -p "$PhysicalHippUnfoldFolder" "$AtlasHippUnfoldFolder"
+
+  log_Msg "Processing $Mesh"
+
+  Space="T2w"
+
+  Structures="dentate hipp"
+  Surfaces="inner@INNER midthickness@MIDTHICKNESS outer@OUTER"
+  Scalars="curvature@GRAY@Curvature gyrification@GRAY@Gyrification surfarea@VIDEEN@SurfaceArea thickness@VIDEEN@Thickness myelin@VIDEEN@MyelinMap"
+  Labels="atlas-multihist7_subfields@HippocampalSubfields"
+
+  for Structure in $Structures ; do
+    for Hemisphere in L R ; do
+      #Surface area is no longer computed by HippUnfold
+      ${CARET7DIR}/wb_command -surface-vertex-areas \
+        "${RawHippUnfoldFolder}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_midthickness.surf.gii" \
+        "${RawHippUnfoldFolder}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_surfarea.shape.gii"
+    done
+
+    if [ "${Structure}" = "dentate" ] ; then
+      Left="HIPPOCAMPUS_DENTATE_LEFT"
+      Right="HIPPOCAMPUS_DENTATE_RIGHT"
+    elif [ "${Structure}" = "hipp" ] ; then
+      Left="HIPPOCAMPUS_LEFT"
+      Right="HIPPOCAMPUS_RIGHT"
     fi
 
-    Structures="dentate hipp"
-    Surfaces="inner@INNER midthickness@MIDTHICKNESS outer@OUTER"
-    Scalars="curvature@GRAY@Curvature gyrification@GRAY@Gyrification surfarea@VIDEEN@SurfaceArea thickness@VIDEEN@Thickness myelin@VIDEEN@MyelinMap"
-    Labels="atlas-multihist7_subfields@HippocampalSubfields"
-
-    for Structure in $Structures ; do
-      for Hemisphere in L R ; do
-        #surfacea no longer computed by HippUnfold
-        ${CARET7DIR}/wb_command -surface-vertex-areas $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_midthickness.surf.gii $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_surfarea.shape.gii
-      done
-      if [ ${Structure} = "dentate" ] ; then
-        Left="HIPPOCAMPUS_DENTATE_LEFT"
-        Right="HIPPOCAMPUS_DENTATE_RIGHT"
-        #for Hemisphere in L R ; do
-          #Already exists #Was: No dentate thickness is computed by HippUnfold
-          #${CARET7DIR}/wb_command -surface-to-surface-3d-distance $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_inner.surf.gii $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_outer.surf.gii $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_thickness.shape.gii
-        #done
-      elif [ ${Structure} = "hipp" ] ; then
-        Left="HIPPOCAMPUS_LEFT"
-        Right="HIPPOCAMPUS_RIGHT"
-      fi
-      for Hemisphere in L R ; do
-        if [ ${Hemisphere} = "L" ] ; then
-          if [ ${Structure} = "dentate" ] ; then
-            HemiStructure="HIPPOCAMPUS_DENTATE_LEFT"
-          elif [ ${Structure} = "hipp" ] ; then
-            HemiStructure="HIPPOCAMPUS_LEFT"
-          fi
-        elif [ ${Hemisphere} = "R" ] ; then
-          if [ ${Structure} = "dentate" ] ; then
-            HemiStructure="HIPPOCAMPUS_DENTATE_RIGHT"
-          elif [ ${Structure} = "hipp" ] ; then
-            HemiStructure="HIPPOCAMPUS_RIGHT"
-          fi
+    for Hemisphere in L R ; do
+      if [ "${Hemisphere}" = "L" ] ; then
+        if [ "${Structure}" = "dentate" ] ; then
+          HemiStructure="HIPPOCAMPUS_DENTATE_LEFT"
+        elif [ "${Structure}" = "hipp" ] ; then
+          HemiStructure="HIPPOCAMPUS_LEFT"
         fi
-        
-        #Anatomical Surfaces
-        for Surface in $Surfaces ; do
-          SurfaceType=`echo $Surface | cut -d "@" -f 2`
-          Surface=`echo $Surface | cut -d "@" -f 1`
-          cp $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_${Surface}.surf.gii ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii
-          ${CARET7DIR}/wb_command -set-structure ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii ${HemiStructure} -surface-type ANATOMICAL -surface-secondary-type ${SurfaceType}
-          ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${HemiStructure} ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii
-          ${CARET7DIR}/wb_command -surface-apply-warpfield ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii ${AtlasFolder}/xfms/standard2acpc_dc.nii.gz ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii -fnirt ${AtlasFolder}/T1w_restore.nii.gz
-          ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${HemiStructure} ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii
-        done
-        
-        #Flat Surfaces
-        cp $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-unfold_den-${Mesh}_label-${Structure}_midthickness.surf.gii ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii
-        ${CARET7DIR}/wb_command -set-structure ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii ${HemiStructure} -surface-type FLAT
-        ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${HemiStructure} ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii
-        cp ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii
-        ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${HemiStructure} ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii
-        
-        #GIFTI Metrics
-        #Don't add GIFTI to Specs
-        for Scalar in $Scalars ; do
-          Name=`echo $Scalar | cut -d "@" -f 3`
-          Color=`echo $Scalar | cut -d "@" -f 2`
-          Scalar=`echo $Scalar | cut -d "@" -f 1`
-          cp $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_${Scalar}.shape.gii ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii
-          ${CARET7DIR}/wb_command -set-structure ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii ${HemiStructure}
-          PALETTE ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii ${Color} metric ${CARET7DIR}/wb_command
-          ${CARET7DIR}/wb_command -set-map-names ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii -map 1 "${Subject}_${Name}"
-          if [ $Scalar = "surfarea" ] ; then
-            ${CARET7DIR}/wb_command -surface-vertex-areas ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_midthickness.${Mesh}.surf.gii ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii
-          else
-            cp ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-          fi
-        done
-        
-        #GIFTI Labels
-        #Don't add GIFTI to Specs
-        for Label in $Labels ; do
-          Name=`echo $Label | cut -d "@" -f 2`
-          Label=`echo $Label | cut -d "@" -f 1`
-          if [ ${Structure} = "hipp" ] ; then
-            if [ ${Hemisphere} = "L" ] ; then
-              Expression="Var"
-            elif [ ${Hemisphere} = "R" ] ; then
-              Expression="Var + 8"
-            fi
-            ${CARET7DIR}/wb_command -metric-math "${Expression}" ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii -var Var $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_${Label}.label.gii |& grep -v NIFTI_INTENT_LABEL
-            ${CARET7DIR}/wb_command -metric-label-import ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii $HCPPIPEDIR/global/config/HippUnfoldLut.txt ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii
-          elif [ ${Structure} = "dentate" ] ; then
-            if [ ${Hemisphere} = "L" ] ; then
-              Expression="6"
-            elif [ ${Hemisphere} = "R" ] ; then
-              Expression="6 + 8"
-            fi
-            ${CARET7DIR}/wb_command -metric-math "${Expression}" ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii -var Var $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_${Scalar}.shape.gii |& grep -v NIFTI_INTENT_LABEL
-            ${CARET7DIR}/wb_command -metric-label-import ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii $HCPPIPEDIR/global/config/HippUnfoldLut.txt ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii
-          fi
-          ${CARET7DIR}/wb_command -set-structure ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii ${HemiStructure}
-          ${CARET7DIR}/wb_command -set-map-names ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii -map 1 "${Subject}_${Name}"
-          cp ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii ${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-        done
-        
-        #NIFTI Hemispheric Labels
-        cp $PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_label-hipp_desc-subfields_atlas-multihist7_dseg.nii.gz ${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.HippocampalSubfields.nii.gz
+      elif [ "${Hemisphere}" = "R" ] ; then
+        if [ "${Structure}" = "dentate" ] ; then
+          HemiStructure="HIPPOCAMPUS_DENTATE_RIGHT"
+        elif [ "${Structure}" = "hipp" ] ; then
+          HemiStructure="HIPPOCAMPUS_RIGHT"
+        fi
+      fi
+
+      #Anatomical Surfaces
+      for SurfaceEntry in $Surfaces ; do
+        SurfaceType=$(echo "$SurfaceEntry" | cut -d "@" -f 2)
+        Surface=$(echo "$SurfaceEntry" | cut -d "@" -f 1)
+
+        cp "${RawHippUnfoldFolder}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-${Structure}_${Surface}.surf.gii" \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii"
+
+        ${CARET7DIR}/wb_command -set-structure \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii" \
+          "${HemiStructure}" \
+          -surface-type ANATOMICAL \
+          -surface-secondary-type "${SurfaceType}"
+
+        ${CARET7DIR}/wb_command -add-to-spec-file \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+          "${HemiStructure}" \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii"
+
+        ${CARET7DIR}/wb_command -surface-apply-warpfield \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii" \
+          "${AtlasFolder}/xfms/standard2acpc_dc.nii.gz" \
+          "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii" \
+          -fnirt "${AtlasFolder}/T1w_restore.nii.gz"
+
+        ${CARET7DIR}/wb_command -add-to-spec-file \
+          "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+          "${HemiStructure}" \
+          "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Surface}.${Mesh}.surf.gii"
       done
+
+      #Flat Surfaces
+      cp "${RawHippUnfoldFolder}/surf/sub-${Subject}_hemi-${Hemisphere}_space-unfold_den-${Mesh}_label-${Structure}_midthickness.surf.gii" \
+        "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii"
+
+      ${CARET7DIR}/wb_command -set-structure \
+        "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii" \
+        "${HemiStructure}" \
+        -surface-type FLAT
+
+      ${CARET7DIR}/wb_command -add-to-spec-file \
+        "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+        "${HemiStructure}" \
+        "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii"
+
+      cp "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii" \
+        "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii"
+
+      ${CARET7DIR}/wb_command -add-to-spec-file \
+        "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+        "${HemiStructure}" \
+        "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_flat.${Mesh}.surf.gii"
+
+      #GIFTI Metrics
+      #Don't add GIFTI to Specs
+      for ScalarEntry in $Scalars ; do
+        Name=$(echo "$ScalarEntry" | cut -d "@" -f 3)
+        Color=$(echo "$ScalarEntry" | cut -d "@" -f 2)
+        Scalar=$(echo "$ScalarEntry" | cut -d "@" -f 1)
+
+        cp "${RawHippUnfoldFolder}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_${Scalar}.shape.gii" \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii"
+
+        ${CARET7DIR}/wb_command -set-structure \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii" \
+          "${HemiStructure}"
+
+        PALETTE \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii" \
+          "${Color}" \
+          metric \
+          "${CARET7DIR}/wb_command"
+
+        ${CARET7DIR}/wb_command -set-map-names \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii" \
+          -map 1 "${Subject}_${Name}"
+
+        if [ "${Scalar}" = "surfarea" ] ; then
+          ${CARET7DIR}/wb_command \
+            -surface-vertex-areas \
+            "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_midthickness.${Mesh}.surf.gii" \
+            "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii"
+        else
+          cp \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii" \
+            "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Scalar}.${Mesh}.shape.gii"
+        fi
+      done
+
+      #GIFTI Labels
+      #Don't add GIFTI to Specs
+      for LabelEntry in $Labels ; do
+        Name=$(echo "$LabelEntry" | cut -d "@" -f 2)
+        Label=$(echo "$LabelEntry" | cut -d "@" -f 1)
+
+        if [ "${Structure}" = "hipp" ] ; then
+          if [ "${Hemisphere}" = "L" ] ; then
+            Expression="Var"
+          elif [ "${Hemisphere}" = "R" ] ; then
+            Expression="Var + 8"
+          fi
+
+          ${CARET7DIR}/wb_command -metric-math \
+            "${Expression}" \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii" \
+            -var Var \
+            "${RawHippUnfoldFolder}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_${Label}.label.gii" \
+            |& grep -v NIFTI_INTENT_LABEL
+
+          ${CARET7DIR}/wb_command \
+            -metric-label-import \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii" \
+            "$HCPPIPEDIR/global/config/HippUnfoldLut.txt" \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii"
+
+        elif [ "${Structure}" = "dentate" ] ; then
+          if [ "${Hemisphere}" = "L" ] ; then
+            Expression="6"
+          elif [ "${Hemisphere}" = "R" ] ; then
+            Expression="6 + 8"
+          fi
+
+          ${CARET7DIR}/wb_command \
+            -metric-math \
+            "${Expression}" \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii" \
+            -var Var \
+            "${RawHippUnfoldFolder}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-${Structure}_thickness.shape.gii" \
+            |& grep -v NIFTI_INTENT_LABEL
+
+          ${CARET7DIR}/wb_command \
+            -metric-label-import \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.shape.gii" \
+            "$HCPPIPEDIR/global/config/HippUnfoldLut.txt" \
+            "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii"
+        fi
+
+        ${CARET7DIR}/wb_command \
+          -set-structure \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii" \
+          "${HemiStructure}"
+
+        ${CARET7DIR}/wb_command \
+          -set-map-names \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii" \
+          -map 1 "${Subject}_${Name}"
+
+        cp \
+          "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii" \
+          "${AtlasHippUnfoldFolder}/${Subject}.${Hemisphere}.${Structure}_${Label}.${Mesh}.label.gii"
+      done
+
+      #NIFTI Hemispheric Labels
+      cp \
+        "${RawHippUnfoldFolder}/anat/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_label-hipp_desc-subfields_atlas-multihist7_dseg.nii.gz" \
+        "${PhysicalHippUnfoldFolder}/${Subject}.${Hemisphere}.HippocampalSubfields.nii.gz"
     done
-    
-    #CIFTI Scalars
-    for Scalar in $Scalars ; do
-      Name=`echo $Scalar | cut -d "@" -f 3`
-      Color=`echo $Scalar | cut -d "@" -f 2`
-      Scalar=`echo $Scalar | cut -d "@" -f 1`
-      ${CARET7DIR}/wb_command -cifti-create-dense-scalar ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii -metric HIPPOCAMPUS_LEFT ${PhysicalHippUnfoldFolder}/${Subject}.L.hipp_${Scalar}.${Mesh}.shape.gii -metric HIPPOCAMPUS_RIGHT ${PhysicalHippUnfoldFolder}/${Subject}.R.hipp_${Scalar}.${Mesh}.shape.gii -metric HIPPOCAMPUS_DENTATE_LEFT ${PhysicalHippUnfoldFolder}/${Subject}.L.dentate_${Scalar}.${Mesh}.shape.gii -metric HIPPOCAMPUS_DENTATE_RIGHT ${PhysicalHippUnfoldFolder}/${Subject}.R.dentate_${Scalar}.${Mesh}.shape.gii
-      PALETTE ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii ${Color} cifti ${CARET7DIR}/wb_command
-      ${CARET7DIR}/wb_command -set-map-names ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii -map 1 "${Subject}_${Name}"
-      ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-      cp ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii ${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-      ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-    done
-
-    
-    #CIFTI Labels
-    for Label in $Labels ; do
-      Name=`echo $Label | cut -d "@" -f 2`
-      Label=`echo $Label | cut -d "@" -f 1`
-      ${CARET7DIR}/wb_command -cifti-create-label ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii -label HIPPOCAMPUS_LEFT ${PhysicalHippUnfoldFolder}/${Subject}.L.hipp_${Label}.${Mesh}.label.gii -label HIPPOCAMPUS_RIGHT ${PhysicalHippUnfoldFolder}/${Subject}.R.hipp_${Label}.${Mesh}.label.gii -label HIPPOCAMPUS_DENTATE_LEFT ${PhysicalHippUnfoldFolder}/${Subject}.L.dentate_${Label}.${Mesh}.label.gii -label HIPPOCAMPUS_DENTATE_RIGHT ${PhysicalHippUnfoldFolder}/${Subject}.R.dentate_${Label}.${Mesh}.label.gii
-      ${CARET7DIR}/wb_command -set-map-names ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii -map 1 "${Subject}_${Name}"
-      ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-      cp ${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii ${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-      ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii #TODO: mv to have maps in AtlasFolder like Cerebral Cortex?
-    done
-
-    #NIFTI Label Volumes
-    fslmaths ${PhysicalHippUnfoldFolder}/${Subject}.R.HippocampalSubfields.nii.gz -add 8 -mas ${PhysicalHippUnfoldFolder}/${Subject}.R.HippocampalSubfields.nii.gz -add ${PhysicalHippUnfoldFolder}/${Subject}.L.HippocampalSubfields.nii.gz ${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz
-    ${CARET7DIR}/wb_command -volume-label-import ${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz $HCPPIPEDIR/global/config/HippUnfoldLut.txt ${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz
-    rm ${PhysicalHippUnfoldFolder}/${Subject}.L.HippocampalSubfields.nii.gz ${PhysicalHippUnfoldFolder}/${Subject}.R.HippocampalSubfields.nii.gz
-    ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz
-    ${CARET7DIR}/wb_command -volume-resample ${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz ${AtlasFolder}/T1w_restore.nii.gz ENCLOSING_VOXEL ${AtlasHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz -warp ${AtlasFolder}/xfms/acpc_dc2standard.nii.gz -fnirt ${AtlasFolder}/T1w_restore.nii.gz
-    ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${AtlasHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz
-
-    #NIFTI Input Volumes
-    ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${T1wFolder}/T1w_acpc_dc_restore.nii.gz
-    ${CARET7DIR}/wb_command -add-to-spec-file ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${T1wFolder}/T2w_acpc_dc_restore.nii.gz
-    ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${AtlasFolder}/T1w_restore.nii.gz
-    ${CARET7DIR}/wb_command -add-to-spec-file ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec INVALID ${AtlasFolder}/T2w_restore.nii.gz
-
-    #TODO: Anything with 8k and 18k meshes?
-    if [ $Mesh = "native" ] ; then
-      ${CARET7DIR}/wb_command -spec-file-merge ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${T1wFolder}/Native/${Subject}.native.wb.spec ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.native.wb_spec #TODO: Don't Hardcode Cortex
-      ${CARET7DIR}/wb_command -spec-file-merge ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${AtlasFolder}/Native/${Subject}.native.wb.spec ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.native.wb_spec #TODO: Don't Hardcode Cortex
-    elif [ $Mesh = "512" ] ; then
-      ${CARET7DIR}/wb_command -spec-file-merge ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${T1wFolder}/fsaverage_LR32k/${Subject}.MSMAll.32k_fs_LR.wb.spec ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.MSMAll.32k.wb_spec #TODO: Don't Hardcode Cortex
-      ${CARET7DIR}/wb_command -spec-file-merge ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${AtlasFolder}/fsaverage_LR32k/${Subject}.MSMAll.32k_fs_LR.wb.spec ${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.MSMAll.32k.wb_spec #TODO: Don't Hardcode Cortex
-    elif [ $Mesh = "2k" ] ; then
-      ${CARET7DIR}/wb_command -spec-file-merge ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec ${AtlasFolder}/${Subject}.MSMAll.164k_fs_LR.wb.spec ${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.MSMAll.164k.wb_spec #TODO: Don't Hardcode Cortex
-    fi
   done
+
+  #CIFTI Scalars
+  for ScalarEntry in $Scalars ; do
+    Name=$(echo "$ScalarEntry" | cut -d "@" -f 3)
+    Color=$(echo "$ScalarEntry" | cut -d "@" -f 2)
+    Scalar=$(echo "$ScalarEntry" | cut -d "@" -f 1)
+
+    ${CARET7DIR}/wb_command \
+      -cifti-create-dense-scalar \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii" \
+      -metric HIPPOCAMPUS_LEFT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.L.hipp_${Scalar}.${Mesh}.shape.gii" \
+      -metric HIPPOCAMPUS_RIGHT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.R.hipp_${Scalar}.${Mesh}.shape.gii" \
+      -metric HIPPOCAMPUS_DENTATE_LEFT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.L.dentate_${Scalar}.${Mesh}.shape.gii" \
+      -metric HIPPOCAMPUS_DENTATE_RIGHT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.R.dentate_${Scalar}.${Mesh}.shape.gii"
+
+    PALETTE \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii" \
+      "${Color}" \
+      cifti \
+      "${CARET7DIR}/wb_command"
+
+    ${CARET7DIR}/wb_command \
+      -set-map-names \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii" \
+      -map 1 "${Subject}_${Name}"
+
+    ${CARET7DIR}/wb_command \
+      -add-to-spec-file \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      INVALID \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii"
+
+    cp \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii" \
+      "${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii"
+
+    ${CARET7DIR}/wb_command \
+      -add-to-spec-file \
+      "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      INVALID \
+      "${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Scalar}.${Mesh}.dscalar.nii"
+  done
+
+  #CIFTI Labels
+  for LabelEntry in $Labels ; do
+    Name=$(echo "$LabelEntry" | cut -d "@" -f 2)
+    Label=$(echo "$LabelEntry" | cut -d "@" -f 1)
+
+    ${CARET7DIR}/wb_command \
+      -cifti-create-label \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii" \
+      -label HIPPOCAMPUS_LEFT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.L.hipp_${Label}.${Mesh}.label.gii" \
+      -label HIPPOCAMPUS_RIGHT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.R.hipp_${Label}.${Mesh}.label.gii" \
+      -label HIPPOCAMPUS_DENTATE_LEFT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.L.dentate_${Label}.${Mesh}.label.gii" \
+      -label HIPPOCAMPUS_DENTATE_RIGHT \
+      "${PhysicalHippUnfoldFolder}/${Subject}.R.dentate_${Label}.${Mesh}.label.gii"
+
+    ${CARET7DIR}/wb_command \
+      -set-map-names \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii" \
+      -map 1 "${Subject}_${Name}"
+
+    ${CARET7DIR}/wb_command \
+      -add-to-spec-file \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      INVALID \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii"
+
+    cp \
+      "${PhysicalHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii" \
+      "${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii"
+
+    ${CARET7DIR}/wb_command \
+      -add-to-spec-file \
+      "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      INVALID \
+      "${AtlasHippUnfoldFolder}/${Subject}.hippocampus_${Label}.${Mesh}.dlabel.nii"
+  done
+
+  #NIFTI Label Volumes
+  fslmaths \
+    "${PhysicalHippUnfoldFolder}/${Subject}.R.HippocampalSubfields.nii.gz" \
+    -add 8 \
+    -mas "${PhysicalHippUnfoldFolder}/${Subject}.R.HippocampalSubfields.nii.gz" \
+    -add "${PhysicalHippUnfoldFolder}/${Subject}.L.HippocampalSubfields.nii.gz" \
+    "${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -volume-label-import \
+    "${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz" \
+    "$HCPPIPEDIR/global/config/HippUnfoldLut.txt" \
+    "${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz"
+
+  rm \
+    "${PhysicalHippUnfoldFolder}/${Subject}.L.HippocampalSubfields.nii.gz" \
+    "${PhysicalHippUnfoldFolder}/${Subject}.R.HippocampalSubfields.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -add-to-spec-file \
+    "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+    INVALID \
+    "${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -volume-resample \
+    "${PhysicalHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz" \
+    "${AtlasFolder}/T1w_restore.nii.gz" \
+    ENCLOSING_VOXEL \
+    "${AtlasHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz" \
+    -warp "${AtlasFolder}/xfms/acpc_dc2standard.nii.gz" \
+    -fnirt "${AtlasFolder}/T1w_restore.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -add-to-spec-file \
+    "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+    INVALID \
+    "${AtlasHippUnfoldFolder}/${Subject}.HippocampalSubfields.nii.gz"
+
+  #NIFTI Input Volumes
+  ${CARET7DIR}/wb_command \
+    -add-to-spec-file \
+    "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+    INVALID \
+    "${T1wFolder}/T1w_acpc_dc_restore.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -add-to-spec-file \
+    "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+    INVALID \
+    "${T1wFolder}/T2w_acpc_dc_restore.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -add-to-spec-file \
+    "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+    INVALID \
+    "${AtlasFolder}/T1w_restore.nii.gz"
+
+  ${CARET7DIR}/wb_command \
+    -add-to-spec-file \
+    "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+    INVALID \
+    "${AtlasFolder}/T2w_restore.nii.gz"
+
+  #TODO: Anything with 8k and 18k meshes?
+  if [ "${Mesh}" = "native" ] ; then
+    ${CARET7DIR}/wb_command \
+      -spec-file-merge \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      "${T1wFolder}/Native/${Subject}.native.wb.spec" \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.native.wb_spec"
+
+    ${CARET7DIR}/wb_command \
+      -spec-file-merge \
+      "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      "${AtlasFolder}/Native/${Subject}.native.wb.spec" \
+      "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.native.wb_spec"
+
+  elif [ "${Mesh}" = "512" ] ; then
+    ${CARET7DIR}/wb_command \
+      -spec-file-merge \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      "${T1wFolder}/fsaverage_LR32k/${Subject}.MSMAll.32k_fs_LR.wb.spec" \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.MSMAll.32k.wb_spec"
+
+    ${CARET7DIR}/wb_command \
+      -spec-file-merge \
+      "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      "${AtlasFolder}/fsaverage_LR32k/${Subject}.MSMAll.32k_fs_LR.wb.spec" \
+      "${AtlasHippUnfoldFolder}/${Subject}.${Mesh}.MSMAll.32k.wb_spec"
+
+  elif [ "${Mesh}" = "2k" ] ; then
+    ${CARET7DIR}/wb_command \
+      -spec-file-merge \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.wb_spec" \
+      "${AtlasFolder}/${Subject}.MSMAll.164k_fs_LR.wb.spec" \
+      "${PhysicalHippUnfoldFolder}/${Subject}.${Mesh}.MSMAll.164k.wb_spec"
+  fi
 done
 
 log_Msg "PostHippUnfold pipeline completed successfully for subject: $Subject"
-
-
-#HippUnfold Outputs Used By HCP
-
-#Version 2.0.0
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat:
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_label-hipp_desc-subfields_atlas-multihist7_dseg.nii.gz
-
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_desc-preproc_T1w.nii.gz
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_desc-preproc_T2w.nii.gz
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-L_space-cropT1w_desc-preproc_T1w.nii.gz
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-L_space-cropT1w_label-hipp_desc-subfields_atlas-multihist7_dseg.nii.gz
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-R_space-cropT1w_desc-preproc_T1w.nii.gz
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-R_space-cropT1w_label-hipp_desc-subfields_atlas-multihist7_dseg.nii.gz
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_space-cropT1w_desc-subfields_atlas-multihist7_volumes.tsv
-
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti:
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-dentate_curvature.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-dentate_gyrification.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-dentate_myelin.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-dentate_surfarea.dscalar.nii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-dentate_thickness.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-hipp_atlas-multihist7_subfields.dlabel.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-hipp_curvature.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-hipp_gyrification.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-hipp_myelin.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-hipp_surfarea.dscalar.nii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/cifti/sub-${Subject}_den-${Mesh}_label-hipp_thickness.dscalar.nii
-
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric:
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-dentate_curvature.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-dentate_gyrification.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-dentate_myelin.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-dentate_surfarea.shape.gii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-dentate_thickness.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-hipp_atlas-multihist7_subfields.label.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-hipp_curvature.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-hipp_gyrification.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-hipp_myelin.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}}_den-${Mesh}_label-hipp_surfarea.shape.gii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_hemi-${Hemisphere}_den-${Mesh}_label-hipp_thickness.shape.gii
-
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_dir-AP_hemi-${Hemisphere}_den-${Mesh}_label-dentate_desc-laplace_coords.shape.gii
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_dir-AP_hemi-${Hemisphere}_den-${Mesh}_label-hipp_desc-laplace_coords.shape.gii
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_dir-PD_hemi-${Hemisphere}_den-${Mesh}_label-dentate_desc-laplace_coords.shape.gii
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/metric/sub-${Subject}_dir-PD_hemi-${Hemisphere}_den-${Mesh}_label-hipp_desc-laplace_coords.shape.gii
-
-#/media/myelin/brainmappers/Connectome_Project/YA_HCP_Final/100307/T1w/HippUnfold/T1w/hippunfold/sub-100307/surf:
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_inner.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_midthickness.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_outer.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_inner.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_midthickness.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_outer.surf.gii
-
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-unfold_den-${Mesh}_label-dentate_midthickness.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-unfold_den-${Mesh}_label-hipp_midthickness.surf.gii
-
-##$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_den-${Mesh}_surfaces.spec
-
-
-#OLD
-#Scalars
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_curvature.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_gyrification.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_myelin.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_surfarea.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_thickness.shape.gii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_curvature.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_gyrification.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_myelin.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_surfarea.shape.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_thickness.shape.gii
-
-#Surfaces
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_inner.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_midthickness.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_outer.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_inner.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_midthickness.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_outer.surf.gii
-
-#Flat Surfaces
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-unfold_den-${Mesh}_label-dentate_midthickness.surf.gii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-unfold_den-${Mesh}_label-hipp_midthickness.surf.gii
-
-#Labels
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-hipp_atlas-multihist7_subfields.label.gii
-
-#Specs
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_den-${Mesh}_label-dentate_surfaces.spec
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_hemi-${Hemisphere}_space-${Space}den-${Mesh}_label-hipp_surfaces.spec
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}den-${Mesh}_label-dentate_surfaces.spec
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_surfaces.spec
-
-#CIFTIScalars (recreated by the script)
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-dentate_curvature.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-dentate_gyrification.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-dentate_myelin.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-dentate_surfarea.dscalar.nii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-dentate_thickness.dscalar.nii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_curvature.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_gyrification.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_myelin.dscalar.nii
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_surfarea.dscalar.nii #Not created by default
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_thickness.dscalar.nii
-
-#CIFTILabels (recreated by the script)
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/surf/sub-${Subject}_space-${Space}_den-${Mesh}_label-hipp_atlas-multihist7_subfields.dlabel.nii
-
-#VolumeLabels
-#$PhysicalHippUnfoldFolderOut/hippunfold/sub-${Subject}/anat/sub-${Subject}_hemi-${Hemisphere}_space-${Space}_desc-subfields_atlas-multihist7_dseg.nii.gz
-

--- a/HippUnfoldHCP/PostHippUnfoldHCP.sh
+++ b/HippUnfoldHCP/PostHippUnfoldHCP.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 set -eu
-
 pipedirguessed=0
 if [[ "${HCPPIPEDIR:-}" == "" ]]
 then
-# pipedirguessed=1
-#fix this if the script is more than one level below HCPPIPEDIR
-export HCPPIPEDIR="$(dirname -- "$0")/.."
+  # pipedirguessed=1
+   #fix this if the script is more than one level below HCPPIPEDIR
+   export HCPPIPEDIR="$(dirname -- "$0")/.."
 fi
 
-#source "${HCPPIPEDIR}/global/scripts/log.shlib" "$@"            
 source "$HCPPIPEDIR/global/scripts/debug.shlib" "$@" # Debugging functions; also sources log.shlib
 source "$HCPPIPEDIR/global/scripts/newopts.shlib" "$@"
+
 
 opts_SetScriptDescription "Make some BIDS structures and run HippUnfold"
 
@@ -24,7 +23,7 @@ opts_ParseArguments "$@"
 
 if ((pipedirguessed))
 then
-  log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
+    log_Err_Abort "HCPPIPEDIR is not set, you must first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
 fi
 
 opts_ShowValues
@@ -42,32 +41,21 @@ if [[ -z "${AtlasHippUnfoldDIR:-}" ]] ; then
 AtlasHippUnfoldDIR="${AtlasFolder}/HippUnfold"
 fi
 
-RawHippUnfoldFolder="${PhysicalHippUnfoldDIR}/sub-${Subject}"
-
-if [[ ! -d "$RawHippUnfoldFolder" ]]
-then
-echo "ERROR: HippUnfold output not found:" >&2
-echo "$RawHippUnfoldFolder" >&2
-exit 1
-fi
-
 function PALETTE {
-File=${1}
-Color=${2}
-Type=${3}
-wb_command=${4}
-
-if [ "${Color}" = "GRAY" ] ; then
-  command="-pos-percent 2 98 -palette-name Gray_Interp -disp-pos true -disp-neg true -disp-zero true"
-elif [ "${Color}" = "VIDEEN" ] ; then
-  command="-pos-percent 4 96 -interpolate true -palette-name videen_style -disp-pos true -disp-neg false -disp-zero false"
-fi
-
-if [ "${Type}" = "metric" ] ; then
-  ${wb_command} -metric-palette "$File" MODE_AUTO_SCALE_PERCENTAGE ${command}
-elif [ "${Type}" = "cifti" ] ; then
-  ${wb_command} -cifti-palette "$File" MODE_AUTO_SCALE_PERCENTAGE "$File" ${command}
-fi
+  File=${1}
+  Color=${2}
+  Type=${3}
+  wb_command=${4}
+  if [ ${Color} = "GRAY" ] ; then
+    command="-pos-percent 2 98 -palette-name Gray_Interp -disp-pos true -disp-neg true -disp-zero true"
+  elif [ ${Color} = "VIDEEN" ] ; then
+    command="-pos-percent 4 96 -interpolate true -palette-name videen_style -disp-pos true -disp-neg false -disp-zero false"
+  fi
+  if [ ${Type} = "metric" ] ; then
+    ${wb_command} -metric-palette "$File" MODE_AUTO_SCALE_PERCENTAGE ${command}
+  elif [ ${Type} = "cifti" ] ; then
+    ${wb_command} -cifti-palette "$File" MODE_AUTO_SCALE_PERCENTAGE "$File" ${command}
+  fi
 }
 
 for Mesh in native 512 2k 8k 18k ; do


### PR DESCRIPTION
Main changes for RunHippUnfold, HippUnfold, PostHippUnfold, RunPostHippUnfold: 

-Updated the HippUnfold command to use the Maguire T2w model, including --force-nnunet-model maguire_T2w and inner/outer registration settings of 0. 

-Changed the output/file structure from supporting separate T1w, T2w, and T1wT2w models to using the Maguire T2w model. Because only one model is now used, the model-specific T1w, T2w, and T1wT2w subdirectories were removed. 

-Log files are now written to a dedicated logging directory within each subject's T1w/HippUnfold directory. 

-In HippUnfoldHCP.sh, imported runlocal from RunHippUnfoldHCP, and added separate per-job cache and Conda directories when runlocal=FALSE. This prevents simultaneous subjects from sharing these directories, which had caused failures when multiple HippUnfold jobs were run in parallel. These temporary per-job directories are removed after successful completion. 

-In PostHippUnfoldHCP.sh, one use of ${Scalar} in the dentate-label generation section was replaced with an explicit thickness.shape.gii input. ${Scalar} is likely a leftover from the preceding scalar-processing loop. The metric is used as the template for generating the constant-valued dentate label; the thickness values themselves are not used in the calculation. 

-Updated RunHippUnfoldHCP.sh and RunPostHippUnfoldHCP.sh for generic study-folder, subject-list, environment-script.
