### PR TITLE
Add hippocampal fMRISurface processing

### DIFF
--- a/fMRISurface/GenericHippocampusfMRISurfaceProcessingPipeline.sh
+++ b/fMRISurface/GenericHippocampusfMRISurfaceProcessingPipeline.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -eu
 # Requirements for this script
 # installed versions of: FSL, Connectome Workbench (wb_command)
 # environment: HCPPIPEDIR, FSLDIR, CARET7DIR
@@ -24,7 +24,9 @@ then
 fi
 
 #comment the line back in when done
-source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"          # Debugging functions; also sources log.shlib
+#source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"          # Debugging functions; also sources log.shlib
+source "${HCPPIPEDIR}/global/scripts/log.shlib" "$@"          # Debugging functions; also sources log.shlib
+
 source "${HCPPIPEDIR}/global/scripts/newopts.shlib" "$@"
 source "${HCPPIPEDIR}/global/scripts/processingmodecheck.shlib" # Check processing mode requirements
 
@@ -40,14 +42,11 @@ opts_AddOptional '--procstring' 'ProcString' 'string' 'processing suffix appende
 
 opts_AddMandatory '--smoothingFWHM' 'SmoothingFWHM' 'number' 'smoothing FWHM (mm)'
 
-opts_AddOptional '--fmri-qc' 'QCMode' 'YES OR NO OR ONLY' "Controls whether to generate a QC scene and snapshots (default=YES). ONLY executes just the QC script." "YES"
-
-opts_AddOptional '--output-directory' 'OutputDirectory' 'path' 'Directory where pipeline outputs will be written' ""
-
 opts_AddOptional '--goodvoxel' 'doGoodVoxels' 'YES OR NO' "Controls whether to do goodVoxel procedure (default = YES)" "YES"
 
-opts_AddOptional '--factor' 'factor' 'number' "Scaling factor for eliminating high COV voxels"
+opts_AddOptional '--factor' 'factor' 'number' "Scaling factor for eliminating high COV voxels (default = 1.5)" "1.5"
 
+opts_AddOptional '--resample_mesh' 'MeshString' 'string' 'Resample native mesh to: 512, 2k, 8k, or 18k. Use quote for multiple meshes, e.g. "512 2k 8k"' "512 2k 8k 18k"
 opts_ParseArguments "$@"
 
 if ((pipedirguessed))
@@ -76,162 +75,59 @@ HCPPIPEDIR_fMRISurf="${HCPPIPEDIR}/fMRISurface/scripts"
 log_Msg "Platform Information Follows:"
 uname -a
 
-QCMode="$(echo "${QCMode}" | tr '[:upper:]' '[:lower:]')"
-
-doProcessing=1
-doQC=1
-
-case "${QCMode}" in
-    yes)
-        ;;
-    no)
-        doQC=0
-        ;;
-    only)
-        doProcessing=0
-        log_Warn "Only generating fMRI QC scene and snapshots from existing data"
-        ;;
-    *)
-        log_Err_Abort "Unrecognized value '${QCMode}' for --fmri-qc; use YES, NO, or ONLY"
-        ;;
-esac
-
-
 # ------------------------------------------------------------------------------
 # Set up paths
 # ------------------------------------------------------------------------------
 
-PipelineScripts="${HCPPIPEDIR_fMRISurf}"
-
 MainSubjectFolder="${Path}/${Subject}"
 AtlasSpaceFolder="${MainSubjectFolder}/MNINonLinear"
 InputResultsFolder="${AtlasSpaceFolder}/Results/${NameOffMRI}"
-ResultsFolderName="Results"
+ResultsFolder="${AtlasSpaceFolder}/Results/${NameOffMRI}"
 
-if [ -n "${OutputDirectory}" ]; then
-    ResultsFolder="${OutputDirectory}/${Subject}/${NameOffMRI}"
-else
-    ResultsFolder="${AtlasSpaceFolder}/${ResultsFolderName}/${NameOffMRI}"
-fi
-
-WorkingDirectory="${ResultsFolder}/tmp"
-
+WorkingDirectory="${ResultsFolder}/HippocampalVolumeToSurfaceMapping" #should 'HippocampalVolumeToSurfaceMapping' be a parameter?'
 mkdir -p "${WorkingDirectory}"
 
-VolumefMRI="${InputResultsFolder}/${NameOffMRI}${ProcString}"
+VolumefMRI="${InputResultsFolder}/${NameOffMRI}${ProcString}.nii.gz"
 
 SBRef="${InputResultsFolder}/${NameOffMRI}_SBRef.nii.gz"
 
 HippUnfoldFolder="${AtlasSpaceFolder}/HippUnfold"
 
-if [ ! -f "${VolumefMRI}.nii.gz" ]; then
-    log_Err_Abort "Cannot find selected fMRI file: ${VolumefMRI}.nii.gz"
+if [ ! -f "${VolumefMRI}" ]; then
+    log_Err_Abort "Cannot find selected fMRI file: ${VolumefMRI}"
 fi
 
 if [ ! -f "${SBRef}" ]; then
     log_Err_Abort "Cannot find selected SBRef file: ${SBRef}"
 fi
 
-log_Msg "Selected fMRI file: ${VolumefMRI}.nii.gz"
+#Parse MeshString into a mesh array
+for Mesh in ${MeshString}; do
+    if [[ " 512 2k 8k 18k " != *" ${Mesh} "* ]]; then
+        log_Err_Abort "Invalid mesh: ${Mesh}"
+    fi
+done
+Meshes="native ${MeshString}"
+
+log_Msg "Selected fMRI file: ${VolumefMRI}"
 log_Msg "Selected SBRef file: ${SBRef}"
 
 # ------------------------------------------------------------------------------
-# Generate fMRI time series within ROIs
+# Combining ROIs into a single CIFTI time series and vn file
 # ------------------------------------------------------------------------------
 
-if ((doProcessing)); then
-
-    # Make fMRI ribbon
-    log_Msg "Make fMRI Ribbon"
-    log_Msg "mkdir -p ${WorkingDirectory}"
-
-    log_Msg "Hippocampal Volume To Surface Mapping"
-    "${PipelineScripts}/HippocampalVolumeToSurfaceMapping.sh" \
-            "${WorkingDirectory}" \
-            "${Subject}" \
-            "${HippUnfoldFolder}" \
-            "${VolumefMRI}" \
-            "${SBRef}" \
-            "${doGoodVoxels}" \
-            "${factor}"
-
-#Surface Smoothing
- # ------------------------------------------------------------------------------
-# Hippocampal Surface Smoothing
-# ------------------------------------------------------------------------------
-
-    log_Msg "Hippocampal Surface Smoothing"
-
-    Sigma=`echo "$SmoothingFWHM / (2 * sqrt(2 * l(2)))" | bc -l`
-
-    Meshes=(native 512 2k 8k 18k)
-    Structures=(hipp dentate)
-
-    for Mesh in "${Meshes[@]}"; do
-        for Structure in "${Structures[@]}"; do
-            for Hemisphere in L R; do
-                "${CARET7DIR}/wb_command" -metric-smoothing \
-                    "${HippUnfoldFolder}/${Mesh}/${Subject}.${Hemisphere}.${Structure}_midthickness.${Mesh}.surf.gii" \
-                    "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_fMRI.${Mesh}.func.gii" \
-                    "${Sigma}" \
-                    "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
-                    -roi "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_ones.${Mesh}.func.gii"
-            done
-        done
-    done
-# ------------------------------------------------------------------------------
-# Combining ROIs into a single CIFTI file
-# ------------------------------------------------------------------------------
+log_Msg "mkdir -p ${WorkingDirectory}"
+log_Msg "Hippocampal Volume To Surface Mapping"
 
 
-    for Mesh in ${Meshes[@]}; do
-        "${CARET7DIR}/wb_command" -cifti-create-dense-timeseries \
-            "${ResultsFolder}/${NameOffMRI}_AtlasHipp_${ProcString}.${Mesh}.dtseries.nii" \
-            -metric HIPPOCAMPUS_LEFT "${WorkingDirectory}/${Subject}.L.hipp_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
-                -roi "${WorkingDirectory}/${Subject}.L.hipp_ones.${Mesh}.func.gii" \
-            -metric HIPPOCAMPUS_RIGHT "${WorkingDirectory}/${Subject}.R.hipp_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
-                -roi "${WorkingDirectory}/${Subject}.R.hipp_ones.${Mesh}.func.gii" \
-            -metric HIPPOCAMPUS_DENTATE_LEFT "${WorkingDirectory}/${Subject}.L.dentate_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
-                -roi "${WorkingDirectory}/${Subject}.L.dentate_ones.${Mesh}.func.gii" \
-            -metric HIPPOCAMPUS_DENTATE_RIGHT "${WorkingDirectory}/${Subject}.R.dentate_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
-                -roi "${WorkingDirectory}/${Subject}.R.dentate_ones.${Mesh}.func.gii"
+# Generate fMRI time series for each of the hippocampal structures: L hipp, R hipp, L dentate, R dentate
+"${HCPPIPEDIR_fMRISurf}/HippocampalVolumeToSurfaceMapping.sh" "${ResultsFolder}" "${Subject}" "${HippUnfoldFolder}" "${VolumefMRI}" "${SBRef}" "${doGoodVoxels}" "${factor}" "${Meshes}"
 
-            log_Msg "Generated fMRI time series Cifti file: "${ResultsFolder}/${Subject}.${NameOffMRI}"_AtlasHipp_${ProcString}.${Mesh}.dtseries.nii"
-            
-# --------------------------------------------------------------------------
-# Combine VN maps from all four hippocampal structures
-# --------------------------------------------------------------------------
+#Surface Smoothing of each hippocampal structure
+"${HCPPIPEDIR_fMRISurf}/HippocampalSmoothing.sh" "${HippUnfoldFolder}" "${ResultsFolder}" "${WorkingDirectory}" "${Subject}" "${SmoothingFWHM}" "${Meshes}"
 
-    "${CARET7DIR}/wb_command" -cifti-create-dense-scalar \
-        "${ResultsFolder}/${NameOffMRI}_AtlasHipp_${ProcString}_vn.${Mesh}.dscalar.nii" \
-        -metric HIPPOCAMPUS_LEFT \
-            "${WorkingDirectory}/${Subject}.L.hipp_fMRI_vn.${Mesh}.func.gii" \
-            -roi "${WorkingDirectory}/${Subject}.L.hipp_ones.${Mesh}.func.gii" \
-        -metric HIPPOCAMPUS_RIGHT \
-            "${WorkingDirectory}/${Subject}.R.hipp_fMRI_vn.${Mesh}.func.gii" \
-            -roi "${WorkingDirectory}/${Subject}.R.hipp_ones.${Mesh}.func.gii" \
-        -metric HIPPOCAMPUS_DENTATE_LEFT \
-            "${WorkingDirectory}/${Subject}.L.dentate_fMRI_vn.${Mesh}.func.gii" \
-            -roi "${WorkingDirectory}/${Subject}.L.dentate_ones.${Mesh}.func.gii" \
-        -metric HIPPOCAMPUS_DENTATE_RIGHT \
-            "${WorkingDirectory}/${Subject}.R.dentate_fMRI_vn.${Mesh}.func.gii" \
-            -roi "${WorkingDirectory}/${Subject}.R.dentate_ones.${Mesh}.func.gii"
+#Integration of the 4 hippocampal structures into single CIFTI timeseries and vn files
+"${HCPPIPEDIR_fMRISurf}/CreateHippocampalCIFTIs.sh" "${ResultsFolder}" "${Subject}" "${NameOffMRI}" "${ProcString}" "${SmoothingFWHM}" "${Meshes}"
 
-    log_Msg "Generated VN CIFTI file: ${ResultsFolder}/${NameOffMRI}_AtlasHipp_${ProcString}_vn.${Mesh}.dscalar.nii"
+log_Msg "GenericHippocampusfMRISurfaceProcessingPipeline Completed!"
 
-    done
-fi
-
-#Uncomment if want to remove the subfoler with intermediate files
-#rm -rf "${WorkingDirectory}"
-
-# if ((doQC)); then
-#     log_Msg "Generating fMRI QC scene and snapshots"
-#     "${PipelineScripts}/GenerateFMRIScenes.sh" \
-#         --study-folder="${Path}" \
-#         --subject="${Subject}" \
-#         --fmriname="${NameOffMRI}${ProcString}" \
-#         --output-folder="${ResultsFolder}/fMRIQC"
-# fi
-
-log_Msg "Completed!"

--- a/fMRISurface/GenericHippocampusfMRISurfaceProcessingPipeline.sh
+++ b/fMRISurface/GenericHippocampusfMRISurfaceProcessingPipeline.sh
@@ -197,6 +197,28 @@ if ((doProcessing)); then
                 -roi "${WorkingDirectory}/${Subject}.R.dentate_ones.${Mesh}.func.gii"
 
             log_Msg "Generated fMRI time series Cifti file: "${ResultsFolder}/${Subject}.${NameOffMRI}"_AtlasHipp_${ProcString}.${Mesh}.dtseries.nii"
+            
+# --------------------------------------------------------------------------
+# Combine VN maps from all four hippocampal structures
+# --------------------------------------------------------------------------
+
+    "${CARET7DIR}/wb_command" -cifti-create-dense-scalar \
+        "${ResultsFolder}/${NameOffMRI}_AtlasHipp_${ProcString}_vn.${Mesh}.dscalar.nii" \
+        -metric HIPPOCAMPUS_LEFT \
+            "${WorkingDirectory}/${Subject}.L.hipp_fMRI_vn.${Mesh}.func.gii" \
+            -roi "${WorkingDirectory}/${Subject}.L.hipp_ones.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_RIGHT \
+            "${WorkingDirectory}/${Subject}.R.hipp_fMRI_vn.${Mesh}.func.gii" \
+            -roi "${WorkingDirectory}/${Subject}.R.hipp_ones.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_DENTATE_LEFT \
+            "${WorkingDirectory}/${Subject}.L.dentate_fMRI_vn.${Mesh}.func.gii" \
+            -roi "${WorkingDirectory}/${Subject}.L.dentate_ones.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_DENTATE_RIGHT \
+            "${WorkingDirectory}/${Subject}.R.dentate_fMRI_vn.${Mesh}.func.gii" \
+            -roi "${WorkingDirectory}/${Subject}.R.dentate_ones.${Mesh}.func.gii"
+
+    log_Msg "Generated VN CIFTI file: ${ResultsFolder}/${NameOffMRI}_AtlasHipp_${ProcString}_vn.${Mesh}.dscalar.nii"
+
     done
 fi
 

--- a/fMRISurface/GenericHippocampusfMRISurfaceProcessingPipeline.sh
+++ b/fMRISurface/GenericHippocampusfMRISurfaceProcessingPipeline.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+# Requirements for this script
+# installed versions of: FSL, Connectome Workbench (wb_command)
+# environment: HCPPIPEDIR, FSLDIR, CARET7DIR
+
+########################################## PIPELINE OVERVIEW ##########################################
+
+# TODO
+
+########################################## OUTPUT DIRECTORIES ##########################################
+
+# TODO
+
+################################################ SUPPORT FUNCTIONS ##################################################
+
+set -eu
+pipedirguessed=0
+if [[ "${HCPPIPEDIR:-}" == "" ]]
+then
+    pipedirguessed=1
+    # Fix this if the script is more than one level below HCPPIPEDIR
+    export HCPPIPEDIR="$(dirname -- "$0")/.."
+fi
+
+#comment the line back in when done
+source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"          # Debugging functions; also sources log.shlib
+source "${HCPPIPEDIR}/global/scripts/newopts.shlib" "$@"
+source "${HCPPIPEDIR}/global/scripts/processingmodecheck.shlib" # Check processing mode requirements
+
+opts_SetScriptDescription "Run hippocampal fMRISurface processing"
+
+opts_AddMandatory '--studyfolder' 'Path' 'path' "folder containing all subjects" "--path"
+
+opts_AddMandatory '--subject' 'Subject' 'subject ID' ""
+
+opts_AddMandatory '--fmriname' 'NameOffMRI' 'string' 'fMRI run name, for example rfMRI_REST1_LR'
+
+opts_AddOptional '--procstring' 'ProcString' 'string' 'processing suffix appended to the 4D fMRI filename; include the leading underscore' ""
+
+opts_AddMandatory '--smoothingFWHM' 'SmoothingFWHM' 'number' 'smoothing FWHM (mm)'
+
+opts_AddOptional '--fmri-qc' 'QCMode' 'YES OR NO OR ONLY' "Controls whether to generate a QC scene and snapshots (default=YES). ONLY executes just the QC script." "YES"
+
+opts_AddOptional '--output-directory' 'OutputDirectory' 'path' 'Directory where pipeline outputs will be written' ""
+
+opts_AddOptional '--goodvoxel' 'doGoodVoxels' 'YES OR NO' "Controls whether to do goodVoxel procedure (default = YES)" "YES"
+
+opts_AddOptional '--factor' 'factor' 'number' "Scaling factor for eliminating high COV voxels"
+
+opts_ParseArguments "$@"
+
+if ((pipedirguessed))
+then
+    log_Err_Abort "HCPPIPEDIR is not set; first source your edited copy of Examples/Scripts/SetUpHCPPipeline.sh"
+fi
+
+opts_ShowValues
+
+"${HCPPIPEDIR}/show_version"
+
+# ------------------------------------------------------------------------------
+# Verify required environment variables are set
+# ------------------------------------------------------------------------------
+
+log_Check_Env_Var HCPPIPEDIR
+log_Check_Env_Var FSLDIR
+log_Check_Env_Var CARET7DIR
+
+HCPPIPEDIR_fMRISurf="${HCPPIPEDIR}/fMRISurface/scripts"
+
+# ------------------------------------------------------------------------------
+# Parse command-line options
+# ------------------------------------------------------------------------------
+
+log_Msg "Platform Information Follows:"
+uname -a
+
+QCMode="$(echo "${QCMode}" | tr '[:upper:]' '[:lower:]')"
+
+doProcessing=1
+doQC=1
+
+case "${QCMode}" in
+    yes)
+        ;;
+    no)
+        doQC=0
+        ;;
+    only)
+        doProcessing=0
+        log_Warn "Only generating fMRI QC scene and snapshots from existing data"
+        ;;
+    *)
+        log_Err_Abort "Unrecognized value '${QCMode}' for --fmri-qc; use YES, NO, or ONLY"
+        ;;
+esac
+
+
+# ------------------------------------------------------------------------------
+# Set up paths
+# ------------------------------------------------------------------------------
+
+PipelineScripts="${HCPPIPEDIR_fMRISurf}"
+
+MainSubjectFolder="${Path}/${Subject}"
+AtlasSpaceFolder="${MainSubjectFolder}/MNINonLinear"
+InputResultsFolder="${AtlasSpaceFolder}/Results/${NameOffMRI}"
+ResultsFolderName="Results"
+
+if [ -n "${OutputDirectory}" ]; then
+    ResultsFolder="${OutputDirectory}/${Subject}/${NameOffMRI}"
+else
+    ResultsFolder="${AtlasSpaceFolder}/${ResultsFolderName}/${NameOffMRI}"
+fi
+
+WorkingDirectory="${ResultsFolder}/tmp"
+
+mkdir -p "${WorkingDirectory}"
+
+VolumefMRI="${InputResultsFolder}/${NameOffMRI}${ProcString}"
+
+SBRef="${InputResultsFolder}/${NameOffMRI}_SBRef.nii.gz"
+
+HippUnfoldFolder="${AtlasSpaceFolder}/HippUnfold"
+
+if [ ! -f "${VolumefMRI}.nii.gz" ]; then
+    log_Err_Abort "Cannot find selected fMRI file: ${VolumefMRI}.nii.gz"
+fi
+
+if [ ! -f "${SBRef}" ]; then
+    log_Err_Abort "Cannot find selected SBRef file: ${SBRef}"
+fi
+
+log_Msg "Selected fMRI file: ${VolumefMRI}.nii.gz"
+log_Msg "Selected SBRef file: ${SBRef}"
+
+# ------------------------------------------------------------------------------
+# Generate fMRI time series within ROIs
+# ------------------------------------------------------------------------------
+
+if ((doProcessing)); then
+
+    # Make fMRI ribbon
+    log_Msg "Make fMRI Ribbon"
+    log_Msg "mkdir -p ${WorkingDirectory}"
+
+    log_Msg "Hippocampal Volume To Surface Mapping"
+    "${PipelineScripts}/HippocampalVolumeToSurfaceMapping.sh" \
+            "${WorkingDirectory}" \
+            "${Subject}" \
+            "${HippUnfoldFolder}" \
+            "${VolumefMRI}" \
+            "${SBRef}" \
+            "${doGoodVoxels}" \
+            "${factor}"
+
+#Surface Smoothing
+ # ------------------------------------------------------------------------------
+# Hippocampal Surface Smoothing
+# ------------------------------------------------------------------------------
+
+    log_Msg "Hippocampal Surface Smoothing"
+
+    Sigma=`echo "$SmoothingFWHM / (2 * sqrt(2 * l(2)))" | bc -l`
+
+    Meshes=(native 512 2k 8k 18k)
+    Structures=(hipp dentate)
+
+    for Mesh in "${Meshes[@]}"; do
+        for Structure in "${Structures[@]}"; do
+            for Hemisphere in L R; do
+                "${CARET7DIR}/wb_command" -metric-smoothing \
+                    "${HippUnfoldFolder}/${Mesh}/${Subject}.${Hemisphere}.${Structure}_midthickness.${Mesh}.surf.gii" \
+                    "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_fMRI.${Mesh}.func.gii" \
+                    "${Sigma}" \
+                    "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+                    -roi "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_ones.${Mesh}.func.gii"
+            done
+        done
+    done
+# ------------------------------------------------------------------------------
+# Combining ROIs into a single CIFTI file
+# ------------------------------------------------------------------------------
+
+
+    for Mesh in ${Meshes[@]}; do
+        "${CARET7DIR}/wb_command" -cifti-create-dense-timeseries \
+            "${ResultsFolder}/${NameOffMRI}_AtlasHipp_${ProcString}.${Mesh}.dtseries.nii" \
+            -metric HIPPOCAMPUS_LEFT "${WorkingDirectory}/${Subject}.L.hipp_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+                -roi "${WorkingDirectory}/${Subject}.L.hipp_ones.${Mesh}.func.gii" \
+            -metric HIPPOCAMPUS_RIGHT "${WorkingDirectory}/${Subject}.R.hipp_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+                -roi "${WorkingDirectory}/${Subject}.R.hipp_ones.${Mesh}.func.gii" \
+            -metric HIPPOCAMPUS_DENTATE_LEFT "${WorkingDirectory}/${Subject}.L.dentate_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+                -roi "${WorkingDirectory}/${Subject}.L.dentate_ones.${Mesh}.func.gii" \
+            -metric HIPPOCAMPUS_DENTATE_RIGHT "${WorkingDirectory}/${Subject}.R.dentate_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+                -roi "${WorkingDirectory}/${Subject}.R.dentate_ones.${Mesh}.func.gii"
+
+            log_Msg "Generated fMRI time series Cifti file: "${ResultsFolder}/${Subject}.${NameOffMRI}"_AtlasHipp_${ProcString}.${Mesh}.dtseries.nii"
+    done
+fi
+
+#Uncomment if want to remove the subfoler with intermediate files
+#rm -rf "${WorkingDirectory}"
+
+# if ((doQC)); then
+#     log_Msg "Generating fMRI QC scene and snapshots"
+#     "${PipelineScripts}/GenerateFMRIScenes.sh" \
+#         --study-folder="${Path}" \
+#         --subject="${Subject}" \
+#         --fmriname="${NameOffMRI}${ProcString}" \
+#         --output-folder="${ResultsFolder}/fMRIQC"
+# fi
+
+log_Msg "Completed!"

--- a/fMRISurface/scripts/CreateHippocampalCIFTIs.sh
+++ b/fMRISurface/scripts/CreateHippocampalCIFTIs.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -eu
+# --------------------------------------------------------------------------------
+#  Usage Description Function
+# --------------------------------------------------------------------------------
+
+script_name=$(basename "${0}")
+
+show_usage() {
+    cat <<EOF
+
+${script_name}: Sub-script of GenericHippocampusfMRISurfaceProcessingPipeline.sh
+
+EOF
+}
+
+# Allow script to return a Usage statement, before any other output or checking
+if [ "$#" = "0" ]; then
+    show_usage
+    exit 1
+fi
+
+# ------------------------------------------------------------------------------
+#  Check that HCPPIPEDIR is defined and Load Function Libraries
+# ------------------------------------------------------------------------------
+
+if [ -z "${HCPPIPEDIR}" ]; then
+    echo "${script_name}: ABORTING: HCPPIPEDIR environment variable must be set"
+    exit 1
+fi
+
+source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"         # Debugging functions; also sources log.shlib
+source "${HCPPIPEDIR}/global/scripts/opts.shlib"               # Command line option functions
+
+opts_ShowVersionIfRequested "$@"
+
+if opts_CheckForHelpRequest "$@"; then
+    show_usage
+    exit 0
+fi
+
+# ------------------------------------------------------------------------------
+#  Verify required environment variables are set and log value
+# ------------------------------------------------------------------------------
+
+log_Check_Env_Var HCPPIPEDIR
+log_Check_Env_Var CARET7DIR
+
+# ------------------------------------------------------------------------------
+#  Start work
+# ------------------------------------------------------------------------------
+
+log_Msg "START"
+
+ResultsFolder="$1"
+Subject="$2"
+NameOffMRI="$3"
+ProcString="$4"
+SmoothingFWHM="$5"
+Meshes="$6"
+
+for Mesh in ${Meshes}; do
+
+    wb_command -cifti-create-dense-timeseries "${ResultsFolder}/${NameOffMRI}_AtlasHipp${ProcString}.${Mesh}.dtseries.nii" \
+        -metric HIPPOCAMPUS_LEFT "${ResultsFolder}/${Subject}.L.hipp_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_RIGHT "${ResultsFolder}/${Subject}.R.hipp_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_DENTATE_LEFT "${ResultsFolder}/${Subject}.L.dentate_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_DENTATE_RIGHT "${ResultsFolder}/${Subject}.R.dentate_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii"
+
+    log_Msg "Generated fMRI time series CIFTI file: ${ResultsFolder}/${NameOffMRI}_AtlasHipp${ProcString}.${Mesh}.dtseries.nii"
+
+    wb_command -cifti-create-dense-scalar "${ResultsFolder}/${NameOffMRI}_AtlasHipp${ProcString}_vn.${Mesh}.dscalar.nii" \
+        -metric HIPPOCAMPUS_LEFT "${ResultsFolder}/${Subject}.L.hipp_fMRI_vn.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_RIGHT "${ResultsFolder}/${Subject}.R.hipp_fMRI_vn.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_DENTATE_LEFT "${ResultsFolder}/${Subject}.L.dentate_fMRI_vn.${Mesh}.func.gii" \
+        -metric HIPPOCAMPUS_DENTATE_RIGHT "${ResultsFolder}/${Subject}.R.dentate_fMRI_vn.${Mesh}.func.gii"
+
+    log_Msg "Generated VN CIFTI file: ${ResultsFolder}/${NameOffMRI}_AtlasHipp${ProcString}_vn.${Mesh}.dscalar.nii"
+
+done
+
+log_Msg "END"

--- a/fMRISurface/scripts/HippocampalSmoothing.sh
+++ b/fMRISurface/scripts/HippocampalSmoothing.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -eu
+# --------------------------------------------------------------------------------
+#  Usage Description Function
+# --------------------------------------------------------------------------------
+
+script_name=$(basename "${0}")
+
+show_usage() {
+    cat <<EOF
+
+${script_name}: Sub-script of GenericHippocampusfMRISurfaceProcessingPipeline.sh
+
+EOF
+}
+
+# Allow script to return a Usage statement, before any other output or checking
+if [ "$#" = "0" ]; then
+    show_usage
+    exit 1
+fi
+
+# ------------------------------------------------------------------------------
+#  Check that HCPPIPEDIR is defined and Load Function Libraries
+# ------------------------------------------------------------------------------
+
+if [ -z "${HCPPIPEDIR}" ]; then
+    echo "${script_name}: ABORTING: HCPPIPEDIR environment variable must be set"
+    exit 1
+fi
+
+source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"         # Debugging functions; also sources log.shlib
+source "${HCPPIPEDIR}/global/scripts/opts.shlib"               # Command line option functions
+
+opts_ShowVersionIfRequested "$@"
+
+if opts_CheckForHelpRequest "$@"; then
+    show_usage
+    exit 0
+fi
+
+# ------------------------------------------------------------------------------
+#  Verify required environment variables are set and log value
+# ------------------------------------------------------------------------------
+
+log_Check_Env_Var HCPPIPEDIR
+log_Check_Env_Var CARET7DIR
+
+# ------------------------------------------------------------------------------
+#  Start work
+# ------------------------------------------------------------------------------
+
+log_Msg "START"
+
+HippUnfoldFolder="$1"
+ResultsFolder="$2"
+WorkingDirectory="$3"
+Subject="$4"
+SmoothingFWHM="$5"
+Meshes="$6"
+
+Sigma=$(echo "${SmoothingFWHM} / (2 * sqrt(2 * l(2)))" | bc -l)
+
+Structures=(hipp dentate)
+
+for Mesh in ${Meshes}; do
+    for Structure in "${Structures[@]}"; do
+        for Hemisphere in L R; do
+            wb_command -metric-smoothing "${HippUnfoldFolder}/${Mesh}/${Subject}.${Hemisphere}.${Structure}_midthickness.${Mesh}.surf.gii" "${ResultsFolder}/${Subject}.${Hemisphere}.${Structure}_fMRI.${Mesh}.func.gii" "${Sigma}" "${ResultsFolder}/${Subject}.${Hemisphere}.${Structure}_fMRI_s${SmoothingFWHM}.${Mesh}.func.gii" -roi "${WorkingDirectory}/${Subject}.${Hemisphere}.${Structure}_ones.${Mesh}.func.gii"
+        done
+    done
+done
+
+log_Msg "END"

--- a/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
+++ b/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
@@ -440,15 +440,15 @@ for Structure in hipp dentate; do
 
         else
 
-            "${WB}" -volume-to-surface-mapping \
-                "${VolumefMRI}.nii.gz" \
-                "${MidSurface}" \
-                "${NativefMRI}" \
-                -ribbon-constrained \
-                    "${InnerSurface}" \
-                    "${OuterSurface}" \
-                    -dilate-missing ${dilation_dist} \
-                        -nearest
+	"${WB}" -volume-to-surface-mapping \
+            "${VolumefMRI}.nii.gz" \
+	    "${MidSurface}" \
+	    "${NativefMRI}" \
+	    -ribbon-constrained \
+	    	"${InnerSurface}" \
+	    	"${OuterSurface}" \
+	    	-dilate-missing ${dilation_dist} 
+	    	-nearest
 
         fi
 
@@ -456,7 +456,7 @@ for Structure in hipp dentate; do
             "${NativefMRI}" \
             "${MidSurface}" \
             "${dilation_dist}" \
-            "${NativefMRI}" \
+            "${NativefMRI}" 
             -nearest
 
         "${WB}" -metric-mask \
@@ -466,7 +466,26 @@ for Structure in hipp dentate; do
 
         log_Msg "Generated fMRI file in native space at: ${NativefMRI}"
 
+	# =====================================================================
+	# Map VN volume to native hippocampal surface
+	# =====================================================================
 
+	VolumefMRIVN="${VolumefMRI}_vn.nii.gz"
+	NativefMRIVN="${WorkingDirectory}/${Prefix}_fMRI_vn.native.func.gii"
+
+	"${WB}" -volume-to-surface-mapping \
+	    "${VolumefMRIVN}" \
+	    "${MidSurface}" \
+	    "${NativefMRIVN}" \
+	    -cubic
+
+	"${WB}" -metric-mask \
+	    "${NativefMRIVN}" \
+	    "${NativeROI}" \
+	    "${NativefMRIVN}"
+
+	log_Msg "Generated VN file in native space at: ${NativefMRIVN}"
+	
         # =====================================================================
         # Resample complete fMRI timeseries to all densities
         # =====================================================================

--- a/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
+++ b/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
@@ -1,0 +1,538 @@
+#!/bin/bash 
+
+# --------------------------------------------------------------------------------
+#  Usage Description Function
+# --------------------------------------------------------------------------------
+
+script_name=$(basename "${0}")
+
+show_usage() {
+    cat <<EOF
+
+${script_name}: Sub-script of GenericHippocampusfMRISurfaceProcessingPipeline.sh
+
+EOF
+}
+
+
+# Allow script to return a Usage statement, before any other output or checking
+if [ "$#" = "0" ]; then
+    show_usage
+    exit 1
+fi
+
+# ------------------------------------------------------------------------------
+#  Check that HCPPIPEDIR is defined and Load Function Libraries
+# ------------------------------------------------------------------------------
+
+if [ -z "${HCPPIPEDIR}" ]; then
+    echo "${script_name}: ABORTING: HCPPIPEDIR environment variable must be set"
+    exit 1
+fi
+
+source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"         # Debugging functions; also sources log.shlib
+#source "${HCPPIPEDIR}/global/scripts/log.shlib" "$@"            # Debugging functions; also sources log.shlib
+source "${HCPPIPEDIR}/global/scripts/opts.shlib"                # Command line option functions
+
+opts_ShowVersionIfRequested "$@"
+
+if opts_CheckForHelpRequest "$@"; then
+    show_usage
+    exit 0
+fi
+
+# ------------------------------------------------------------------------------
+#  Verify required environment variables are set and log value
+# ------------------------------------------------------------------------------
+
+log_Check_Env_Var HCPPIPEDIR
+log_Check_Env_Var CARET7DIR
+
+# ------------------------------------------------------------------------------
+#  Start work
+# ------------------------------------------------------------------------------
+
+WorkingDirectory="$1"
+Subject="$2"
+HippUnfoldFolder="$3"
+VolumefMRI="$4"
+SBRef="$5"
+doGoodVoxels="$6"
+Factor="$7"
+#Factor="1"                 # Factor is a scaling factor for how many std units away from mean to set threshold
+NeighborhoodSmoothing="5"   # Distinguishes large vs small dropout
+dilation_dist="10"
+
+Meshes=(512 2k 8k 18k)
+
+WB="${CARET7DIR}/wb_command"
+
+mkdir -p "${WorkingDirectory}"
+
+FirstRibbon="YES"
+
+# ------------------------------------------------------------------------------
+#  Generating mean, std, and coefficient of variation metric maps
+# ------------------------------------------------------------------------------
+
+fslmaths "${VolumefMRI}" \
+    -Tmean "${WorkingDirectory}/${Subject}.mean" \
+    -odt float
+
+fslmaths "${VolumefMRI}" \
+    -Tstd "${WorkingDirectory}/${Subject}.std" \
+    -odt float
+
+fslmaths "${WorkingDirectory}/${Subject}.std" \
+    -div "${WorkingDirectory}/${Subject}.mean" \
+    "${WorkingDirectory}/${Subject}.cov"
+
+
+for Structure in hipp dentate; do
+
+    for Hemisphere in L R; do
+
+        # ------------------------------------------------------------------------------
+        #  Establishing input and output files
+        # ------------------------------------------------------------------------------
+
+        Prefix="${Subject}.${Hemisphere}.${Structure}"
+
+        ThicknessMetric="${HippUnfoldFolder}/native/${Prefix}_thickness.native.shape.gii"
+
+        InnerSurface="${HippUnfoldFolder}/native/${Prefix}_inner.native.surf.gii"
+        MidSurface="${HippUnfoldFolder}/native/${Prefix}_midthickness.native.surf.gii"
+        OuterSurface="${HippUnfoldFolder}/native/${Prefix}_outer.native.surf.gii"
+
+        OnesMetric="${WorkingDirectory}/${Prefix}_ones.native.func.gii"
+        ProbabilisticRibbon="${WorkingDirectory}/${Prefix}.ribbon_probabilistic.nii.gz"
+        BinaryRibbon="${WorkingDirectory}/${Prefix}.ribbon.nii.gz"
+
+
+        # ------------------------------------------------------------------------------
+        #  Generating an all-ones surface metric
+        # ------------------------------------------------------------------------------
+
+        "${WB}" -metric-math \
+            '1' \
+            "${OnesMetric}" \
+            -var x \
+            "${ThicknessMetric}"
+
+
+        # ------------------------------------------------------------------------------
+        #  Mapping the all-ones metric into SBRef volume space using the inner and
+        #  outer surfaces as ribbon boundaries
+        # ------------------------------------------------------------------------------
+
+        "${WB}" -metric-to-volume-mapping \
+            "${OnesMetric}" \
+            "${MidSurface}" \
+            "${SBRef}" \
+            "${ProbabilisticRibbon}" \
+            -ribbon-constrained \
+                "${InnerSurface}" \
+                "${OuterSurface}"
+
+
+        # ------------------------------------------------------------------------------
+        #  Thresholding the fractional ribbon at greater than 0 to create a binary mask
+        # ------------------------------------------------------------------------------
+
+        "${WB}" -volume-math \
+            "x > 0" \
+            "${BinaryRibbon}" \
+            -var x \
+            "${ProbabilisticRibbon}"
+
+
+        # ------------------------------------------------------------------------------
+        #  Generating good-voxel mask for each structure
+        # ------------------------------------------------------------------------------
+
+        if [[ "${doGoodVoxels}" == "YES" ]]; then
+
+            fslmaths "${WorkingDirectory}/${Subject}.cov" \
+                -mas "${BinaryRibbon}" \
+                "${WorkingDirectory}/${Prefix}_cov_ribbon"
+
+            meanIntensity=$(fslstats "${WorkingDirectory}/${Prefix}_cov_ribbon" -M)
+
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon" \
+                -div ${meanIntensity} \
+                "${WorkingDirectory}/${Prefix}_cov_ribbon_norm"
+
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon_norm" \
+                -bin \
+                -s "${NeighborhoodSmoothing}" \
+                "${WorkingDirectory}/${Prefix}_SmoothNorm"
+
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon_norm" \
+                -s "${NeighborhoodSmoothing}" \
+                -div "${WorkingDirectory}/${Prefix}_SmoothNorm" \
+                -dilD \
+                "${WorkingDirectory}/${Prefix}_cov_ribbon_norm_s${NeighborhoodSmoothing}"
+
+            fslmaths "${WorkingDirectory}/${Subject}.cov" \
+                -div ${meanIntensity} \
+                -div "${WorkingDirectory}/${Prefix}_cov_ribbon_norm_s${NeighborhoodSmoothing}" \
+                "${WorkingDirectory}/${Prefix}_cov_norm_modulate"
+
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_norm_modulate" \
+                -mas "${BinaryRibbon}" \
+                "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon"
+
+            STD=$(fslstats \
+                "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon" \
+                -S)
+
+            echo "STD: ${STD}"
+
+            MEAN=$(fslstats \
+                "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon" \
+                -M)
+
+            echo "MEAN: ${MEAN}"
+
+            Lower=$(echo "${MEAN} - (${STD} * ${Factor})" | bc -l)
+            echo "LOWER: ${Lower}"
+
+            Upper=$(echo "${MEAN} + (${STD} * ${Factor})" | bc -l)
+            echo "UPPER: ${Upper}"
+
+            fslmaths "${WorkingDirectory}/${Subject}.mean" \
+                -bin \
+                "${WorkingDirectory}/${Prefix}_mask"
+
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_norm_modulate" \
+                -thr "${Upper}" \
+                -bin \
+                -sub "${WorkingDirectory}/${Prefix}_mask" \
+                -mul -1 \
+                -mas "${BinaryRibbon}" \
+                "${WorkingDirectory}/${Prefix}_goodvoxels"
+        fi
+
+
+        NativeFolder="${HippUnfoldFolder}/native"
+
+        InnerSurface="${NativeFolder}/${Prefix}_inner.native.surf.gii"
+        MidSurface="${NativeFolder}/${Prefix}_midthickness.native.surf.gii"
+        OuterSurface="${NativeFolder}/${Prefix}_outer.native.surf.gii"
+
+        NativeFlat="${NativeFolder}/${Prefix}_flat.native.surf.gii"
+        NativeSurfArea="${NativeFolder}/${Prefix}_surfarea.native.shape.gii"
+
+        NativeROI="${WorkingDirectory}/${Prefix}_ones.native.func.gii"
+
+
+        # =====================================================================
+        # Map mean and covariance volumes
+        # =====================================================================
+
+        for Map in mean cov; do
+
+            NativeMetric="${WorkingDirectory}/${Prefix}_${Map}.native.func.gii"
+            NativeAllMetric="${WorkingDirectory}/${Prefix}_${Map}_all.native.func.gii"
+
+
+            # -----------------------------------------------------------------
+            # Map using good voxels
+            # -----------------------------------------------------------------
+
+            if [[ "${doGoodVoxels}" == "YES" ]]; then
+
+                "${WB}" -volume-to-surface-mapping \
+                    "${WorkingDirectory}/${Subject}.${Map}.nii.gz" \
+                    "${MidSurface}" \
+                    "${NativeMetric}" \
+                    -ribbon-constrained \
+                        "${InnerSurface}" \
+                        "${OuterSurface}" \
+                        -volume-roi "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" \
+                        -dilate-missing ${dilation_dist} \
+                            -nearest
+
+            else
+
+                "${WB}" -volume-to-surface-mapping \
+                    "${WorkingDirectory}/${Subject}.${Map}.nii.gz" \
+                    "${MidSurface}" \
+                    "${NativeMetric}" \
+                    -ribbon-constrained \
+                        "${InnerSurface}" \
+                        "${OuterSurface}" \
+                        -dilate-missing ${dilation_dist} \
+                            -nearest
+            fi
+
+            "${WB}" -metric-dilate \
+                "${NativeMetric}" \
+                "${MidSurface}" \
+                "${dilation_dist}" \
+                "${NativeMetric}" \
+                -nearest
+
+            "${WB}" -metric-mask \
+                "${NativeMetric}" \
+                "${NativeROI}" \
+                "${NativeMetric}"
+
+
+            # -----------------------------------------------------------------
+            # Map using all ribbon voxels
+            # -----------------------------------------------------------------
+
+            "${WB}" -volume-to-surface-mapping \
+                "${WorkingDirectory}/${Subject}.${Map}.nii.gz" \
+                "${MidSurface}" \
+                "${NativeAllMetric}" \
+                -ribbon-constrained \
+                    "${InnerSurface}" \
+                    "${OuterSurface}" \
+                    -dilate-missing ${dilation_dist} \
+                        -nearest
+
+            "${WB}" -metric-mask \
+                "${NativeAllMetric}" \
+                "${NativeROI}" \
+                "${NativeAllMetric}"
+
+
+            # -----------------------------------------------------------------
+            # Resample native metrics using unfolded flat surfaces
+            # -----------------------------------------------------------------
+
+            for Mesh in ${Meshes[@]}; do
+
+                MeshFolder="${HippUnfoldFolder}/${Mesh}"
+
+                TargetFlat="${MeshFolder}/${Prefix}_flat.${Mesh}.surf.gii"
+                TargetMidSurface="${MeshFolder}/${Prefix}_midthickness.${Mesh}.surf.gii"
+                TargetSurfArea="${MeshFolder}/${Prefix}_surfarea.${Mesh}.shape.gii"
+
+                TargetROI="${WorkingDirectory}/${Prefix}_ones.${Mesh}.func.gii"
+
+                TargetMetric="${WorkingDirectory}/${Prefix}_${Map}.${Mesh}.func.gii"
+                TargetAllMetric="${WorkingDirectory}/${Prefix}_${Map}_all.${Mesh}.func.gii"
+
+
+                "${WB}" -metric-math \
+                    "x * 0 + 1" \
+                    "${TargetROI}" \
+                    -var x "${TargetSurfArea}"
+
+
+                "${WB}" -metric-resample \
+                    "${NativeMetric}" \
+                    "${NativeFlat}" \
+                    "${TargetFlat}" \
+                    ADAP_BARY_AREA \
+                    "${TargetMetric}" \
+                    -area-surfs \
+                        "${MidSurface}" \
+                        "${TargetMidSurface}" \
+                    -current-roi "${NativeROI}" \
+                    -bypass-sphere-check
+
+                "${WB}" -metric-mask \
+                    "${TargetMetric}" \
+                    "${TargetROI}" \
+                    "${TargetMetric}"
+
+
+                "${WB}" -metric-resample \
+                    "${NativeAllMetric}" \
+                    "${NativeFlat}" \
+                    "${TargetFlat}" \
+                    ADAP_BARY_AREA \
+                    "${TargetAllMetric}" \
+                    -area-surfs \
+                        "${MidSurface}" \
+                        "${TargetMidSurface}" \
+                    -current-roi "${NativeROI}" \
+                    -bypass-sphere-check
+
+                "${WB}" -metric-mask \
+                    "${TargetAllMetric}" \
+                    "${TargetROI}" \
+                    "${TargetAllMetric}"
+
+
+        done
+
+
+        # =====================================================================
+        # Map goodvoxels in volume space
+        # =====================================================================
+
+        if [[ "${doGoodVoxels}" == "YES" ]]; then
+
+            NativeGoodVoxels="${WorkingDirectory}/${Prefix}_goodvoxels.native.func.gii"
+
+            "${WB}" -volume-to-surface-mapping \
+                "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" \
+                "${MidSurface}" \
+                "${NativeGoodVoxels}" \
+                -ribbon-constrained \
+                    "${InnerSurface}" \
+                    "${OuterSurface}" \
+                    -dilate-missing ${dilation_dist} \
+                        -nearest
+
+            "${WB}" -metric-mask \
+                "${NativeGoodVoxels}" \
+                "${NativeROI}" \
+                "${NativeGoodVoxels}"
+
+
+            for Mesh in ${Meshes[@]}; do
+
+                MeshFolder="${HippUnfoldFolder}/${Mesh}"
+
+                TargetFlat="${MeshFolder}/${Prefix}_flat.${Mesh}.surf.gii"
+                TargetMidSurface="${MeshFolder}/${Prefix}_midthickness.${Mesh}.surf.gii"
+                TargetROI="${WorkingDirectory}/${Prefix}_ones.${Mesh}.func.gii"
+
+                TargetGoodVoxels="${WorkingDirectory}/${Prefix}_goodvoxels.${Mesh}.func.gii"
+
+
+                "${WB}" -metric-resample \
+                    "${NativeGoodVoxels}" \
+                    "${NativeFlat}" \
+                    "${TargetFlat}" \
+                    ADAP_BARY_AREA \
+                    "${TargetGoodVoxels}" \
+                    -area-surfs \
+                        "${MidSurface}" \
+                        "${TargetMidSurface}" \
+                    -current-roi "${NativeROI}" \
+                    -bypass-sphere-check
+
+                "${WB}" -metric-mask \
+                    "${TargetGoodVoxels}" \
+                    "${TargetROI}" \
+                    "${TargetGoodVoxels}"
+
+            done
+
+        fi
+
+
+        # =====================================================================
+        # Map complete fMRI timeseries to native hippocampal surface
+        # =====================================================================
+
+        NativefMRI="${WorkingDirectory}/${Prefix}_fMRI.native.func.gii"
+
+
+        if [[ "${doGoodVoxels}" == "YES" ]]; then
+
+            "${WB}" -volume-to-surface-mapping \
+                "${VolumefMRI}.nii.gz" \
+                "${MidSurface}" \
+                "${NativefMRI}" \
+                -ribbon-constrained \
+                    "${InnerSurface}" \
+                    "${OuterSurface}" \
+                    -volume-roi "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" \
+                    -dilate-missing ${dilation_dist} \
+                        -nearest
+
+        else
+
+            "${WB}" -volume-to-surface-mapping \
+                "${VolumefMRI}.nii.gz" \
+                "${MidSurface}" \
+                "${NativefMRI}" \
+                -ribbon-constrained \
+                    "${InnerSurface}" \
+                    "${OuterSurface}" \
+                    -dilate-missing ${dilation_dist} \
+                        -nearest
+
+        fi
+
+
+        "${WB}" -metric-dilate \
+            "${NativefMRI}" \
+            "${MidSurface}" \
+            "${dilation_dist}" \
+            "${NativefMRI}" \
+            -nearest
+
+        "${WB}" -metric-mask \
+            "${NativefMRI}" \
+            "${NativeROI}" \
+            "${NativefMRI}"
+
+        log_Msg "Generated fMRI file in native space at: ${NativefMRI}"
+
+
+        # =====================================================================
+        # Resample complete fMRI timeseries to all densities
+        # =====================================================================
+
+        for Mesh in ${Meshes[@]}; do
+
+            MeshFolder="${HippUnfoldFolder}/${Mesh}"
+
+            TargetFlat="${MeshFolder}/${Prefix}_flat.${Mesh}.surf.gii"
+            TargetMidSurface="${MeshFolder}/${Prefix}_midthickness.${Mesh}.surf.gii"
+            TargetROI="${WorkingDirectory}/${Prefix}_ones.${Mesh}.func.gii"
+
+            TargetfMRI="${WorkingDirectory}/${Prefix}_fMRI.${Mesh}.func.gii"
+
+
+            "${WB}" -metric-resample \
+                "${NativefMRI}" \
+                "${NativeFlat}" \
+                "${TargetFlat}" \
+                ADAP_BARY_AREA \
+                "${TargetfMRI}" \
+                -area-surfs \
+                    "${MidSurface}" \
+                    "${TargetMidSurface}" \
+                -current-roi "${NativeROI}" \
+                -bypass-sphere-check
+
+
+            "${WB}" -metric-dilate \
+                "${TargetfMRI}" \
+                "${TargetMidSurface}" \
+                ${dilation_dist} \
+                "${TargetfMRI}" \
+                -nearest
+
+
+            "${WB}" -metric-mask \
+                "${TargetfMRI}" \
+                "${TargetROI}" \
+                "${TargetfMRI}"
+
+
+            log_Msg "Generated fMRI file in ${Mesh} mesh at: ${TargetfMRI}"
+
+
+            done
+        done
+    done
+done
+
+# =====================================================================
+# All voxel mask an good voxel mask
+# =====================================================================
+
+fslmaths "${WorkingDirectory}/${Subject}.L.hipp.ribbon.nii.gz" \
+    -add "${WorkingDirectory}/${Subject}.R.hipp.ribbon.nii.gz" \
+    -add "${WorkingDirectory}/${Subject}.L.dentate.ribbon.nii.gz" \
+    -add "${WorkingDirectory}/${Subject}.R.dentate.ribbon.nii.gz" \
+    -bin \
+    "${WorkingDirectory}/${Subject}.allStructures.allVoxels.ribbon.nii.gz"
+
+fslmaths "${WorkingDirectory}/${Subject}.L.hipp_goodvoxels.nii.gz" \
+    -add "${WorkingDirectory}/${Subject}.R.hipp_goodvoxels.nii.gz" \
+    -add "${WorkingDirectory}/${Subject}.L.dentate_goodvoxels.nii.gz" \
+    -add "${WorkingDirectory}/${Subject}.R.dentate_goodvoxels.nii.gz" \
+    -bin \
+    "${WorkingDirectory}/${Subject}.all_structures.goodvoxels.nii.gz"

--- a/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
+++ b/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
@@ -30,8 +30,8 @@ if [ -z "${HCPPIPEDIR}" ]; then
     exit 1
 fi
 
-source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"         # Debugging functions; also sources log.shlib
-#source "${HCPPIPEDIR}/global/scripts/log.shlib" "$@"            # Debugging functions; also sources log.shlib
+#source "${HCPPIPEDIR}/global/scripts/debug.shlib" "$@"         # Debugging functions; also sources log.shlib
+source "${HCPPIPEDIR}/global/scripts/log.shlib" "$@"            # Debugging functions; also sources log.shlib
 source "${HCPPIPEDIR}/global/scripts/opts.shlib"                # Command line option functions
 
 opts_ShowVersionIfRequested "$@"
@@ -358,9 +358,8 @@ for Structure in hipp dentate; do
                     "${TargetROI}" \
                     "${TargetAllMetric}"
 
-
+            done
         done
-
 
         # =====================================================================
         # Map goodvoxels in volume space
@@ -453,7 +452,6 @@ for Structure in hipp dentate; do
 
         fi
 
-
         "${WB}" -metric-dilate \
             "${NativefMRI}" \
             "${MidSurface}" \
@@ -513,26 +511,26 @@ for Structure in hipp dentate; do
 
             log_Msg "Generated fMRI file in ${Mesh} mesh at: ${TargetfMRI}"
 
+            # =====================================================================
+            # Map VN volume to native hippocampal surface
+            # =====================================================================
 
-            done
+            VolumefMRIVN="${VolumefMRI}_vn.nii.gz"
+            TargetfMRIVN="${WorkingDirectory}/${Prefix}_fMRI_vn.${Mesh}.func.gii"
+
+            "${WB}" -volume-to-surface-mapping \
+                "${VolumefMRIVN}" \
+                "${TargetMidSurface}" \
+                "${TargetfMRIVN}" \
+                -cubic
+
+            "${WB}" -metric-mask \
+                "${TargetfMRIVN}" \
+                "${TargetROI}" \
+                "${TargetfMRIVN}"
+
+            log_Msg "Generated VN file in ${Mesh} mesh at: ${TargetfMRIVN}"
         done
     done
 done
 
-# =====================================================================
-# All voxel mask an good voxel mask
-# =====================================================================
-
-fslmaths "${WorkingDirectory}/${Subject}.L.hipp.ribbon.nii.gz" \
-    -add "${WorkingDirectory}/${Subject}.R.hipp.ribbon.nii.gz" \
-    -add "${WorkingDirectory}/${Subject}.L.dentate.ribbon.nii.gz" \
-    -add "${WorkingDirectory}/${Subject}.R.dentate.ribbon.nii.gz" \
-    -bin \
-    "${WorkingDirectory}/${Subject}.allStructures.allVoxels.ribbon.nii.gz"
-
-fslmaths "${WorkingDirectory}/${Subject}.L.hipp_goodvoxels.nii.gz" \
-    -add "${WorkingDirectory}/${Subject}.R.hipp_goodvoxels.nii.gz" \
-    -add "${WorkingDirectory}/${Subject}.L.dentate_goodvoxels.nii.gz" \
-    -add "${WorkingDirectory}/${Subject}.R.dentate_goodvoxels.nii.gz" \
-    -bin \
-    "${WorkingDirectory}/${Subject}.all_structures.goodvoxels.nii.gz"

--- a/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
+++ b/fMRISurface/scripts/HippocampalVolumeToSurfaceMapping.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-
+set -eu
 # --------------------------------------------------------------------------------
 #  Usage Description Function
 # --------------------------------------------------------------------------------
@@ -16,7 +16,7 @@ EOF
 
 
 # Allow script to return a Usage statement, before any other output or checking
-if [ "$#" = "0" ]; then
+if [[ "$#" = "0" ]]; then
     show_usage
     exit 1
 fi
@@ -25,7 +25,7 @@ fi
 #  Check that HCPPIPEDIR is defined and Load Function Libraries
 # ------------------------------------------------------------------------------
 
-if [ -z "${HCPPIPEDIR}" ]; then
+if [[ -z "${HCPPIPEDIR}" ]]; then
     echo "${script_name}: ABORTING: HCPPIPEDIR environment variable must be set"
     exit 1
 fi
@@ -42,56 +42,33 @@ if opts_CheckForHelpRequest "$@"; then
 fi
 
 # ------------------------------------------------------------------------------
-#  Verify required environment variables are set and log value
-# ------------------------------------------------------------------------------
-
-log_Check_Env_Var HCPPIPEDIR
-log_Check_Env_Var CARET7DIR
-
-# ------------------------------------------------------------------------------
 #  Start work
 # ------------------------------------------------------------------------------
 
-WorkingDirectory="$1"
+ResultsFolder="$1"
 Subject="$2"
 HippUnfoldFolder="$3"
 VolumefMRI="$4"
 SBRef="$5"
 doGoodVoxels="$6"
-Factor="$7"
-#Factor="1"                 # Factor is a scaling factor for how many std units away from mean to set threshold
+Factor="$7" # Factor is a scaling factor for how many std units away from mean to set threshold
+Meshes="$8" # default: Meshes=(native 512 2k 8k 18k)
+
 NeighborhoodSmoothing="5"   # Distinguishes large vs small dropout
 dilation_dist="10"
 
-Meshes=(512 2k 8k 18k)
-
-WB="${CARET7DIR}/wb_command"
-
-mkdir -p "${WorkingDirectory}"
-
-FirstRibbon="YES"
+WorkingDirectory="${ResultsFolder}/HippocampalVolumeToSurfaceMapping"
 
 # ------------------------------------------------------------------------------
 #  Generating mean, std, and coefficient of variation metric maps
 # ------------------------------------------------------------------------------
 
-fslmaths "${VolumefMRI}" \
-    -Tmean "${WorkingDirectory}/${Subject}.mean" \
-    -odt float
-
-fslmaths "${VolumefMRI}" \
-    -Tstd "${WorkingDirectory}/${Subject}.std" \
-    -odt float
-
-fslmaths "${WorkingDirectory}/${Subject}.std" \
-    -div "${WorkingDirectory}/${Subject}.mean" \
-    "${WorkingDirectory}/${Subject}.cov"
-
+fslmaths "${VolumefMRI}" -Tmean "${WorkingDirectory}/${Subject}.mean" -odt float
+fslmaths "${VolumefMRI}" -Tstd "${WorkingDirectory}/${Subject}.std" -odt float
+fslmaths "${WorkingDirectory}/${Subject}.std" -div "${WorkingDirectory}/${Subject}.mean" "${WorkingDirectory}/${Subject}.cov"
 
 for Structure in hipp dentate; do
-
     for Hemisphere in L R; do
-
         # ------------------------------------------------------------------------------
         #  Establishing input and output files
         # ------------------------------------------------------------------------------
@@ -99,7 +76,6 @@ for Structure in hipp dentate; do
         Prefix="${Subject}.${Hemisphere}.${Structure}"
 
         ThicknessMetric="${HippUnfoldFolder}/native/${Prefix}_thickness.native.shape.gii"
-
         InnerSurface="${HippUnfoldFolder}/native/${Prefix}_inner.native.surf.gii"
         MidSurface="${HippUnfoldFolder}/native/${Prefix}_midthickness.native.surf.gii"
         OuterSurface="${HippUnfoldFolder}/native/${Prefix}_outer.native.surf.gii"
@@ -113,38 +89,20 @@ for Structure in hipp dentate; do
         #  Generating an all-ones surface metric
         # ------------------------------------------------------------------------------
 
-        "${WB}" -metric-math \
-            '1' \
-            "${OnesMetric}" \
-            -var x \
-            "${ThicknessMetric}"
-
+        wb_command -metric-math '1' "${OnesMetric}" -var x "${ThicknessMetric}"
 
         # ------------------------------------------------------------------------------
         #  Mapping the all-ones metric into SBRef volume space using the inner and
         #  outer surfaces as ribbon boundaries
         # ------------------------------------------------------------------------------
 
-        "${WB}" -metric-to-volume-mapping \
-            "${OnesMetric}" \
-            "${MidSurface}" \
-            "${SBRef}" \
-            "${ProbabilisticRibbon}" \
-            -ribbon-constrained \
-                "${InnerSurface}" \
-                "${OuterSurface}"
-
+        wb_command -metric-to-volume-mapping "${OnesMetric}" "${MidSurface}" "${SBRef}" "${ProbabilisticRibbon}" -ribbon-constrained "${InnerSurface}" "${OuterSurface}"
 
         # ------------------------------------------------------------------------------
         #  Thresholding the fractional ribbon at greater than 0 to create a binary mask
         # ------------------------------------------------------------------------------
 
-        "${WB}" -volume-math \
-            "x > 0" \
-            "${BinaryRibbon}" \
-            -var x \
-            "${ProbabilisticRibbon}"
-
+        wb_command -volume-math "x > 0" "${BinaryRibbon}" -var x "${ProbabilisticRibbon}"
 
         # ------------------------------------------------------------------------------
         #  Generating good-voxel mask for each structure
@@ -152,65 +110,23 @@ for Structure in hipp dentate; do
 
         if [[ "${doGoodVoxels}" == "YES" ]]; then
 
-            fslmaths "${WorkingDirectory}/${Subject}.cov" \
-                -mas "${BinaryRibbon}" \
-                "${WorkingDirectory}/${Prefix}_cov_ribbon"
-
+            fslmaths "${WorkingDirectory}/${Subject}.cov" -mas "${BinaryRibbon}" "${WorkingDirectory}/${Prefix}_cov_ribbon"
             meanIntensity=$(fslstats "${WorkingDirectory}/${Prefix}_cov_ribbon" -M)
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon" -div ${meanIntensity} "${WorkingDirectory}/${Prefix}_cov_ribbon_norm"
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon_norm" -bin -s "${NeighborhoodSmoothing}" "${WorkingDirectory}/${Prefix}_SmoothNorm"
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon_norm" -s "${NeighborhoodSmoothing}" -div "${WorkingDirectory}/${Prefix}_SmoothNorm" -dilD "${WorkingDirectory}/${Prefix}_cov_ribbon_norm_s${NeighborhoodSmoothing}"
+            fslmaths "${WorkingDirectory}/${Subject}.cov" -div ${meanIntensity} -div "${WorkingDirectory}/${Prefix}_cov_ribbon_norm_s${NeighborhoodSmoothing}" "${WorkingDirectory}/${Prefix}_cov_norm_modulate"
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_norm_modulate" -mas "${BinaryRibbon}" "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon"
 
-            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon" \
-                -div ${meanIntensity} \
-                "${WorkingDirectory}/${Prefix}_cov_ribbon_norm"
-
-            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon_norm" \
-                -bin \
-                -s "${NeighborhoodSmoothing}" \
-                "${WorkingDirectory}/${Prefix}_SmoothNorm"
-
-            fslmaths "${WorkingDirectory}/${Prefix}_cov_ribbon_norm" \
-                -s "${NeighborhoodSmoothing}" \
-                -div "${WorkingDirectory}/${Prefix}_SmoothNorm" \
-                -dilD \
-                "${WorkingDirectory}/${Prefix}_cov_ribbon_norm_s${NeighborhoodSmoothing}"
-
-            fslmaths "${WorkingDirectory}/${Subject}.cov" \
-                -div ${meanIntensity} \
-                -div "${WorkingDirectory}/${Prefix}_cov_ribbon_norm_s${NeighborhoodSmoothing}" \
-                "${WorkingDirectory}/${Prefix}_cov_norm_modulate"
-
-            fslmaths "${WorkingDirectory}/${Prefix}_cov_norm_modulate" \
-                -mas "${BinaryRibbon}" \
-                "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon"
-
-            STD=$(fslstats \
-                "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon" \
-                -S)
-
+            STD=$(fslstats "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon" -S)
             echo "STD: ${STD}"
-
-            MEAN=$(fslstats \
-                "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon" \
-                -M)
-
+            MEAN=$(fslstats "${WorkingDirectory}/${Prefix}_cov_norm_modulate_ribbon" -M)
             echo "MEAN: ${MEAN}"
-
-            Lower=$(echo "${MEAN} - (${STD} * ${Factor})" | bc -l)
-            echo "LOWER: ${Lower}"
-
             Upper=$(echo "${MEAN} + (${STD} * ${Factor})" | bc -l)
             echo "UPPER: ${Upper}"
 
-            fslmaths "${WorkingDirectory}/${Subject}.mean" \
-                -bin \
-                "${WorkingDirectory}/${Prefix}_mask"
-
-            fslmaths "${WorkingDirectory}/${Prefix}_cov_norm_modulate" \
-                -thr "${Upper}" \
-                -bin \
-                -sub "${WorkingDirectory}/${Prefix}_mask" \
-                -mul -1 \
-                -mas "${BinaryRibbon}" \
-                "${WorkingDirectory}/${Prefix}_goodvoxels"
+            fslmaths "${WorkingDirectory}/${Subject}.mean" -bin "${WorkingDirectory}/${Prefix}_mask"
+            fslmaths "${WorkingDirectory}/${Prefix}_cov_norm_modulate" -thr "${Upper}" -bin -sub "${WorkingDirectory}/${Prefix}_mask" -mul -1 -mas "${BinaryRibbon}" "${WorkingDirectory}/${Prefix}_goodvoxels"
         fi
 
 
@@ -221,89 +137,50 @@ for Structure in hipp dentate; do
         OuterSurface="${NativeFolder}/${Prefix}_outer.native.surf.gii"
 
         NativeFlat="${NativeFolder}/${Prefix}_flat.native.surf.gii"
-        NativeSurfArea="${NativeFolder}/${Prefix}_surfarea.native.shape.gii"
-
         NativeROI="${WorkingDirectory}/${Prefix}_ones.native.func.gii"
-
 
         # =====================================================================
         # Map mean and covariance volumes
         # =====================================================================
 
         for Map in mean cov; do
-
             NativeMetric="${WorkingDirectory}/${Prefix}_${Map}.native.func.gii"
             NativeAllMetric="${WorkingDirectory}/${Prefix}_${Map}_all.native.func.gii"
-
 
             # -----------------------------------------------------------------
             # Map using good voxels
             # -----------------------------------------------------------------
 
             if [[ "${doGoodVoxels}" == "YES" ]]; then
-
-                "${WB}" -volume-to-surface-mapping \
-                    "${WorkingDirectory}/${Subject}.${Map}.nii.gz" \
-                    "${MidSurface}" \
-                    "${NativeMetric}" \
-                    -ribbon-constrained \
-                        "${InnerSurface}" \
-                        "${OuterSurface}" \
-                        -volume-roi "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" \
-                        -dilate-missing ${dilation_dist} \
-                            -nearest
-
+                wb_command -volume-to-surface-mapping "${WorkingDirectory}/${Subject}.${Map}.nii.gz" "${MidSurface}" "${NativeMetric}" \
+                    -ribbon-constrained "${InnerSurface}" "${OuterSurface}" -volume-roi "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" -dilate-missing ${dilation_dist} -nearest
             else
 
-                "${WB}" -volume-to-surface-mapping \
-                    "${WorkingDirectory}/${Subject}.${Map}.nii.gz" \
-                    "${MidSurface}" \
-                    "${NativeMetric}" \
-                    -ribbon-constrained \
-                        "${InnerSurface}" \
-                        "${OuterSurface}" \
-                        -dilate-missing ${dilation_dist} \
-                            -nearest
+                wb_command -volume-to-surface-mapping "${WorkingDirectory}/${Subject}.${Map}.nii.gz" "${MidSurface}" "${NativeMetric}" \
+                    -ribbon-constrained "${InnerSurface}" "${OuterSurface}" -dilate-missing ${dilation_dist} -nearest
             fi
 
-            "${WB}" -metric-dilate \
-                "${NativeMetric}" \
-                "${MidSurface}" \
-                "${dilation_dist}" \
-                "${NativeMetric}" \
-                -nearest
-
-            "${WB}" -metric-mask \
-                "${NativeMetric}" \
-                "${NativeROI}" \
-                "${NativeMetric}"
+            wb_command -metric-dilate "${NativeMetric}" "${MidSurface}" "${dilation_dist}" "${NativeMetric}" -nearest
+            wb_command -metric-mask "${NativeMetric}" "${NativeROI}" "${NativeMetric}"
 
 
             # -----------------------------------------------------------------
             # Map using all ribbon voxels
             # -----------------------------------------------------------------
 
-            "${WB}" -volume-to-surface-mapping \
-                "${WorkingDirectory}/${Subject}.${Map}.nii.gz" \
-                "${MidSurface}" \
-                "${NativeAllMetric}" \
-                -ribbon-constrained \
-                    "${InnerSurface}" \
-                    "${OuterSurface}" \
-                    -dilate-missing ${dilation_dist} \
-                        -nearest
-
-            "${WB}" -metric-mask \
-                "${NativeAllMetric}" \
-                "${NativeROI}" \
-                "${NativeAllMetric}"
-
+            wb_command -volume-to-surface-mapping "${WorkingDirectory}/${Subject}.${Map}.nii.gz" "${MidSurface}" "${NativeAllMetric}" \
+                -ribbon-constrained "${InnerSurface}" "${OuterSurface}" -dilate-missing ${dilation_dist} -nearest
+            wb_command -metric-mask "${NativeAllMetric}" "${NativeROI}" "${NativeAllMetric}"
 
             # -----------------------------------------------------------------
             # Resample native metrics using unfolded flat surfaces
             # -----------------------------------------------------------------
 
-            for Mesh in ${Meshes[@]}; do
+            for Mesh in ${Meshes}; do
+
+                if [[ "${Mesh}" == "native" ]]; then
+                    continue
+                fi
 
                 MeshFolder="${HippUnfoldFolder}/${Mesh}"
 
@@ -316,48 +193,13 @@ for Structure in hipp dentate; do
                 TargetMetric="${WorkingDirectory}/${Prefix}_${Map}.${Mesh}.func.gii"
                 TargetAllMetric="${WorkingDirectory}/${Prefix}_${Map}_all.${Mesh}.func.gii"
 
-
-                "${WB}" -metric-math \
-                    "x * 0 + 1" \
-                    "${TargetROI}" \
-                    -var x "${TargetSurfArea}"
-
-
-                "${WB}" -metric-resample \
-                    "${NativeMetric}" \
-                    "${NativeFlat}" \
-                    "${TargetFlat}" \
-                    ADAP_BARY_AREA \
-                    "${TargetMetric}" \
-                    -area-surfs \
-                        "${MidSurface}" \
-                        "${TargetMidSurface}" \
-                    -current-roi "${NativeROI}" \
-                    -bypass-sphere-check
-
-                "${WB}" -metric-mask \
-                    "${TargetMetric}" \
-                    "${TargetROI}" \
-                    "${TargetMetric}"
-
-
-                "${WB}" -metric-resample \
-                    "${NativeAllMetric}" \
-                    "${NativeFlat}" \
-                    "${TargetFlat}" \
-                    ADAP_BARY_AREA \
-                    "${TargetAllMetric}" \
-                    -area-surfs \
-                        "${MidSurface}" \
-                        "${TargetMidSurface}" \
-                    -current-roi "${NativeROI}" \
-                    -bypass-sphere-check
-
-                "${WB}" -metric-mask \
-                    "${TargetAllMetric}" \
-                    "${TargetROI}" \
-                    "${TargetAllMetric}"
-
+                wb_command -metric-math "x * 0 + 1" "${TargetROI}" -var x "${TargetSurfArea}"
+                wb_command -metric-resample "${NativeMetric}" "${NativeFlat}" "${TargetFlat}" ADAP_BARY_AREA "${TargetMetric}" \
+                    -area-surfs "${MidSurface}" "${TargetMidSurface}" -current-roi "${NativeROI}" -bypass-sphere-check
+                wb_command -metric-mask "${TargetMetric}" "${TargetROI}" "${TargetMetric}"
+                wb_command -metric-resample "${NativeAllMetric}" "${NativeFlat}" "${TargetFlat}" ADAP_BARY_AREA "${TargetAllMetric}" \
+                    -area-surfs "${MidSurface}" "${TargetMidSurface}" -current-roi "${NativeROI}" -bypass-sphere-check
+                wb_command -metric-mask "${TargetAllMetric}" "${TargetROI}" "${TargetAllMetric}"
             done
         done
 
@@ -369,24 +211,15 @@ for Structure in hipp dentate; do
 
             NativeGoodVoxels="${WorkingDirectory}/${Prefix}_goodvoxels.native.func.gii"
 
-            "${WB}" -volume-to-surface-mapping \
-                "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" \
-                "${MidSurface}" \
-                "${NativeGoodVoxels}" \
-                -ribbon-constrained \
-                    "${InnerSurface}" \
-                    "${OuterSurface}" \
-                    -dilate-missing ${dilation_dist} \
-                        -nearest
-
-            "${WB}" -metric-mask \
-                "${NativeGoodVoxels}" \
-                "${NativeROI}" \
-                "${NativeGoodVoxels}"
+            wb_command -volume-to-surface-mapping "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" "${MidSurface}" "${NativeGoodVoxels}" \
+                -ribbon-constrained "${InnerSurface}" "${OuterSurface}" -dilate-missing ${dilation_dist} -nearest
+            wb_command -metric-mask "${NativeGoodVoxels}" "${NativeROI}" "${NativeGoodVoxels}"
 
 
-            for Mesh in ${Meshes[@]}; do
-
+            for Mesh in ${Meshes}; do
+                if [[ "${Mesh}" == "native" ]]; then
+                    continue
+                fi
                 MeshFolder="${HippUnfoldFolder}/${Mesh}"
 
                 TargetFlat="${MeshFolder}/${Prefix}_flat.${Mesh}.surf.gii"
@@ -396,159 +229,95 @@ for Structure in hipp dentate; do
                 TargetGoodVoxels="${WorkingDirectory}/${Prefix}_goodvoxels.${Mesh}.func.gii"
 
 
-                "${WB}" -metric-resample \
-                    "${NativeGoodVoxels}" \
-                    "${NativeFlat}" \
-                    "${TargetFlat}" \
-                    ADAP_BARY_AREA \
-                    "${TargetGoodVoxels}" \
-                    -area-surfs \
-                        "${MidSurface}" \
-                        "${TargetMidSurface}" \
-                    -current-roi "${NativeROI}" \
-                    -bypass-sphere-check
-
-                "${WB}" -metric-mask \
-                    "${TargetGoodVoxels}" \
-                    "${TargetROI}" \
-                    "${TargetGoodVoxels}"
-
+                wb_command -metric-resample "${NativeGoodVoxels}" "${NativeFlat}" "${TargetFlat}" ADAP_BARY_AREA "${TargetGoodVoxels}" \
+                    -area-surfs "${MidSurface}" "${TargetMidSurface}" -current-roi "${NativeROI}" -bypass-sphere-check
+                wb_command -metric-mask "${TargetGoodVoxels}" "${TargetROI}" "${TargetGoodVoxels}"
             done
-
         fi
-
 
         # =====================================================================
         # Map complete fMRI timeseries to native hippocampal surface
         # =====================================================================
+        for Mesh in ${Meshes}; do
 
-        NativefMRI="${WorkingDirectory}/${Prefix}_fMRI.native.func.gii"
-
-
-        if [[ "${doGoodVoxels}" == "YES" ]]; then
-
-            "${WB}" -volume-to-surface-mapping \
-                "${VolumefMRI}.nii.gz" \
-                "${MidSurface}" \
-                "${NativefMRI}" \
-                -ribbon-constrained \
-                    "${InnerSurface}" \
-                    "${OuterSurface}" \
-                    -volume-roi "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" \
-                    -dilate-missing ${dilation_dist} \
-                        -nearest
-
-        else
-
-	"${WB}" -volume-to-surface-mapping \
-            "${VolumefMRI}.nii.gz" \
-	    "${MidSurface}" \
-	    "${NativefMRI}" \
-	    -ribbon-constrained \
-	    	"${InnerSurface}" \
-	    	"${OuterSurface}" \
-	    	-dilate-missing ${dilation_dist} 
-	    	-nearest
-
-        fi
-
-        "${WB}" -metric-dilate \
-            "${NativefMRI}" \
-            "${MidSurface}" \
-            "${dilation_dist}" \
-            "${NativefMRI}" 
-            -nearest
-
-        "${WB}" -metric-mask \
-            "${NativefMRI}" \
-            "${NativeROI}" \
-            "${NativefMRI}"
-
-        log_Msg "Generated fMRI file in native space at: ${NativefMRI}"
-
-	# =====================================================================
-	# Map VN volume to native hippocampal surface
-	# =====================================================================
-
-	VolumefMRIVN="${VolumefMRI}_vn.nii.gz"
-	NativefMRIVN="${WorkingDirectory}/${Prefix}_fMRI_vn.native.func.gii"
-
-	"${WB}" -volume-to-surface-mapping \
-	    "${VolumefMRIVN}" \
-	    "${MidSurface}" \
-	    "${NativefMRIVN}" \
-	    -cubic
-
-	"${WB}" -metric-mask \
-	    "${NativefMRIVN}" \
-	    "${NativeROI}" \
-	    "${NativefMRIVN}"
-
-	log_Msg "Generated VN file in native space at: ${NativefMRIVN}"
-	
-        # =====================================================================
-        # Resample complete fMRI timeseries to all densities
-        # =====================================================================
-
-        for Mesh in ${Meshes[@]}; do
-
+            TargetfMRI="${ResultsFolder}/${Prefix}_fMRI.${Mesh}.func.gii"
             MeshFolder="${HippUnfoldFolder}/${Mesh}"
-
             TargetFlat="${MeshFolder}/${Prefix}_flat.${Mesh}.surf.gii"
             TargetMidSurface="${MeshFolder}/${Prefix}_midthickness.${Mesh}.surf.gii"
             TargetROI="${WorkingDirectory}/${Prefix}_ones.${Mesh}.func.gii"
 
-            TargetfMRI="${WorkingDirectory}/${Prefix}_fMRI.${Mesh}.func.gii"
+            if [[ "${Mesh}" == "native" ]]; then
 
+                # Map fMRI volume to native surface
+                if [[ "${doGoodVoxels}" == "YES" ]]; then
 
-            "${WB}" -metric-resample \
-                "${NativefMRI}" \
-                "${NativeFlat}" \
-                "${TargetFlat}" \
-                ADAP_BARY_AREA \
-                "${TargetfMRI}" \
-                -area-surfs \
-                    "${MidSurface}" \
-                    "${TargetMidSurface}" \
-                -current-roi "${NativeROI}" \
-                -bypass-sphere-check
+                    wb_command -volume-to-surface-mapping "${VolumefMRI}" "${TargetMidSurface}" "${TargetfMRI}" -ribbon-constrained "${InnerSurface}" "${OuterSurface}" \
+                        -volume-roi "${WorkingDirectory}/${Prefix}_goodvoxels.nii.gz" -dilate-missing "${dilation_dist}" -nearest
+                else
 
+                    wb_command -volume-to-surface-mapping "${VolumefMRI}" "${TargetMidSurface}" "${TargetfMRI}" \
+                        -ribbon-constrained "${InnerSurface}" "${OuterSurface}" -dilate-missing "${dilation_dist}" -nearest
+                fi
+                NativefMRI="${TargetfMRI}"
+                log_Msg "Generated fMRI file in native mesh at: ${TargetfMRI}"
+            else
 
-            "${WB}" -metric-dilate \
+                # Resample native fMRI surface to target mesh
+                wb_command -metric-resample "${NativefMRI}" "${NativeFlat}" "${TargetFlat}" ADAP_BARY_AREA "${TargetfMRI}" \
+                    -area-surfs "${MidSurface}" "${TargetMidSurface}" -current-roi "${NativeROI}" -bypass-sphere-check
+
+                log_Msg "Generated fMRI file in ${Mesh} mesh at: ${TargetfMRI}"
+
+            fi
+
+            # Dilate and mask both native and target-mesh fMRI
+            wb_command -metric-dilate \
                 "${TargetfMRI}" \
                 "${TargetMidSurface}" \
-                ${dilation_dist} \
+                "${dilation_dist}" \
                 "${TargetfMRI}" \
                 -nearest
 
-
-            "${WB}" -metric-mask \
+            wb_command -metric-mask \
                 "${TargetfMRI}" \
                 "${TargetROI}" \
                 "${TargetfMRI}"
 
+        done
+        # =====================================================================
+        # Map VN volume to native hippocampal surface
+        # =====================================================================
+        VolumefMRIVN="${VolumefMRI%.nii.gz}_vn.nii.gz"
 
-            log_Msg "Generated fMRI file in ${Mesh} mesh at: ${TargetfMRI}"
+        if [[ ! -f "${VolumefMRIVN}" ]]; then
+            log_Err_Abort "Cannot find VN volume: ${VolumefMRIVN}"
+        fi
 
-            # =====================================================================
-            # Map VN volume to native hippocampal surface
-            # =====================================================================
+        FiniteVolumefMRIVN="${WorkingDirectory}/${Subject}_vn_finite.nii.gz"
 
-            VolumefMRIVN="${VolumefMRI}_vn.nii.gz"
-            TargetfMRIVN="${WorkingDirectory}/${Prefix}_fMRI_vn.${Mesh}.func.gii"
+        fslmaths "${VolumefMRIVN}" -thr -1e30 -uthr 1e30 -nan "${FiniteVolumefMRIVN}" #Thresholding inf and -inf and replacing nan with 0
 
-            "${WB}" -volume-to-surface-mapping \
-                "${VolumefMRIVN}" \
-                "${TargetMidSurface}" \
-                "${TargetfMRIVN}" \
-                -cubic
+        for Mesh in ${Meshes}; do
 
-            "${WB}" -metric-mask \
-                "${TargetfMRIVN}" \
-                "${TargetROI}" \
-                "${TargetfMRIVN}"
+            TargetfMRIVN="${ResultsFolder}/${Prefix}_fMRI_vn.${Mesh}.func.gii"
+            MeshFolder="${HippUnfoldFolder}/${Mesh}"
+            TargetFlat="${MeshFolder}/${Prefix}_flat.${Mesh}.surf.gii"
+            TargetMidSurface="${MeshFolder}/${Prefix}_midthickness.${Mesh}.surf.gii"
 
-            log_Msg "Generated VN file in ${Mesh} mesh at: ${TargetfMRIVN}"
+            if [[ "${Mesh}" == "native" ]]; then
+
+                # Map VN volume to native surface
+                wb_command -volume-to-surface-mapping "${FiniteVolumefMRIVN}" "${TargetMidSurface}" "${TargetfMRIVN}" -cubic
+                NativefMRIVN="${TargetfMRIVN}"
+
+                log_Msg "Generated VN file in native mesh at: ${TargetfMRIVN}"
+            else
+                # Resample native VN surface to other mesh surface
+                wb_command -metric-resample "${NativefMRIVN}" "${NativeFlat}" "${TargetFlat}" ADAP_BARY_AREA "${TargetfMRIVN}" \
+                    -area-surfs "${MidSurface}" "${TargetMidSurface}" -current-roi "${NativeROI}" -bypass-sphere-check
+
+                log_Msg "Generated VN file in ${Mesh} mesh at: ${TargetfMRIVN}"
+            fi
         done
     done
 done


### PR DESCRIPTION
fMRI pipeline changes:

GenericHippocampusfMRISurfaceProcessingPipeline.sh:

Re-enabled pipedirguessed=1.

Removed the output-folder and fmri-qc options.

Added the --resample-mesh option. A validation loop was also added to allow only valid mesh values (512, 2k, 8k, 18k). The selected meshes are then passed to the child script HippocampalVolumeToSurfaceMapping.sh.
Moved surface smoothing into a separate child script, HippocampalSurfaceSmoothing.sh.
Moved CIFTI generation into a separate child script, HippocampalCreateCIFTIs.sh.

Shifted to a more compact formatting style, including reducing unnecessary use of line-continuation backslashes.
Removed the variable previously used for wb_command and now call wb_command directly.

The native mesh is added internally to the requested resampling meshes so that native-space processing is always performed before resampling to the user-requested meshes.

HippocampalVolumeToSurfaceMapping.sh:

The script now receives the mesh list as an input parameter.

Similar to its cortical counterpart, RibbonVolumeToSurfaceMapping.sh, intermediate volumetric files are generated inside the HippocampalVolumeToSurfaceMapping working subdirectory. Final surface-related files are generated in the parent fMRI results directory (e.g., rfMRI_REST1_LR).

Previously, generation of the fMRI surface time series and VN surface files was intermixed. These are now handled in separate processing loops.

VN is mapped once from the volume to the native hippocampal surface and then resampled from native to the requested meshes.

Shifted to a more compact formatting style, including reducing unnecessary use of line-continuation backslashes.
Removed the variable previously used for wb_command and now call wb_command directly.

Questions:
1. The HippocampalVolumeToSurfaceMapping working-directory name is currently hardcoded in both the parent and child scripts. Should the working-directory path instead be passed from the parent to the child as an input parameter?

2. If the long-term plan is to combine the cortical and hippocampal fMRISurface pipelines, would it make more sense to begin integrating them now rather than maintaining two parallel pipelines?

3. There is some inconsistency in how wb_command is called across HCP scripts. For example, some scripts, such as RSNRegression.sh, use wb_command, while others, such as SurfaceSmoothing.sh, use ${CARET7DIR}/wb_command. Which format should I use?
